### PR TITLE
Set text color of popover to primary to complement background color

### DIFF
--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -20,6 +20,7 @@ export const useStyles = makeStyles(
   (theme) => ({
     root: {
       background: theme.palette.common.white,
+      color: theme.palette.text.primary,
       borderRadius: theme.pxToRem(10),
       boxShadow: theme.boxShadows.popover,
       minWidth: theme.pxToRem(224),


### PR DESCRIPTION
Fixes a bug where if popover is a child of a div with `color: white` (or other non-contrasting text with it's white background), the text is not visible. Since it sets the background explicitly to white, it should also set the text color.

Bug in action:

![white-text](https://user-images.githubusercontent.com/833911/109855477-5022ee00-7c26-11eb-8d2d-93009633ea26.gif)
