### PR TITLE
CHROM add flex-start and flex-end

### DIFF
--- a/src/components/Box/Box.test.tsx
+++ b/src/components/Box/Box.test.tsx
@@ -42,12 +42,28 @@ test('it renders a Box with align="center"', async () => {
   expect(root).toHaveClass('ChromaBox-alignCenter');
 });
 
+test('it renders a Box with align="start"', async () => {
+  const { findByTestId } = renderWithTheme(
+    <Box align="start" data-testid={testId} />
+  );
+  const root = await findByTestId(testId);
+  expect(root).toHaveClass('ChromaBox-alignStart');
+});
+
 test('it renders a Box with align="flex-start"', async () => {
   const { findByTestId } = renderWithTheme(
     <Box align="flex-start" data-testid={testId} />
   );
   const root = await findByTestId(testId);
-  expect(root).toHaveClass('ChromaBox-alignStart');
+  expect(root).toHaveClass('ChromaBox-alignFlexStart');
+});
+
+test('it renders a Box with align="end"', async () => {
+  const { findByTestId } = renderWithTheme(
+    <Box align="end" data-testid={testId} />
+  );
+  const root = await findByTestId(testId);
+  expect(root).toHaveClass('ChromaBox-alignEnd');
 });
 
 test('it renders a Box with align="flex-end"', async () => {
@@ -55,7 +71,7 @@ test('it renders a Box with align="flex-end"', async () => {
     <Box align="flex-end" data-testid={testId} />
   );
   const root = await findByTestId(testId);
-  expect(root).toHaveClass('ChromaBox-alignEnd');
+  expect(root).toHaveClass('ChromaBox-alignFlexEnd');
 });
 
 test('it renders a Box with justify="center"', async () => {

--- a/src/components/Box/Box.tsx
+++ b/src/components/Box/Box.tsx
@@ -17,7 +17,14 @@ export interface BoxProps
   ref?: React.Ref<HTMLDivElement>;
   className?: string;
   flexWrap?: boolean;
-  align?: 'stretch' | 'baseline' | 'center' | 'flex-start' | 'flex-end';
+  align?:
+    | 'stretch'
+    | 'baseline'
+    | 'center'
+    | 'start'
+    | 'flex-start'
+    | 'end'
+    | 'flex-end';
   direction?: 'row' | 'column';
   justify?:
     | 'center'
@@ -76,7 +83,9 @@ const useStyles = makeStyles<BoxProps>(
       alignBaseline: { alignItems: 'baseline' },
       alignCenter: { alignItems: 'center' },
       alignStart: { alignItems: 'start' },
+      alignFlexStart: { alignItems: 'flex-start' },
       alignEnd: { alignItems: 'end' },
+      alignFlexEnd: { alignItems: 'flex-end' },
       directionRow: { flexDirection: 'row' },
       directionColumn: { flexDirection: 'column' },
       justifyStart: { justifyContent: 'flex-start' },
@@ -186,8 +195,10 @@ export const Box = React.forwardRef<HTMLDivElement, BoxProps>((props, ref) => {
         {
           [classes.alignBaseline]: align === 'baseline',
           [classes.alignCenter]: align === 'center',
-          [classes.alignStart]: align === 'flex-start',
-          [classes.alignEnd]: align === 'flex-end',
+          [classes.alignStart]: align === 'start',
+          [classes.alignFlexStart]: align === 'flex-start',
+          [classes.alignEnd]: align === 'end',
+          [classes.alignFlexEnd]: align === 'flex-end',
         },
         {
           [classes.justifyBetween]: justify === 'space-between',


### PR DESCRIPTION
**Changes**
- Added `flex-end` and `flex-start`
    - Right now we are setting `flex-end` to `align-items: end` when I think we should allow for both being an option to pass in. 

Ex issue: 

- Before when I passed in `align="flex-end"`
![Screen Shot 2020-10-07 at 4 10 09 PM](https://user-images.githubusercontent.com/32574227/95382435-a4b08000-08b7-11eb-8b76-b91763d0f94f.png)

- After when I passed in `align="flex-end"`
![Screen Shot 2020-10-07 at 4 10 14 PM](https://user-images.githubusercontent.com/32574227/95382486-b7c35000-08b7-11eb-9ff2-a3a620dfd61d.png)
