### PR TITLE
PHC-463 Table Header

### DIFF
--- a/src/components/TableModule/TableHeaderCell.test.tsx
+++ b/src/components/TableModule/TableHeaderCell.test.tsx
@@ -230,6 +230,7 @@ test('it applies none for aria-sort when isSorting is falsy', async () => {
   expect(root.getAttribute('aria-sort')).toBe('none');
 });
 
+// For accessibility audit
 test('it renders td if there is no header content or label', async () => {
   const props = getBaseProps();
   const header = {

--- a/src/components/TableModule/TableHeaderCell.test.tsx
+++ b/src/components/TableModule/TableHeaderCell.test.tsx
@@ -229,3 +229,43 @@ test('it applies none for aria-sort when isSorting is falsy', async () => {
 
   expect(root.getAttribute('aria-sort')).toBe('none');
 });
+
+test('it renders td if there is no header content or label', async () => {
+  const props = getBaseProps();
+  const header = {
+    label: '',
+  };
+
+  const { findByTestId } = renderWithTheme(
+    <RenderInsideTableRow>
+      <TableHeaderCell
+        {...props}
+        header={header}
+        isSorting={false}
+        data-testid={testId}
+      />
+    </RenderInsideTableRow>
+  );
+  const root = await findByTestId(testId);
+  expect(root.tagName).toBe('TD');
+});
+
+test('it renders th if there is header content or label', async () => {
+  const props = getBaseProps();
+  const header = {
+    label: 'header',
+  };
+
+  const { findByTestId } = renderWithTheme(
+    <RenderInsideTableRow>
+      <TableHeaderCell
+        {...props}
+        header={header}
+        isSorting={false}
+        data-testid={testId}
+      />
+    </RenderInsideTableRow>
+  );
+  const root = await findByTestId(testId);
+  expect(root.tagName).toBe('TH');
+});

--- a/src/components/TableModule/TableHeaderCell.tsx
+++ b/src/components/TableModule/TableHeaderCell.tsx
@@ -111,8 +111,10 @@ export const TableHeaderCell: React.FC<TableHeaderCellProps> = ({
 
   const canSort = onClick && header.onSort;
 
+  const Tag = !header?.content && !header.label ? 'td' : 'th';
+
   return (
-    <th
+    <Tag
       className={clsx(
         classes.root,
         header.onSort && classes.clickable,
@@ -165,6 +167,6 @@ export const TableHeaderCell: React.FC<TableHeaderCellProps> = ({
           height={18}
         />
       )}
-    </th>
+    </Tag>
   );
 };


### PR DESCRIPTION
**Changes**
- Updated table header tag from `th` to `td` if no header content or label is provided.
     - Followed recommended "How to fix": `If the cell is not a header or must remain empty (such as the top-left cell in a data table), make the cell a <td> rather than a <th>`

![Screen Shot 2021-01-27 at 9 01 40 AM](https://user-images.githubusercontent.com/32574227/106001722-4f72c700-607e-11eb-8b2c-4ec5b54b77fc.png)
