### PR TITLE
Improve tooltip legibility

### DIFF
--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -42,7 +42,7 @@ export const useStyles = makeStyles(
       letterSpacing: theme.pxToRem(0.5),
     },
     tooltip: {
-      fontSize: theme.pxToRem(10),
+      fontSize: theme.pxToRem(11),
       letterSpacing: theme.pxToRem(0.5),
       lineHeight: theme.pxToRem(18),
     },

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -18,10 +18,10 @@ export const TooltipStylesKey = 'ChromaTooltip';
 export const useStyles = makeStyles(
   (theme) => ({
     root: {
-      backgroundColor: theme.palette.common.white,
+      backgroundColor: theme.palette.common.black,
       borderRadius: theme.pxToRem(4),
       boxShadow: theme.boxShadows.tooltip,
-      color: theme.palette.text.hint,
+      color: theme.palette.common.white,
       fontFamily: theme.typography.fontFamily,
       fontSize: fontSizes.tooltip,
       letterSpacing: '0.021875em',
@@ -29,7 +29,7 @@ export const useStyles = makeStyles(
       paddingLeft: theme.spacing(1),
       paddingRight: theme.spacing(1),
       paddingTop: theme.spacing(0.5),
-      paddingBottom: theme.spacing(0.5),
+      paddingBottom: theme.spacing(0.75),
       zIndex: 1300,
     },
   }),

--- a/src/styles/__snapshots__/createTheme.test.ts.snap
+++ b/src/styles/__snapshots__/createTheme.test.ts.snap
@@ -175,7 +175,7 @@ Object {
         "backgroundColor": "#ffffff",
         "boxShadow": "0px 0px 24px rgba(0, 0, 0, 0.15)",
         "color": "#7b8996",
-        "fontSize": "0.625rem",
+        "fontSize": "0.6875rem",
         "letterSpacing": "0.021875em",
         "maxWidth": 500,
         "paddingLeft": 8,

--- a/src/styles/createTypography.ts
+++ b/src/styles/createTypography.ts
@@ -58,7 +58,7 @@ export const fontSizes: FontSize = {
   button: '0.75rem',
   subtitle: '0.875rem',
   caption: '0.75rem',
-  tooltip: '0.625rem',
+  tooltip: '0.6875rem',
   code: '1rem',
 };
 


### PR DESCRIPTION
BEFORE | AFTER
-- | --
<img width="496" alt="01-Screen Shot 2021-02-24 at 10 28 47 AM" src="https://user-images.githubusercontent.com/485903/109024576-e89bfa00-768b-11eb-9fe0-1426298179ec.png"> | <img width="496" alt="02-Screen Shot 2021-02-24 at 10 28 19 AM" src="https://user-images.githubusercontent.com/485903/109024581-e9349080-768b-11eb-85f9-71d67ae3a575.png">
<img width="496" alt="03-Screen Shot 2021-02-24 at 10 26 51 AM" src="https://user-images.githubusercontent.com/485903/109024582-e9cd2700-768b-11eb-837b-408e840081be.png"> | <img width="496" alt="04-Screen Shot 2021-02-24 at 10 27 10 AM" src="https://user-images.githubusercontent.com/485903/109024584-e9cd2700-768b-11eb-8b5e-5d325a4e2c9b.png">
