### PR TITLE
Add overflow hidden to ensure content doesn't go outside rounded corners

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -52,6 +52,7 @@ export const useStyles = makeStyles(
       paddingBottom: theme.spacing(0.25),
       width: theme.pxToRem(384),
       maxWidth: theme.pxToRem(600),
+      overflow: 'hidden',
       '@media screen and (max-width: 480px)': {
         marginBottom: theme.spacing(0.75),
         marginLeft: theme.spacing(0.75),


### PR DESCRIPTION
Gif shows the issue. When a parent has border radius, it needs overflow hidden to ensure child content doesn't exceed the corners.


![modal](https://user-images.githubusercontent.com/833911/97885669-b25df780-1cf5-11eb-8a08-c45b5fecc2ea.gif)
