### PR TITLE
Add disableDismissOnClickOutside prop to Modal

### DIFF
--- a/src/components/Modal/Modal.test.tsx
+++ b/src/components/Modal/Modal.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent } from '@testing-library/react';
 import * as React from 'react';
 import { renderWithTheme } from '../../testUtils/renderWithTheme';
 import { Modal, ModalProps } from './index';
+import { OVERLAY_TEST_ID } from './Modal';
 
 const testId = 'Modal';
 
@@ -249,4 +250,37 @@ test('it renders the customHeader when fullscreen', async () => {
 
   const customHeader = await findByTestId(CUSTOM_HEADER_ID);
   expect(customHeader).toBeTruthy();
+});
+
+test('calls "onDismiss" on clicking outside the modal', async () => {
+  const onDismissMock = jest.fn();
+  const props: ModalProps = {
+    ...getBaseProps(),
+    onDismiss: onDismissMock,
+  };
+
+  const { findByTestId } = renderWithTheme(<Modal {...props} />);
+  const overlay = await findByTestId(OVERLAY_TEST_ID);
+
+  fireEvent.mouseDown(overlay);
+  fireEvent.click(overlay);
+
+  expect(onDismissMock).toHaveBeenCalledTimes(1);
+});
+
+test('disables dismissing by clicking outside the modal based on prop', async () => {
+  const onDismissMock = jest.fn();
+  const props: ModalProps = {
+    ...getBaseProps(),
+    onDismiss: onDismissMock,
+    disableDismissOnClickOutside: true,
+  };
+
+  const { findByTestId } = renderWithTheme(<Modal {...props} />);
+  const overlay = await findByTestId(OVERLAY_TEST_ID);
+
+  fireEvent.mouseDown(overlay);
+  fireEvent.click(overlay);
+
+  expect(onDismissMock).not.toHaveBeenCalled();
 });

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -23,6 +23,8 @@ const ariaLabelledBy = 'modal-header';
 
 export const ModalStylesKey = 'ChromaModal';
 
+export const OVERLAY_TEST_ID = 'chroma-overlay-testid';
+
 const useStyles = makeStyles(
   (theme) => ({
     overlay: {
@@ -174,6 +176,7 @@ export interface ModalProps
   isOpen?: boolean;
   justifyActions?: ModalActionsProps['justify'];
   onDismiss?: (props: any) => void;
+  disableDismissOnClickOutside?: boolean;
   onFormSubmit?: (data: any) => void;
   poses?: Variants;
   size?: 0 | 1;
@@ -188,6 +191,7 @@ const ModalInner = React.forwardRef<HTMLDivElement, ModalProps>(
       children,
       onClick,
       onDismiss,
+      disableDismissOnClickOutside,
       onMouseDown,
       onKeyDown,
     },
@@ -204,11 +208,12 @@ const ModalInner = React.forwardRef<HTMLDivElement, ModalProps>(
       <FocusLock autoFocus returnFocus>
         <RemoveScroll allowPinchZoom={allowPinchZoom}>
           <motion.div
+            data-testid={OVERLAY_TEST_ID}
             className={clsx(classes.overlay, overlayClassName)}
             onClick={wrapEvent(onClick, (event: React.SyntheticEvent) => {
               if (mouseDownTarget.current === event.target) {
                 event.stopPropagation();
-                onDismiss && onDismiss(event);
+                onDismiss && !disableDismissOnClickOutside && onDismiss(event);
               }
             })}
             onMouseDown={wrapEvent(onMouseDown, (event: React.MouseEvent) => {
@@ -447,6 +452,7 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
       isFullScreen,
       isOpen,
       onDismiss,
+      disableDismissOnClickOutside,
       size = 0,
       overlayClassName,
       ...rootProps
@@ -466,6 +472,7 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
             allowPinchZoom={allowPinchZoom}
             isOpen={isOpen}
             onDismiss={onDismiss}
+            disableDismissOnClickOutside={disableDismissOnClickOutside}
           >
             {isFullScreen ? (
               <FullScreenContent

--- a/stories/components/Modal/Modal.stories.tsx
+++ b/stories/components/Modal/Modal.stories.tsx
@@ -31,6 +31,10 @@ const ModalStory: React.FC = () => {
           console.log('closing...');
           setIsOpen(false);
         }}
+        disableDismissOnClickOutside={boolean(
+          'disableDismissOnClickOutside',
+          false
+        )}
       />
     </Container>
   );

--- a/stories/components/Modal/default.md
+++ b/stories/components/Modal/default.md
@@ -82,13 +82,34 @@ vertical sizing.
 
 #### On Dismiss
 
-To wire a callback in when the Modal is closed, use onDismiss.
+To wire a callback in when the `Modal` is closed, use `onDismiss`.
 
 ```jsx
 <Modal
   isOpen={isOpen}
   onDismiss={() => {
     console.log('closing...');
+    setIsOpen(false);
+  }}
+>
+  <p>Modal Content</p>
+</Modal>
+```
+
+By default, the `Modal` will call `onDismiss` when any of the following occurs:
+
+1. The user clicks the close button.
+2. The user presses the `ESC` key.
+3. The user clicks outside the modal content (anywhere on the overlay).
+
+To disable the behavior of #3, use `disableDismissOnClickOutside`.
+
+```jsx
+<Modal
+  isOpen={isOpen}
+  disableDismissOnClickOutside
+  onDismiss={() => {
+    console.log('user clicked close button or pressed ESC');
     setIsOpen(false);
   }}
 >


### PR DESCRIPTION
## Motivation
See [this Slack thread](https://lifeomic.slack.com/archives/CHMFL4PQT/p1602771468011800).

## Changes
- Added the `disableDismissOnClickOutside` prop to the `Modal` component, to disable automatic dismissal on clicking the overlay.
- Updated tests + docs around the new prop.
- Added a hard-coded test ID for the overlay component to support unit tests.
  - I couldn't think of an idiomatic way to find that component / execute the click without this. If there's a better alternative to exporting that ID, 100% open to suggestions!

## Screenshots
![2020-10-16 13 42 23](https://user-images.githubusercontent.com/14932834/96291225-bb409080-0fb5-11eb-951e-144790d85052.gif)