### PR TITLE
Support secondaryLabel for Select and ComboBox components

### DIFF
--- a/src/components/Select/ComboBox.test.tsx
+++ b/src/components/Select/ComboBox.test.tsx
@@ -32,6 +32,16 @@ test('it renders the provided label', async () => {
   expect(label).toBeInTheDocument();
 });
 
+test('it renders the provided secondaryLabel', async () => {
+  const props = getBaseProps();
+  const { findByText } = renderWithTheme(
+    <ComboBox {...props} data-testid={testId} secondaryLabel="Optional" />
+  );
+
+  const label = await findByText('Optional');
+  expect(label).toBeInTheDocument();
+});
+
 test('it renders the provided helpMessage', async () => {
   const props = getBaseProps();
   const { findByText } = renderWithTheme(

--- a/src/components/Select/ComboBox.tsx
+++ b/src/components/Select/ComboBox.tsx
@@ -109,6 +109,7 @@ export const ComboBox: React.FC<ComboBoxProps> = ({
   helpMessage,
   id,
   label,
+  secondaryLabel,
   onChange,
   placeholder,
   placement,
@@ -211,6 +212,16 @@ export const ComboBox: React.FC<ComboBoxProps> = ({
         htmlFor={uniqueId}
       >
         {label || ariaLabel}
+        {secondaryLabel ? (
+          <span
+            className={clsx(
+              classes.labelSecondary,
+              color === 'inverse' && classes.labelInverse
+            )}
+          >
+            {secondaryLabel}
+          </span>
+        ) : null}
       </label>
       <PopoverDisclosure
         className={clsx(

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -33,6 +33,16 @@ test('it renders the provided label', async () => {
   expect(label).toBeInTheDocument();
 });
 
+test('it renders the provided secondaryLabel', async () => {
+  const props = getBaseProps();
+  const { findByText } = renderWithTheme(
+    <Select {...props} data-testid={testId} secondaryLabel="Optional" />
+  );
+
+  const label = await findByText('Optional');
+  expect(label).toBeInTheDocument();
+});
+
 test('it renders the provided helpMessage', async () => {
   const props = getBaseProps();
   const { findByText } = renderWithTheme(

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -58,6 +58,12 @@ export const useStyles = makeStyles(
         marginBottom: theme.spacing(0),
       },
     },
+    labelSecondary: {
+      fontSize: theme.pxToRem(11),
+      display: 'inline-block',
+      margin: theme.spacing(0, 0.75),
+      opacity: 0.65,
+    },
     labelInverse: {
       color: theme.palette.common.white,
     },
@@ -289,6 +295,7 @@ export interface SelectProps
       'className' | 'id' | 'value'
     > {
   ['aria-label']?: string;
+  secondaryLabel?: string;
   fullWidth?: boolean;
   onChange?: (value: string, meta: any) => void;
   placeholder?: string;
@@ -322,6 +329,7 @@ export const Select: React.FC<SelectProps> = ({
   helpMessage,
   id,
   label,
+  secondaryLabel,
   onChange,
   placeholder,
   placement,
@@ -396,6 +404,16 @@ export const Select: React.FC<SelectProps> = ({
         htmlFor={uniqueId}
       >
         {label || ariaLabel}
+        {secondaryLabel ? (
+          <span
+            className={clsx(
+              classes.labelSecondary,
+              color === 'inverse' && classes.labelInverse
+            )}
+          >
+            {secondaryLabel}
+          </span>
+        ) : null}
       </label>
       <PopoverDisclosure
         className={clsx(

--- a/stories/components/ComboBox/ComboBox.stories.tsx
+++ b/stories/components/ComboBox/ComboBox.stories.tsx
@@ -77,6 +77,30 @@ const ComboBoxStory: React.FC = () => {
           </ComboBox>
           <ComboBox
             label="Select option(s)"
+            secondaryLabel="Optional"
+            placeholder="Optionally pick any that apply…"
+            value={comboValue}
+            onChange={(v: Array<string>) => setComboValue(v)}
+          >
+            <SelectOption title="Option 1" value="option 1" />
+            <SelectOption
+              title="Option 2"
+              subtitle="This is a subtitle. For options that need a little extra description."
+              value="option 2"
+            />
+            <SelectOption title="Option 3" value="option 3" />
+            <SelectOption title="Option 4" value="option 4" />
+            <SelectOption
+              title="Option 5 has really long content"
+              value="option 5"
+            />
+            <SelectOption
+              title="Option 6 has really long content"
+              value="option 6"
+            />
+          </ComboBox>
+          <ComboBox
+            label="Select option(s)"
             placeholder="Pick any that apply…"
             value={comboValue}
             onChange={(v: Array<string>) => setComboValue(v)}
@@ -206,6 +230,30 @@ const ComboBoxStory: React.FC = () => {
             value={comboValue}
             onChange={(v: Array<string>) => setComboValue(v)}
             helpMessage="Some helper text…"
+          >
+            <SelectOption title="Option 1" value="option 1" />
+            <SelectOption
+              title="Option 2"
+              subtitle="This is a subtitle. For options that need a little extra description."
+              value="option 2"
+            />
+            <SelectOption title="Option 3" value="option 3" />
+            <SelectOption title="Option 4" value="option 4" />
+            <SelectOption
+              title="Option 5 has really long content"
+              value="option 5"
+            />
+            <SelectOption
+              title="Option 6 has really long content"
+              value="option 6"
+            />
+          </ComboBox>
+          <ComboBox
+            label="Select option(s)"
+            secondaryLabel="Optional"
+            placeholder="Optionally pick any that apply…"
+            value={comboValue}
+            onChange={(v: Array<string>) => setComboValue(v)}
           >
             <SelectOption title="Option 1" value="option 1" />
             <SelectOption
@@ -377,6 +425,31 @@ const ComboBoxStory: React.FC = () => {
           </ComboBox>
           <ComboBox
             label="Select option(s)"
+            secondaryLabel="Optional"
+            placeholder="Optionally pick any that apply…"
+            value={comboValue}
+            onChange={(v: Array<string>) => setComboValue(v)}
+            color="inverse"
+          >
+            <SelectOption title="Option 1" value="option 1" />
+            <SelectOption
+              title="Option 2"
+              subtitle="This is a subtitle. For options that need a little extra description."
+              value="option 2"
+            />
+            <SelectOption title="Option 3" value="option 3" />
+            <SelectOption title="Option 4" value="option 4" />
+            <SelectOption
+              title="Option 5 has really long content"
+              value="option 5"
+            />
+            <SelectOption
+              title="Option 6 has really long content"
+              value="option 6"
+            />
+          </ComboBox>
+          <ComboBox
+            label="Select option(s)"
             placeholder="Pick any that apply…"
             value={comboValue}
             onChange={(v: Array<string>) => setComboValue(v)}
@@ -512,6 +585,31 @@ const ComboBoxStory: React.FC = () => {
             onChange={(v: Array<string>) => setComboValue(v)}
             color="inverse"
             helpMessage="Some helper text…"
+          >
+            <SelectOption title="Option 1" value="option 1" />
+            <SelectOption
+              title="Option 2"
+              subtitle="This is a subtitle. For options that need a little extra description."
+              value="option 2"
+            />
+            <SelectOption title="Option 3" value="option 3" />
+            <SelectOption title="Option 4" value="option 4" />
+            <SelectOption
+              title="Option 5 has really long content"
+              value="option 5"
+            />
+            <SelectOption
+              title="Option 6 has really long content"
+              value="option 6"
+            />
+          </ComboBox>
+          <ComboBox
+            label="Select option(s)"
+            secondaryLabel="Optional"
+            placeholder="Optionally pick any that apply…"
+            value={comboValue}
+            onChange={(v: Array<string>) => setComboValue(v)}
+            color="inverse"
           >
             <SelectOption title="Option 1" value="option 1" />
             <SelectOption

--- a/stories/components/ComboBox/default.md
+++ b/stories/components/ComboBox/default.md
@@ -73,6 +73,14 @@ provided, `popoverAriaLabel` should be provided.
 <ComboBox label="Name" />
 ```
 
+### Secondary Label
+
+A secondary, supplemental label to display for the combobox element.
+
+```jsx
+<Select secondaryLabel="Optional" />
+```
+
 ### Placeholder
 
 The placeholder text to display.

--- a/stories/components/Select/Select.stories.tsx
+++ b/stories/components/Select/Select.stories.tsx
@@ -59,6 +59,22 @@ const SelectStory: React.FC = () => {
           </Select>
           <Select
             label="Select an option"
+            secondaryLabel="Optional"
+            placeholder="Optionally pick one…"
+            value={selectValue}
+            onChange={(v: string) => setSelectValue(v)}
+          >
+            <SelectOption title="Option 1" value="option 1" />
+            <SelectOption
+              title="Option 2"
+              subtitle="This is a subtitle. For options that need a little extra description."
+              value="option 2"
+            />
+            <SelectOption title="Option 3" value="option 3" />
+            <SelectOption title="Option 4" value="option 4" />
+          </Select>
+          <Select
+            label="Select an option"
             placeholder="Pick one…"
             value={selectValue}
             onChange={(v: string) => setSelectValue(v)}
@@ -141,6 +157,22 @@ const SelectStory: React.FC = () => {
             value={selectValue}
             onChange={(v: string) => setSelectValue(v)}
             helpMessage="Some helper text…"
+          >
+            <SelectOption title="Option 1" value="option 1" />
+            <SelectOption
+              title="Option 2"
+              subtitle="This is a subtitle. For options that need a little extra description."
+              value="option 2"
+            />
+            <SelectOption title="Option 3" value="option 3" />
+            <SelectOption title="Option 4" value="option 4" />
+          </Select>
+          <Select
+            label="Select an option"
+            secondaryLabel="Optional"
+            placeholder="Optionally pick one…"
+            value={selectValue}
+            onChange={(v: string) => setSelectValue(v)}
           >
             <SelectOption title="Option 1" value="option 1" />
             <SelectOption
@@ -249,6 +281,23 @@ const SelectStory: React.FC = () => {
           </Select>
           <Select
             label="Select an option"
+            secondaryLabel="Optional"
+            placeholder="Optionally pick one…"
+            value={selectValue}
+            onChange={(v: string) => setSelectValue(v)}
+            color="inverse"
+          >
+            <SelectOption title="Option 1" value="option 1" />
+            <SelectOption
+              title="Option 2"
+              subtitle="This is a subtitle. For options that need a little extra description."
+              value="option 2"
+            />
+            <SelectOption title="Option 3" value="option 3" />
+            <SelectOption title="Option 4" value="option 4" />
+          </Select>
+          <Select
+            label="Select an option"
             placeholder="Pick one…"
             value={selectValue}
             onChange={(v: string) => setSelectValue(v)}
@@ -341,6 +390,23 @@ const SelectStory: React.FC = () => {
             onChange={(v: string) => setSelectValue(v)}
             color="inverse"
             helpMessage="Some helper text…"
+          >
+            <SelectOption title="Option 1" value="option 1" />
+            <SelectOption
+              title="Option 2"
+              subtitle="This is a subtitle. For options that need a little extra description."
+              value="option 2"
+            />
+            <SelectOption title="Option 3" value="option 3" />
+            <SelectOption title="Option 4" value="option 4" />
+          </Select>
+          <Select
+            label="Select an option"
+            secondaryLabel="Optional"
+            placeholder="Optionally pick one…"
+            value={selectValue}
+            onChange={(v: string) => setSelectValue(v)}
+            color="inverse"
           >
             <SelectOption title="Option 1" value="option 1" />
             <SelectOption

--- a/stories/components/Select/default.md
+++ b/stories/components/Select/default.md
@@ -37,6 +37,14 @@ provided, `popoverAriaLabel` should be provided.
 <Select label="Name" />
 ```
 
+### Secondary Label
+
+A secondary, supplemental label to display for the Select element.
+
+```jsx
+<Select secondaryLabel="Optional" />
+```
+
 ### Placeholder
 
 The placeholder text to display.


### PR DESCRIPTION
Wanted to add suport for `secondaryLabel` for `Select` and `ComboBox` components to help facilitate some figma designs.

https://www.figma.com/file/I9QFAEnOHpurBdOHHUP6y7/PHC-Designs?node-id=3348%3A0

![image](https://user-images.githubusercontent.com/19804196/101540347-1612ba80-395d-11eb-9ba0-793cee3b0868.png)
