### PR TITLE
Export useStyles hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,16 @@ function App({ children }) {
   return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
 }
 ```
+
+## Importing Component Styles Only?
+
+Need to build a custom component, but want to use the styles hook of an existing Chroma component?
+
+```jsx
+import { useStyles } from '@lifeomic/chroma-react/components/Button/Button';
+
+const CustomButton = ({}) => {
+  const classes = useStyles({});
+  return <button className={classes.root}>Custom Button</button>;
+};
+```

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -6,7 +6,7 @@ import { NotificationStatusType } from '../_private/notificationTypes';
 
 export const AlertStylesKey = 'ChromaAlert';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       alignItems: 'flex-start',

--- a/src/components/Alert/AlertActionsRow.tsx
+++ b/src/components/Alert/AlertActionsRow.tsx
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 
 export const AlertActionsRowStylesKey = 'ChromaAlertActionsRow';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   () => ({
     root: {
       marginTop: '0.5rem',

--- a/src/components/Alert/AlertBody.tsx
+++ b/src/components/Alert/AlertBody.tsx
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 
 export const AlertBodyStylesKey = 'ChromaAlertBody';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   () => ({
     root: {
       color: 'inherit',

--- a/src/components/Alert/AlertIcon.tsx
+++ b/src/components/Alert/AlertIcon.tsx
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 
 export const AlertIconStylesKey = 'ChromaAlertIcon';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   () => ({
     root: {
       color: 'inherit',

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -6,7 +6,7 @@ import { AvatarSizeContext } from './AvatarSizeContext';
 
 export const AvatarStylesKey = 'ChromaAvatar';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       alignItems: 'center',

--- a/src/components/Avatar/AvatarBadge.tsx
+++ b/src/components/Avatar/AvatarBadge.tsx
@@ -6,7 +6,7 @@ import { useAvatarSize } from './AvatarSizeContext';
 
 export const AvatarBadgeStylesKey = 'ChromaAvatarBadge';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       alignItems: 'center',

--- a/src/components/Box/Box.tsx
+++ b/src/components/Box/Box.tsx
@@ -55,7 +55,7 @@ export interface BoxProps
   bgColor?: string;
 }
 
-const useStyles = makeStyles<BoxProps>(
+export const useStyles = makeStyles<BoxProps>(
   (theme) => {
     const stringOrThemeSpacing = (value: string | number | undefined) => {
       if (typeof value === 'string') return value;

--- a/src/components/Breadcrumbs/Breadcrumb.tsx
+++ b/src/components/Breadcrumbs/Breadcrumb.tsx
@@ -6,7 +6,7 @@ import { GetClasses } from '../../typeUtils';
 
 export const BreadcrumbStylesKey = 'ChromaBreadcrumb';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       display: 'inline',

--- a/src/components/Breadcrumbs/BreadcrumbNav.tsx
+++ b/src/components/Breadcrumbs/BreadcrumbNav.tsx
@@ -5,7 +5,7 @@ import { GetClasses } from '../../typeUtils';
 
 export const BreadcrumbNavStylesKey = 'ChromaBreadcrumbNav';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {},
     ol: {

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -7,7 +7,7 @@ import { BreadcrumbNav } from './BreadcrumbNav';
 
 export const BreadcrumbsStylesKey = 'ChromaBreadcrumbs';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (_theme) => ({
     root: {},
     inverse: {},

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -6,7 +6,7 @@ import 'focus-visible';
 
 export const ButtonStylesKey = 'ChromaButton';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       alignItems: 'center',

--- a/src/components/ButtonFilePicker/ButtonFilePicker.tsx
+++ b/src/components/ButtonFilePicker/ButtonFilePicker.tsx
@@ -8,7 +8,7 @@ import 'focus-visible';
 
 export const ButtonFilePickerStylesKey = 'ChromaButtonFilePicker';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       alignItems: 'center',

--- a/src/components/ButtonFloat/ButtonFloat.tsx
+++ b/src/components/ButtonFloat/ButtonFloat.tsx
@@ -6,7 +6,7 @@ import 'focus-visible';
 
 export const ButtonFloatStylesKey = 'ChromaButtonFloat';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       alignItems: 'center',

--- a/src/components/ButtonLink/ButtonLink.tsx
+++ b/src/components/ButtonLink/ButtonLink.tsx
@@ -9,7 +9,7 @@ import 'focus-visible';
 
 export const ButtonLinkStylesKey = 'ChromaButtonLink';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       alignItems: 'center',

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -17,7 +17,7 @@ import 'focus-visible';
 
 export const CheckboxStylesKey = 'ChromaCheckbox';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       // All values that are animated to/from need to be specified as css variables for the

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -6,7 +6,7 @@ import { GetClasses } from '../../typeUtils';
 
 export const ChipStylesKey = 'ChromaChip';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       margin: theme.spacing(1.25, 1.25, 0, 0),

--- a/src/components/Divider/Divider.tsx
+++ b/src/components/Divider/Divider.tsx
@@ -5,7 +5,7 @@ import { GetClasses } from '../../typeUtils';
 
 export const DividerStylesKey = 'ChromaDivider';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       backgroundColor: 'rgba(0, 0, 0, 0.15)',

--- a/src/components/DotLoader/DotLoader.tsx
+++ b/src/components/DotLoader/DotLoader.tsx
@@ -6,7 +6,7 @@ import { AnimatePresence, motion, MotionProps } from 'framer-motion';
 
 export const DotLoaderStylesKey = 'ChromaDotLoader';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       height: theme.pxToRem(100),

--- a/src/components/FormBox/FormBox.tsx
+++ b/src/components/FormBox/FormBox.tsx
@@ -6,7 +6,7 @@ import { Box, BoxProps } from '../Box';
 
 export const FormBoxStylesKey = 'ChromaFormBox';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {},
     vSpacing0: {

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -7,7 +7,7 @@ export const headerHeight = '3.125rem';
 
 export const HeaderStylesKey = 'ChromaHeader';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       alignItems: 'center',

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -6,7 +6,7 @@ import 'focus-visible';
 
 export const IconButtonStylesKey = 'ChromaIconButton';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       alignItems: 'center',

--- a/src/components/IconButtonFloat/IconButtonFloat.tsx
+++ b/src/components/IconButtonFloat/IconButtonFloat.tsx
@@ -6,7 +6,7 @@ import 'focus-visible';
 
 export const IconButtonFloatStylesKey = 'ChromaIconButtonFloat';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       alignItems: 'center',

--- a/src/components/IconButtonLink/IconButtonLink.tsx
+++ b/src/components/IconButtonLink/IconButtonLink.tsx
@@ -9,7 +9,7 @@ import 'focus-visible';
 
 export const IconButtonLinkStylesKey = 'ChromaIconButtonLink';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       alignItems: 'center',

--- a/src/components/IconTile/IconTile.tsx
+++ b/src/components/IconTile/IconTile.tsx
@@ -5,7 +5,7 @@ import { GetClasses } from '../../typeUtils';
 
 export const IconTileStylesKey = 'ChromaIconTile';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       width: theme.pxToRem(202),

--- a/src/components/IconTile/IconTileBadge.tsx
+++ b/src/components/IconTile/IconTileBadge.tsx
@@ -5,7 +5,7 @@ import { GetClasses } from '../../typeUtils';
 
 export const IconTileBadgeStylesKey = 'ChromaIconTileBadge';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       display: 'flex',

--- a/src/components/IconTile/IconTileContent.tsx
+++ b/src/components/IconTile/IconTileContent.tsx
@@ -6,7 +6,7 @@ import { Text } from '../Text';
 
 export const IconTileContentStylesKey = 'ChromaIconTileContent';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       width: '100%',

--- a/src/components/IconTile/IconTileHero.tsx
+++ b/src/components/IconTile/IconTileHero.tsx
@@ -5,7 +5,7 @@ import { GetClasses, StandardProps } from '../../typeUtils';
 
 export const IconTileHeroStylesKey = 'ChromaIconTileHero';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   () => ({
     root: {
       position: 'relative',

--- a/src/components/KeymapHelp/KeymapHelp.tsx
+++ b/src/components/KeymapHelp/KeymapHelp.tsx
@@ -23,7 +23,7 @@ const BASE_KEY_MAP_DOCS: KeyBindingDoc[] = [
 
 export const KeymapHelpStylesKey = 'ChromaKeymapHelp';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {},
     sequence: {

--- a/src/components/LinearProgress/LinearProgress.tsx
+++ b/src/components/LinearProgress/LinearProgress.tsx
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 
 export const LinearProgressStylesKey = 'ChromaLinearProgress';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       '--linear-progress-height': '0.25rem',

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -9,7 +9,7 @@ import { GetClasses } from '../../typeUtils';
 
 export const LinkStylesKey = 'ChromaLink';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       color: theme.palette.primary.main,

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -18,7 +18,7 @@ import 'focus-visible';
 
 export const MenuStylesKey = 'ChromaMenu';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       backgroundColor: theme.palette.common.white,

--- a/src/components/Menu/MenuButton.tsx
+++ b/src/components/Menu/MenuButton.tsx
@@ -5,7 +5,7 @@ import { Button, ButtonProps } from '../Button';
 
 export const MenuButtonStylesKey = 'ChromaMenuButton';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     trailingIcon: {
       width: theme.spacing(2),

--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -5,7 +5,7 @@ import { GetClasses } from '../../typeUtils';
 
 export const MenuItemStylesKey = 'ChromaMenuItem';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       alignItems: 'center',

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -25,7 +25,7 @@ export const ModalStylesKey = 'ChromaModal';
 
 export const OVERLAY_TEST_ID = 'chroma-overlay-testid';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     overlay: {
       backgroundColor: 'rgba(0, 0, 0, 0.5)',

--- a/src/components/Modal/ModalActions.tsx
+++ b/src/components/Modal/ModalActions.tsx
@@ -5,7 +5,7 @@ import { GetClasses } from '../../typeUtils';
 
 export const ModalActionsStylesKey = 'ChromaModalActions';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       display: 'flex',

--- a/src/components/Paper/Paper.tsx
+++ b/src/components/Paper/Paper.tsx
@@ -6,7 +6,7 @@ import { Box, BoxProps } from '../Box';
 
 export const PaperStylesKey = 'ChromaPaper';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       background: theme.palette.common.white,

--- a/src/components/Pill/Pill.tsx
+++ b/src/components/Pill/Pill.tsx
@@ -6,7 +6,7 @@ import { motion, MotionProps } from 'framer-motion';
 
 export const PillStylesKey = 'ChromaPill';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       display: 'inline-flex',

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -16,7 +16,7 @@ import * as React from 'react';
 
 export const PopoverStylesKey = 'ChromaPopover';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       background: theme.palette.common.white,

--- a/src/components/Popover/PopoverActions.tsx
+++ b/src/components/Popover/PopoverActions.tsx
@@ -5,7 +5,7 @@ import { GetClasses } from '../../typeUtils';
 
 export const PopoverActionsStylesKey = 'ChromaPopoverActions';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       borderTop: `1px solid ${theme.palette.divider}`,

--- a/src/components/Popover/PopoverContent.tsx
+++ b/src/components/Popover/PopoverContent.tsx
@@ -4,7 +4,7 @@ import { GetClasses } from '../../typeUtils';
 
 export const PopoverContentStylesKey = 'ChromaPopoverContent';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       padding: theme.spacing(1.25, 2.5),

--- a/src/components/Popover/PopoverItem.tsx
+++ b/src/components/Popover/PopoverItem.tsx
@@ -6,7 +6,7 @@ import { Text } from '../Text';
 
 export const PopoverItemStylesKey = 'ChromaPopoverItem';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       display: 'flex',

--- a/src/components/Popover/PopoverList.tsx
+++ b/src/components/Popover/PopoverList.tsx
@@ -4,7 +4,7 @@ import { GetClasses } from '../../typeUtils';
 
 export const PopoverListStylesKey = 'ChromaPopoverList';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       listStyle: 'none',

--- a/src/components/PrimaryNavigation/PrimaryNavigationExpansionItem.tsx
+++ b/src/components/PrimaryNavigation/PrimaryNavigationExpansionItem.tsx
@@ -22,7 +22,7 @@ import { motion, MotionProps, Variants } from 'framer-motion';
 export const PrimaryNavigationExpansionItemStylesKey =
   'ChromaPrimaryNavigationExpansionItem';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       listStyle: 'none',

--- a/src/components/PrimaryNavigation/PrimaryNavigationItem.tsx
+++ b/src/components/PrimaryNavigation/PrimaryNavigationItem.tsx
@@ -17,7 +17,7 @@ import { motion } from 'framer-motion';
 
 export const PrimaryNavigationItemStylesKey = 'ChromaPrimaryNavigationItem';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       listStyle: 'none',

--- a/src/components/PrimaryNavigation/PrimaryNavigationSubItem.tsx
+++ b/src/components/PrimaryNavigation/PrimaryNavigationSubItem.tsx
@@ -12,7 +12,7 @@ import { motion, MotionProps } from 'framer-motion';
 export const PrimaryNavigationSubItemStylesKey =
   'ChromaPrimaryNavigationSubItem';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       listStyle: 'none',

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -14,7 +14,7 @@ import { useRadioGroup } from './useRadioGroup';
 
 export const RadioStylesKey = 'ChromaRadio';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       display: 'flex',

--- a/src/components/Radio/RadioGroup.tsx
+++ b/src/components/Radio/RadioGroup.tsx
@@ -7,7 +7,7 @@ import { RadioGroupContext } from './useRadioGroup';
 
 export const RadioGroupStylesKey = 'ChromaRadioGroup';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       border: 0,

--- a/src/components/Radio/RadioGroupMinimal.tsx
+++ b/src/components/Radio/RadioGroupMinimal.tsx
@@ -7,7 +7,7 @@ import { RadioGroupContext } from './useRadioGroup';
 
 export const RadioGroupMinimalStylesKey = 'ChromaRadioGroupMinimal';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       border: 0,

--- a/src/components/SearchField/SearchField.tsx
+++ b/src/components/SearchField/SearchField.tsx
@@ -13,7 +13,7 @@ import { clearClipPath, defaultClipPath } from './clipPaths';
 
 export const SearchFieldStylesKey = 'ChromaSearchField';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       position: 'relative',

--- a/src/components/SecondaryNavigation/SecondaryNavigation.tsx
+++ b/src/components/SecondaryNavigation/SecondaryNavigation.tsx
@@ -5,7 +5,7 @@ import { GetClasses, StandardProps } from '../../typeUtils';
 
 export const SecondaryNavigationStylesKey = 'ChromaSecondaryNavigation';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       borderRight: `1px solid ${theme.palette.divider}`,

--- a/src/components/SecondaryNavigation/SecondaryNavigationItem.tsx
+++ b/src/components/SecondaryNavigation/SecondaryNavigationItem.tsx
@@ -6,7 +6,7 @@ import { GetClasses, StandardProps } from '../../typeUtils';
 
 export const SecondaryNavigationItemStylesKey = 'ChromaSecondaryNavigationItem';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       paddingTop: theme.spacing(1.5),

--- a/src/components/Select/SelectOption.tsx
+++ b/src/components/Select/SelectOption.tsx
@@ -10,7 +10,7 @@ export const SelectOptionStylesKey = 'ChromaSelectOption';
 
 export const checkSize = 20;
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       paddingTop: theme.spacing(0.5),

--- a/src/components/SlideOver/Actions.tsx
+++ b/src/components/SlideOver/Actions.tsx
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 
 export const ActionsStylesKey = 'ChromaSlideOverActions';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       borderTop: `1px solid ${theme.palette.divider}`,

--- a/src/components/SlideOver/Body.tsx
+++ b/src/components/SlideOver/Body.tsx
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 
 export const BodyStylesKey = 'ChromaSlideOverBody';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       display: 'flex',

--- a/src/components/SlideOver/Header.tsx
+++ b/src/components/SlideOver/Header.tsx
@@ -8,7 +8,7 @@ import clsx from 'clsx';
 
 export const HeaderStylesKey = 'ChromaSlideOverHeader';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       alignItems: 'center',

--- a/src/components/SlideOver/SlideOver.tsx
+++ b/src/components/SlideOver/SlideOver.tsx
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 
 export const SlideOverStylesKey = 'ChromaSlideOver';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     '@keyframes fade-in': {
       '0%': {

--- a/src/components/SmallTile/SmallTile.tsx
+++ b/src/components/SmallTile/SmallTile.tsx
@@ -5,7 +5,7 @@ import { GetClasses } from '../../typeUtils';
 
 export const SmallTileStylesKey = 'ChromaSmallTile';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       width: theme.pxToRem(172),

--- a/src/components/SmallTile/SmallTileContent.tsx
+++ b/src/components/SmallTile/SmallTileContent.tsx
@@ -6,7 +6,7 @@ import { Text } from '../Text';
 
 export const SmallTileContentStylesKey = 'ChromaSmallTileContent';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       display: 'flex',

--- a/src/components/SmallTile/SmallTileFooter.tsx
+++ b/src/components/SmallTile/SmallTileFooter.tsx
@@ -6,7 +6,7 @@ import { Text } from '../Text';
 
 export const SmallTileFooterStylesKey = 'ChromaSmallTileFooter';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       display: 'flex',

--- a/src/components/Snackbar/Snackbar.tsx
+++ b/src/components/Snackbar/Snackbar.tsx
@@ -10,7 +10,7 @@ import { NotificationStatusType } from '../_private/notificationTypes';
 
 export const SnackbarStylesKey = 'ChromaSnackbar';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       color: theme.palette.text.secondary,

--- a/src/components/Stepper/Step.tsx
+++ b/src/components/Stepper/Step.tsx
@@ -8,7 +8,7 @@ import { Text } from '../Text';
 
 export const StepStylesKey = 'ChromaStep';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     buttonRoot: {
       alignItems: 'center',

--- a/src/components/Stepper/StepConnector.tsx
+++ b/src/components/Stepper/StepConnector.tsx
@@ -5,7 +5,7 @@ import { GetClasses } from '../../typeUtils';
 
 export const StepConnectorStylesKey = 'ChromaStepConnector';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     connectorRoot: {
       flex: 1,

--- a/src/components/Stepper/Stepper.tsx
+++ b/src/components/Stepper/Stepper.tsx
@@ -7,7 +7,7 @@ import { StepConnector } from './StepConnector';
 
 export const StepperStylesKey = 'ChromaStepper';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       backgroundColor: theme.palette.common.white,

--- a/src/components/TableModule/TableActionDivider.tsx
+++ b/src/components/TableModule/TableActionDivider.tsx
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 
 export const TableActionDividerStylesKey = 'ChromaTableActionDivider';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       height: theme.pxToRem(19),

--- a/src/components/TableModule/TableHeaderCell.tsx
+++ b/src/components/TableModule/TableHeaderCell.tsx
@@ -7,7 +7,7 @@ import { TableSortDirection, TableHeader, TableSortClickProps } from './types';
 
 export const TableHeaderCellStylesKey = 'ChromaTableHeaderCell';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       transition: 'color 0.25s ease',

--- a/src/components/TableModule/TableModuleActions.tsx
+++ b/src/components/TableModule/TableModuleActions.tsx
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 
 export const TableModuleActionsStylesKey = 'ChromaTableModuleActions';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       display: 'flex',

--- a/src/components/Tabs/Tab.tsx
+++ b/src/components/Tabs/Tab.tsx
@@ -8,7 +8,7 @@ import { TabStop } from './types';
 
 export const TabStylesKey = 'ChromaTab';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       alignItems: 'center',

--- a/src/components/Tabs/TabList.tsx
+++ b/src/components/Tabs/TabList.tsx
@@ -7,7 +7,7 @@ import { TabsContext } from './TabsContext';
 
 export const TabListStylesKey = 'ChromaTabList';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       display: 'flex',

--- a/src/components/Tabs/TabPanel.tsx
+++ b/src/components/Tabs/TabPanel.tsx
@@ -8,7 +8,7 @@ import { TabStop } from './types';
 
 export const TabPanelStylesKey = 'ChromaTabPanel';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (_theme) => ({
     root: {
       outline: 'none',

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -5,7 +5,7 @@ import { GetClasses } from '../../typeUtils';
 
 export const TextStylesKey = 'ChromaText';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       color: theme.palette.black.main,

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -15,7 +15,7 @@ import { Tooltip } from '../Tooltip';
 
 export const TextAreaStylesKey = 'ChromaTextArea';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {},
     label: {

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -15,7 +15,7 @@ import { Tooltip } from '../Tooltip';
 
 export const TextFieldStylesKey = 'ChromaTextField';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {},
     label: {

--- a/src/components/Toggle/Toggle.tsx
+++ b/src/components/Toggle/Toggle.tsx
@@ -15,7 +15,7 @@ import { Text } from '../Text';
 
 export const ToggleStylesKey = 'ChromaToggle';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       display: 'flex',

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -15,7 +15,7 @@ import * as React from 'react';
 
 export const TooltipStylesKey = 'ChromaTooltip';
 
-const useStyles = makeStyles(
+export const useStyles = makeStyles(
   (theme) => ({
     root: {
       backgroundColor: theme.palette.common.white,


### PR DESCRIPTION
### Changes

- Export `useStyles` for each component not already doing so

### Motivation

This would allow folks who need to build a custom component to use the existing styles of a Chroma component.  This would mean the component would _look_ pretty close (if not identical) to a Chroma component, but would serve the developer's custom-built needs.  I believe @HaleyWardo ran into a case where this would've helped her.  She may have more info and a better example