### PR TITLE
Allow for icon being optional in Step defaulting to number position

### DIFF
--- a/src/components/Stepper/Step.tsx
+++ b/src/components/Stepper/Step.tsx
@@ -122,7 +122,7 @@ export interface StepProps {
   className?: string;
   completed?: boolean;
   disabled?: boolean;
-  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+  icon?: React.ComponentType<React.SVGProps<SVGSVGElement>>;
   index?: number;
   onClick?: (index: number | undefined) => void;
   subTitle?: string;
@@ -161,15 +161,29 @@ export const Step: React.FC<StepProps> = ({
         )}
         justify="center"
       >
-        <Icon
-          aria-hidden="true"
-          className={clsx(
-            classes.icon,
-            active && classes.activeIcon,
-            completed && classes.completedIcon
-          )}
-          role="img"
-        />
+        {Icon ? (
+          <Icon
+            aria-hidden="true"
+            className={clsx(
+              classes.icon,
+              active && classes.activeIcon,
+              completed && classes.completedIcon
+            )}
+            role="img"
+          />
+        ) : (
+          <Text
+            aria-hidden="true"
+            size="headline"
+            className={clsx(
+              classes.icon,
+              active && classes.activeIcon,
+              completed && classes.completedIcon
+            )}
+          >
+            {(index || 0) + 1}
+          </Text>
+        )}
       </Box>
       <Text
         className={clsx(classes.title, active && classes.activeTitle)}

--- a/stories/components/Stepper/Stepper.stories.tsx
+++ b/stories/components/Stepper/Stepper.stories.tsx
@@ -38,6 +38,14 @@ const StepperStory: React.FC = () => {
           <Step icon={Flag} title="Completed" />
         </Stepper>
       </Container>
+      <Container>
+        <Stepper activeStep={3} as="div">
+          <Step title="Registered" />
+          <Step title="Consented" />
+          <Step title="Demographics" />
+          <Step title="Completed" />
+        </Stepper>
+      </Container>
     </>
   );
 };

--- a/stories/components/Stepper/default.md
+++ b/stories/components/Stepper/default.md
@@ -57,7 +57,7 @@ button components (clickable) or div components.
 
 The following props are available on the component:
 
-- icon: A React SVG component to render.
+- icon: A React SVG component to render. Leaving out icon will render its ordered number.
 - title: The primary text to display directly underneath the Stepper icon.
 - subTitle: The text to display directly underneath the title.
 - subTitlePillLabel: A Pill to display directly underneath the title (usually to
@@ -83,6 +83,16 @@ component.
 
 ```jsx
 <Step subTitlePillLabel={320} />
+```
+
+### Rendering Steps Ordered as 1, 2, 3, etc
+
+By not providing the Icon, `Step` will display the `index + 1` in the icons place.
+
+```jsx
+<Step title="First" />
+<Step title="Second" />
+<Step title="Last" />
 ```
 
 ## Links


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19804196/100909837-6afc8f80-348a-11eb-98ce-7a8774917adb.png)

I think this could come in handy during prototyping and playing around, not having to worry about providing Icons, and also maybe in some places an Icon just doesn't make sense though mixing the two options probably would not work great