### PR TITLE
Bugfix - ComboBox multi selection cuts off

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -68,7 +68,7 @@ export const useStyles = makeStyles(
       borderRadius: theme.pxToRem(4),
       color: theme.palette.text.primary,
       cursor: 'pointer',
-      display: 'inline-flex',
+      display: 'block',
       fontFamily: theme.typography.fontFamily,
       fontSize: theme.pxToRem(14),
       maxHeight: theme.pxToRem(84),

--- a/stories/components/ComboBox/ComboBox.stories.tsx
+++ b/stories/components/ComboBox/ComboBox.stories.tsx
@@ -42,6 +42,14 @@ const ComboBoxStory: React.FC = () => {
             />
             <SelectOption title="Option 3" value="option 3" />
             <SelectOption title="Option 4" value="option 4" />
+            <SelectOption
+              title="Option 5 has really long content"
+              value="option 5"
+            />
+            <SelectOption
+              title="Option 6 has really long content"
+              value="option 6"
+            />
           </ComboBox>
           <ComboBox
             label="Select option(s)"
@@ -58,6 +66,14 @@ const ComboBoxStory: React.FC = () => {
             />
             <SelectOption title="Option 3" value="option 3" />
             <SelectOption title="Option 4" value="option 4" />
+            <SelectOption
+              title="Option 5 has really long content"
+              value="option 5"
+            />
+            <SelectOption
+              title="Option 6 has really long content"
+              value="option 6"
+            />
           </ComboBox>
           <ComboBox
             label="Select option(s)"
@@ -75,6 +91,14 @@ const ComboBoxStory: React.FC = () => {
             />
             <SelectOption title="Option 3" value="option 3" />
             <SelectOption title="Option 4" value="option 4" />
+            <SelectOption
+              title="Option 5 has really long content"
+              value="option 5"
+            />
+            <SelectOption
+              title="Option 6 has really long content"
+              value="option 6"
+            />
           </ComboBox>
           <ComboBox
             label="Disabled"
@@ -101,6 +125,14 @@ const ComboBoxStory: React.FC = () => {
             />
             <SelectOption title="Option 3" value="option 3" />
             <SelectOption title="Option 4" value="option 4" />
+            <SelectOption
+              title="Option 5 has really long content"
+              value="option 5"
+            />
+            <SelectOption
+              title="Option 6 has really long content"
+              value="option 6"
+            />
           </ComboBox>
         </FormBox>
       </Container>
@@ -130,6 +162,14 @@ const ComboBoxStory: React.FC = () => {
             />
             <SelectOption title="Option 3" value="option 3" />
             <SelectOption title="Option 4" value="option 4" />
+            <SelectOption
+              title="Option 5 has really long content"
+              value="option 5"
+            />
+            <SelectOption
+              title="Option 6 has really long content"
+              value="option 6"
+            />
           </ComboBox>
           <ComboBox
             label="Select option(s)"
@@ -146,6 +186,14 @@ const ComboBoxStory: React.FC = () => {
             />
             <SelectOption title="Option 3" value="option 3" />
             <SelectOption title="Option 4" value="option 4" />
+            <SelectOption
+              title="Option 5 has really long content"
+              value="option 5"
+            />
+            <SelectOption
+              title="Option 6 has really long content"
+              value="option 6"
+            />
           </ComboBox>
           <ComboBox
             label="Select option(s)"
@@ -163,6 +211,14 @@ const ComboBoxStory: React.FC = () => {
             />
             <SelectOption title="Option 3" value="option 3" />
             <SelectOption title="Option 4" value="option 4" />
+            <SelectOption
+              title="Option 5 has really long content"
+              value="option 5"
+            />
+            <SelectOption
+              title="Option 6 has really long content"
+              value="option 6"
+            />
           </ComboBox>
           <ComboBox
             label="Disabled"
@@ -189,6 +245,14 @@ const ComboBoxStory: React.FC = () => {
             />
             <SelectOption title="Option 3" value="option 3" />
             <SelectOption title="Option 4" value="option 4" />
+            <SelectOption
+              title="Option 5 has really long content"
+              value="option 5"
+            />
+            <SelectOption
+              title="Option 6 has really long content"
+              value="option 6"
+            />
           </ComboBox>
         </FormBox>
       </Container>
@@ -219,6 +283,14 @@ const ComboBoxStory: React.FC = () => {
             />
             <SelectOption title="Option 3" value="option 3" />
             <SelectOption title="Option 4" value="option 4" />
+            <SelectOption
+              title="Option 5 has really long content"
+              value="option 5"
+            />
+            <SelectOption
+              title="Option 6 has really long content"
+              value="option 6"
+            />
           </ComboBox>
           <ComboBox
             label="Select option(s)"
@@ -236,6 +308,14 @@ const ComboBoxStory: React.FC = () => {
             />
             <SelectOption title="Option 3" value="option 3" />
             <SelectOption title="Option 4" value="option 4" />
+            <SelectOption
+              title="Option 5 has really long content"
+              value="option 5"
+            />
+            <SelectOption
+              title="Option 6 has really long content"
+              value="option 6"
+            />
           </ComboBox>
           <ComboBox
             label="Select option(s)"
@@ -254,6 +334,14 @@ const ComboBoxStory: React.FC = () => {
             />
             <SelectOption title="Option 3" value="option 3" />
             <SelectOption title="Option 4" value="option 4" />
+            <SelectOption
+              title="Option 5 has really long content"
+              value="option 5"
+            />
+            <SelectOption
+              title="Option 6 has really long content"
+              value="option 6"
+            />
           </ComboBox>
           <ComboBox
             label="Disabled"
@@ -282,6 +370,14 @@ const ComboBoxStory: React.FC = () => {
             />
             <SelectOption title="Option 3" value="option 3" />
             <SelectOption title="Option 4" value="option 4" />
+            <SelectOption
+              title="Option 5 has really long content"
+              value="option 5"
+            />
+            <SelectOption
+              title="Option 6 has really long content"
+              value="option 6"
+            />
           </ComboBox>
         </FormBox>
       </Container>
@@ -312,6 +408,14 @@ const ComboBoxStory: React.FC = () => {
             />
             <SelectOption title="Option 3" value="option 3" />
             <SelectOption title="Option 4" value="option 4" />
+            <SelectOption
+              title="Option 5 has really long content"
+              value="option 5"
+            />
+            <SelectOption
+              title="Option 6 has really long content"
+              value="option 6"
+            />
           </ComboBox>
           <ComboBox
             label="Select option(s)"
@@ -329,6 +433,14 @@ const ComboBoxStory: React.FC = () => {
             />
             <SelectOption title="Option 3" value="option 3" />
             <SelectOption title="Option 4" value="option 4" />
+            <SelectOption
+              title="Option 5 has really long content"
+              value="option 5"
+            />
+            <SelectOption
+              title="Option 6 has really long content"
+              value="option 6"
+            />
           </ComboBox>
           <ComboBox
             label="Select option(s)"
@@ -347,6 +459,14 @@ const ComboBoxStory: React.FC = () => {
             />
             <SelectOption title="Option 3" value="option 3" />
             <SelectOption title="Option 4" value="option 4" />
+            <SelectOption
+              title="Option 5 has really long content"
+              value="option 5"
+            />
+            <SelectOption
+              title="Option 6 has really long content"
+              value="option 6"
+            />
           </ComboBox>
           <ComboBox
             label="Disabled"
@@ -375,6 +495,14 @@ const ComboBoxStory: React.FC = () => {
             />
             <SelectOption title="Option 3" value="option 3" />
             <SelectOption title="Option 4" value="option 4" />
+            <SelectOption
+              title="Option 5 has really long content"
+              value="option 5"
+            />
+            <SelectOption
+              title="Option 6 has really long content"
+              value="option 6"
+            />
           </ComboBox>
         </FormBox>
       </Container>


### PR DESCRIPTION
Issue: when you have multiple options with long display values, the top selection gets cut off.

**Changes**
- Fixed display value for select and comboBox button styles
- Added more options with longer text

**BEFORE:**
![Screen Shot 2020-10-08 at 2 28 54 PM](https://user-images.githubusercontent.com/32574227/95499138-d5092480-0972-11eb-8121-2b0ad6239d8e.png)

**AFTER**:
![Screen Shot 2020-10-08 at 2 28 04 PM](https://user-images.githubusercontent.com/32574227/95499168-e05c5000-0972-11eb-900f-aa98d7f4a4f8.png)
