### PR TITLE
PHC-463 ComboBox chip color

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -191,7 +191,7 @@ export const useStyles = makeStyles(
     },
     chip: {
       alignItems: 'center',
-      background: theme.palette.primary[600],
+      background: theme.palette.primary.main,
       borderRadius: theme.pxToRem(3),
       color: theme.palette.common.white,
       display: 'inline-block',


### PR DESCRIPTION
**Changes**
- Updated ComboBox selected chip color from `primary[600]` (#0096e1) to `primary.main` (#0096e1). 
    - **They are the same color** but this will allow me to override this color in other apps by changing the main color in the palette. 

**BEFORE**
![Screen Shot 2021-01-27 at 4 38 17 PM](https://user-images.githubusercontent.com/32574227/106057502-12c6c000-60be-11eb-9f90-0ff0b65af6f4.png)

**AFTER**
![Screen Shot 2021-01-27 at 4 36 10 PM](https://user-images.githubusercontent.com/32574227/106057461-05113a80-60be-11eb-9832-32e40a28522e.png)

