### PR TITLE
FIX: rowActions return null shouldnt render bubble

### DIFF
--- a/src/components/TableModule/TableModuleRow.test.tsx
+++ b/src/components/TableModule/TableModuleRow.test.tsx
@@ -105,3 +105,24 @@ test('it renders the provided `rowActions`', async () => {
   const actions = await findByTestId('row-action');
   expect(actions).toBeInTheDocument();
 });
+
+test('it does not render row actions when the `rowActions` function returns null', async () => {
+  const { findByRole } = renderWithTheme(
+    <table>
+      <tbody>
+        <TableModuleRow
+          data={{}}
+          row={{}}
+          cells={[]}
+          headingsLength={0}
+          rowActions={() => {
+            return null;
+          }}
+        />
+      </tbody>
+    </table>
+  );
+
+  const td = await findByRole('cell');
+  expect(td.innerHTML).toBe('');
+});

--- a/src/components/TableModule/TableModuleRow.tsx
+++ b/src/components/TableModule/TableModuleRow.tsx
@@ -93,6 +93,11 @@ const TableModuleRow: React.FC<TableModuleRowProps> = React.memo(
       [cells, headingsLength, maxCellWidth, row]
     );
 
+    const maybeRowActions = React.useMemo(() => rowActions?.(row), [
+      row,
+      rowActions,
+    ]);
+
     return (
       <tr
         className={clsx(
@@ -115,26 +120,28 @@ const TableModuleRow: React.FC<TableModuleRowProps> = React.memo(
             )}
             role="cell"
           >
-            <TableModuleActions
-              className={classes.tableModuleActions}
-              tabIndex={0}
-            >
-              {rowActions?.(row)}
-              {onRowClick && (
-                <Tooltip title={rowClickLabel || 'View Details'}>
-                  <IconButton
-                    aria-label={rowClickLabel || 'View Details'}
-                    icon={ChevronRight}
-                    color="inverse"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      e.currentTarget.blur();
-                      onRowClick?.(row);
-                    }}
-                  />
-                </Tooltip>
-              )}
-            </TableModuleActions>
+            {(Boolean(maybeRowActions) || onRowClick) && (
+              <TableModuleActions
+                className={classes.tableModuleActions}
+                tabIndex={0}
+              >
+                {maybeRowActions}
+                {onRowClick && (
+                  <Tooltip title={rowClickLabel || 'View Details'}>
+                    <IconButton
+                      aria-label={rowClickLabel || 'View Details'}
+                      icon={ChevronRight}
+                      color="inverse"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        e.currentTarget.blur();
+                        onRowClick?.(row);
+                      }}
+                    />
+                  </Tooltip>
+                )}
+              </TableModuleActions>
+            )}
           </td>
         )}
       </tr>

--- a/stories/components/TableModule/TableModule.stories.tsx
+++ b/stories/components/TableModule/TableModule.stories.tsx
@@ -627,6 +627,59 @@ const TestBed: React.FC = () => {
         onRowClick={() => console.log('Row click handler')}
         isLoading={boolean('isLoading', false)}
       />
+
+      <Text size="headline">Specific rows with actions, others without</Text>
+      <TableModule
+        data={data}
+        config={config}
+        isLoading={boolean('isLoading', false)}
+        rowActions={(row) => {
+          if (row.carbs === '37' || row.carbs === '67') {
+            return (
+              <>
+                <Button
+                  variant="text"
+                  color="inverse"
+                  style={{ marginRight: '8px' }}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    e.currentTarget.blur();
+                  }}
+                >
+                  Revoke
+                </Button>
+                <TableActionDivider />
+                <Tooltip title="Share">
+                  <IconButton
+                    aria-label="Share"
+                    icon={Share}
+                    color="inverse"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      e.currentTarget.blur();
+                      console.log(`search ${row}!`);
+                    }}
+                  />
+                </Tooltip>
+                <Tooltip title="Trash">
+                  <IconButton
+                    aria-label="Trash"
+                    icon={Trash}
+                    color="inverse"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      e.currentTarget.blur();
+                      console.log(`trash ${row}!`);
+                    }}
+                  />
+                </Tooltip>
+              </>
+            );
+          }
+
+          return null;
+        }}
+      />
     </FormBox>
   );
 };


### PR DESCRIPTION
### Changes

- TableModule `rowActions` can sometimes return `null`.

An example may be like in the story for this PR, where based on the `row` returned, you want to optionally show actions. 

```jsx
<TableModule
  rowActions={(row) => {
    // Only show actions when carbs are 37 or 67, otherwise,
    // we don't want any actionable buttons displayed for this row
    if (row.carbs === '37' || row.carbs === '67') {
      return actions; // your action buttons go here
    }

    return null;
  }}
/>
```

Currently, on master, the above example would yield you an empty toolbar:

![94025892-04227200-fd87-11ea-81de-8d6390198848](https://user-images.githubusercontent.com/8069555/94147135-e61a4780-fe42-11ea-9f01-a49917d65292.png)


This change does what you'd expect - if `rowActions` returns `null`, a toolbar will not be displayed at all