### PR TITLE
FIX: Allow left align override on last column header and cell

### DIFF
--- a/src/components/TableModule/TableHeaderCell.tsx
+++ b/src/components/TableModule/TableHeaderCell.tsx
@@ -123,9 +123,10 @@ export const TableHeaderCell: React.FC<TableHeaderCellProps> = ({
         //   then it is left-aligned
         // - If this is the last header and there is more than one column, then
         //   it is right-aligned
+        // - Allow for left alignment override on last header
         // - Fallback behavior is left aligned (specified by root class)
-        ((header.align && header.align === 'right') ||
-          (headingsCount > 1 && index === headingsCount - 1)) &&
+        ((!header.align && headingsCount > 1 && index === headingsCount - 1) ||
+          header?.align === 'right') &&
           classes.rootAlignRight,
         header.className
       )}

--- a/src/components/TableModule/TableModuleCell.test.tsx
+++ b/src/components/TableModule/TableModuleCell.test.tsx
@@ -86,7 +86,7 @@ test('it renders with "isLastCellInRow"', async () => {
     </RenderInTable>
   );
   const root = await findByTestId(testIds.bodyCell);
-  expect(root).toHaveClass('ChromaTableModule-tableRowCellAlignRight');
+  expect(root).toHaveClass('ChromaTableModule-tableRowCell');
 });
 
 test('it renders with cell "align: right"', async () => {

--- a/src/components/TableModule/TableModuleCell.tsx
+++ b/src/components/TableModule/TableModuleCell.tsx
@@ -27,10 +27,12 @@ export const TableModuleCell: React.FC<TableModuleCell> = React.memo(
         //   then it is left-aligned
         // - If this is the last cell and there is more than one column, then
         //   it is right-aligned
+        // - Allow for left alignment override on last cell
         // - Fallback behavior is left aligned (specified by tableRowCell class)
         className={clsx(
           classes.tableRowCell,
-          ((cell.align && cell.align === 'right') || isLastCellInRow) &&
+          ((isLastCellInRow && cell?.align !== 'left') ||
+            cell?.align === 'right') &&
             classes.tableRowCellAlignRight,
           maxCellWidth && classes.tableRowCellTruncate,
           {


### PR DESCRIPTION
This PR allows for last column table content to be left-aligned. Last column content will continue to default to right-aligned.

BEFORE | AFTER
-- | --
<img width="920" alt="Screen Shot 2020-10-29 at 11 26 19 AM" src="https://user-images.githubusercontent.com/485903/97595059-b3cbaf00-19d9-11eb-9de1-a2387cd0b9b2.png"> | <img width="920" alt="Screen Shot 2020-10-29 at 11 26 54 AM" src="https://user-images.githubusercontent.com/485903/97595062-b4644580-19d9-11eb-85db-4113dc070a7b.png">
