### PR TITLE
FEAT: Add children to SliderOver Header

### DIFF
--- a/src/components/SlideOver/Header.test.tsx
+++ b/src/components/SlideOver/Header.test.tsx
@@ -57,3 +57,14 @@ test('it renders the provided title', async () => {
   const title = await findByText(/SlideOverTitle/);
   expect(title).toBeInTheDocument();
 });
+
+test('it renders the provided children', async () => {
+  const { findByTestId } = renderWithTheme(
+    <Header {...getBaseProps()}>
+      <p data-testid={testId}>children</p>
+    </Header>
+  );
+
+  const children = await findByTestId(testId);
+  expect(children).toBeInTheDocument();
+});

--- a/src/components/SlideOver/Header.tsx
+++ b/src/components/SlideOver/Header.tsx
@@ -27,7 +27,7 @@ export type HeaderClasses = GetClasses<typeof useStyles>;
 export interface HeaderProps {
   className?: string;
   onClose: () => any;
-  title: string;
+  title?: string;
   classes?: {
     root?: string;
     text?: string;
@@ -36,6 +36,7 @@ export interface HeaderProps {
 }
 
 export const Header: React.FC<HeaderProps> = ({
+  children,
   classes: additionalClasses,
   className,
   onClose,
@@ -48,9 +49,16 @@ export const Header: React.FC<HeaderProps> = ({
       className={clsx(classes.root, additionalClasses?.root, className)}
       {...rootProps}
     >
-      <Text className={clsx(additionalClasses?.text)} size="body" weight="bold">
-        {title}
-      </Text>
+      {children}
+      {title && (
+        <Text
+          className={clsx(additionalClasses?.text)}
+          size="body"
+          weight="bold"
+        >
+          {title}
+        </Text>
+      )}
       <IconButton
         className={additionalClasses?.button}
         aria-label="Close panel"

--- a/stories/components/SlideOver/SlideOver.stories.tsx
+++ b/stories/components/SlideOver/SlideOver.stories.tsx
@@ -4,8 +4,9 @@ import {
   Header,
   SlideOver,
 } from '../../../src/components/SlideOver';
-import { Box } from '../../../src/components/Box';
+import { Avatar } from '../../../src/components/Avatar';
 import { Button } from '../../../src/components/Button';
+import { FormBox } from '../../../src/components/FormBox';
 import { Toggle } from '../../../src/components/Toggle';
 import { Container } from '../../storyComponents/Container';
 import { storiesOf } from '@storybook/react';
@@ -16,10 +17,13 @@ import defaultMd from './default.md';
 const SlideOverStory: React.FC = () => {
   const [isSlideOverOpen, setIsSlideOverOpen] = React.useState<boolean>(false);
   const [includeActions, setIncludeActions] = React.useState<boolean>(false);
+  const [withCustomHeader, setWithCustomHeader] = React.useState<boolean>(
+    false
+  );
 
   return (
     <Container>
-      <Box direction="column" align="center">
+      <FormBox direction="column" align="center">
         <Button
           variant="text"
           onClick={() => setIsSlideOverOpen(!isSlideOverOpen)}
@@ -31,13 +35,26 @@ const SlideOverStory: React.FC = () => {
           checked={includeActions}
           onChange={(e) => setIncludeActions(e.target.checked)}
         />
-      </Box>
+        <Toggle
+          label="With custom header"
+          checked={withCustomHeader}
+          onChange={(e) => setWithCustomHeader(e.target.checked)}
+        />
+      </FormBox>
 
       <SlideOver isOpen={isSlideOverOpen}>
-        <Header
-          title="Panel Title"
-          onClose={() => setIsSlideOverOpen(!isSlideOverOpen)}
-        />
+        {!withCustomHeader && (
+          <Header
+            title="Panel Title"
+            onClose={() => setIsSlideOverOpen(!isSlideOverOpen)}
+          />
+        )}
+        {withCustomHeader && (
+          <Header onClose={() => setIsSlideOverOpen(!isSlideOverOpen)}>
+            <Avatar name="Tony" />
+            <Text>Custom Header</Text>
+          </Header>
+        )}
         <Body>
           <Text>your content</Text>
         </Body>

--- a/stories/components/SlideOver/default.md
+++ b/stories/components/SlideOver/default.md
@@ -63,6 +63,19 @@ The title for the Panel.
 </SlideOver>
 ```
 
+### Children
+
+If you'd like to render custom content in the Header instead of a title-only header, provide children:
+
+```jsx
+<SlideOver>
+  <Header>
+    <Avatar name="User" />
+    <Text>User</Text>
+  </Header>
+</SlideOver>
+```
+
 ### onClose
 
 A callback for when the Close icon button is clicked. This will commonly close


### PR DESCRIPTION
### Changes

- @derrh is wanting to render an avatar + name in the header rather than the `title`.  This should allow him to do what he needs.

I think your code would look something like the storybook example:

```jsx
<Header>
  <Avatar name="Tony" src={path-to-some-img-url-for-the-avatar} />
  <Text>Tony Ward</Text>
</Header>
```

If you want some better spacing between the avatar and text, may need a wrapping `<div />` and apply a class to it.

```jsx
<Header>
  <div className="some-spacing-class">
    <Avatar name="Tony" src={path-to-some-img-url-for-the-avatar} />
    <Text>Tony Ward</Text>
  </div>
</Header>
```

**NOTE:** Since this is making a prop go from required, to not-required, I'm still going to upgrade with `patch`.  Let me know if this warrants a `minor` in your mind though.   If I was going from not-required to required, I think it'd definitely be wise to bump a breaking-change version, but not with the opposite direction we have here?