### PR TITLE
FIX: Adjust release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,16 +19,19 @@ jobs:
         with:
           node-version: 12
           registry-url: https://registry.npmjs.org
-      - name: Build, test, and npm publish
+      - name: Lint, test, and build
         run: |
           yarn
           yarn lint
           yarn test
           yarn build
-          npm publish --access public
+      - name: Publish to npm
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.LIFEOMIC_NPM_TOKEN}}
       - name: Create Release
+        if: startsWith(github.ref, 'refs/tags/v')
         id: create_release
         uses: actions/create-release@latest
         env:


### PR DESCRIPTION
### Changes

- Attempt to only run the release step when a tag is available

Looking at the last merge to master (without a tag), https://github.com/lifeomic/chroma-react/runs/1161223504?check_suite_focus=true, it still attempted to publish to npm.   I'm hoping this will only attempt to publish to NPM and cut a release if the last commit has a tag.  I looked at https://stackoverflow.com/questions/58475748/github-actions-how-to-check-if-current-push-has-new-tag-is-new-release as a reference.