### PR TITLE
Create ButtonUnstyled

### DIFF
--- a/src/components/ButtonUnstyled/ButtonUnstyled.test.tsx
+++ b/src/components/ButtonUnstyled/ButtonUnstyled.test.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import { ButtonUnstyled, ButtonUnstyledProps } from './index';
+import { renderWithTheme } from '../../testUtils/renderWithTheme';
+
+const testId = 'ButtonUnstyled';
+
+const getBaseProps = (): ButtonUnstyledProps => ({});
+
+test('it renders an ButtonUnstyled', async () => {
+  const props = getBaseProps();
+  const { findByTestId } = renderWithTheme(
+    <ButtonUnstyled {...props} data-testid={testId}>
+      Button
+    </ButtonUnstyled>
+  );
+  const button = await findByTestId(testId);
+  expect(button).toBeInTheDocument();
+  expect(button.getAttribute('type')).toEqual('button');
+  expect(button.getAttribute('tabIndex')).toEqual('0');
+});
+
+test('it applies the provided className', async () => {
+  const props = getBaseProps();
+  const { findByTestId } = renderWithTheme(
+    <ButtonUnstyled
+      {...props}
+      data-testid={testId}
+      className="custom-class-name"
+    >
+      Button
+    </ButtonUnstyled>
+  );
+  const button = await findByTestId(testId);
+  expect(button).toHaveClass('custom-class-name');
+});
+
+test('it renders with the "fullWidth" prop', async () => {
+  const props = getBaseProps();
+  const { findByTestId } = renderWithTheme(
+    <ButtonUnstyled {...props} data-testid={testId} fullWidth>
+      Button
+    </ButtonUnstyled>
+  );
+  const button = await findByTestId(testId);
+  expect(button).toHaveClass('ChromaButtonUnstyled-fullWidth');
+});
+
+test('it renders a disabled button', async () => {
+  const props = getBaseProps();
+  const { findByTestId } = renderWithTheme(
+    <ButtonUnstyled {...props} data-testid={testId} disabled>
+      Button
+    </ButtonUnstyled>
+  );
+  const button = await findByTestId(testId);
+  expect(button).toBeDisabled();
+  expect(button.getAttribute('tabIndex')).toEqual('-1');
+});

--- a/src/components/ButtonUnstyled/ButtonUnstyled.test.tsx
+++ b/src/components/ButtonUnstyled/ButtonUnstyled.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { ButtonUnstyled, ButtonUnstyledProps } from './index';
+import { fireEvent } from '@testing-library/react';
 import { renderWithTheme } from '../../testUtils/renderWithTheme';
 
 const testId = 'ButtonUnstyled';
@@ -55,4 +56,17 @@ test('it renders a disabled button', async () => {
   const button = await findByTestId(testId);
   expect(button).toBeDisabled();
   expect(button.getAttribute('tabIndex')).toEqual('-1');
+});
+
+test('it calls onClick', async () => {
+  const mockFn = jest.fn();
+  const props = getBaseProps();
+  const { findByTestId } = renderWithTheme(
+    <ButtonUnstyled {...props} data-testid={testId} onClick={mockFn}>
+      Button
+    </ButtonUnstyled>
+  );
+  const button = await findByTestId(testId);
+  fireEvent.click(button);
+  expect(mockFn).toHaveBeenCalled();
 });

--- a/src/components/ButtonUnstyled/ButtonUnstyled.tsx
+++ b/src/components/ButtonUnstyled/ButtonUnstyled.tsx
@@ -38,6 +38,7 @@ export interface ButtonUnstyledProps
   disabled?: boolean;
   fullWidth?: boolean;
 }
+
 export const ButtonUnstyled = React.forwardRef<
   HTMLButtonElement,
   ButtonUnstyledProps

--- a/src/components/ButtonUnstyled/ButtonUnstyled.tsx
+++ b/src/components/ButtonUnstyled/ButtonUnstyled.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import { GetClasses } from '../../typeUtils';
+import { makeStyles } from '../../styles';
+import clsx from 'clsx';
+
+export const ButtonUnstyledStylesKey = 'ChromaButtonUnstyled';
+
+export const useStyles = makeStyles(
+  (theme) => ({
+    root: {
+      backgroundColor: 'transparent',
+      border: 0,
+      borderRadius: theme.pxToRem(4),
+      cursor: 'pointer',
+      padding: 0,
+      width: 'fit-content',
+      '&:focus': {
+        outline: 'none',
+      },
+      '&:focus.focus-visible': {
+        boxShadow: theme.boxShadows.focusVisible,
+      },
+      '&::-moz-focus-inner': {
+        border: 'none',
+      },
+    },
+    fullWidth: {
+      width: '100%',
+    },
+  }),
+  { name: ButtonUnstyledStylesKey }
+);
+
+export type ButtonUnstyledClasses = GetClasses<typeof useStyles>;
+
+export interface ButtonUnstyledProps
+  extends React.ComponentPropsWithoutRef<'button'> {
+  disabled?: boolean;
+  fullWidth?: boolean;
+}
+export const ButtonUnstyled = React.forwardRef<
+  HTMLButtonElement,
+  ButtonUnstyledProps
+>(({ children, className, disabled, fullWidth, ...rootProps }, ref) => {
+  const classes = useStyles({});
+
+  return (
+    <button
+      className={clsx(classes.root, fullWidth && classes.fullWidth, className)}
+      disabled={disabled}
+      ref={ref}
+      tabIndex={disabled ? -1 : 0}
+      type="button"
+      {...rootProps}
+    >
+      {children}
+    </button>
+  );
+});

--- a/src/components/ButtonUnstyled/index.ts
+++ b/src/components/ButtonUnstyled/index.ts
@@ -1,0 +1,6 @@
+export {
+  ButtonUnstyled,
+  ButtonUnstyledProps,
+  ButtonUnstyledStylesKey,
+  ButtonUnstyledClasses,
+} from './ButtonUnstyled';

--- a/src/styles/overrides/ChromaOverrides.ts
+++ b/src/styles/overrides/ChromaOverrides.ts
@@ -182,6 +182,10 @@ import {
 } from '../../components/TextField';
 import { ToggleClasses, ToggleStylesKey } from '../../components/Toggle';
 import { TooltipClasses, TooltipStylesKey } from '../../components/Tooltip';
+import {
+  ButtonUnstyledClasses,
+  ButtonUnstyledStylesKey,
+} from '../../components/ButtonUnstyled';
 
 export type ChromaOverrides = {
   [Name in keyof ChromaComponentNameToClassKey]?: Partial<
@@ -203,6 +207,7 @@ export interface ChromaComponentNameToClassKey {
   [ButtonFilePickerStylesKey]: ButtonFilePickerClasses;
   [ButtonLinkStylesKey]: ButtonLinkClasses;
   [ButtonStylesKey]: ButtonClasses;
+  [ButtonUnstyledStylesKey]: ButtonUnstyledClasses;
   [CheckboxStylesKey]: CheckboxClasses;
   [ChipStylesKey]: ChipClasses;
   [DividerStylesKey]: DividerClasses;

--- a/stories/components/ButtonUnstyled/ButtonUnstyled.stories.tsx
+++ b/stories/components/ButtonUnstyled/ButtonUnstyled.stories.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import md from './default.md';
+import { Alert, AlertBody, AlertIcon } from '../../../src/components/Alert';
+import { ButtonUnstyled } from '../../../src/components/ButtonUnstyled';
+import { Container } from '../../storyComponents/Container';
+import { Info } from '../../../src/icons/lined';
+import { storiesOf } from '@storybook/react';
+import { Text } from '../../../src/components/Text';
+
+const ButtonUnstyledStory: React.FC = () => {
+  return (
+    <Container
+      containerStyles={{
+        flex: 1,
+        flexDirection: 'column',
+        alignContent: 'center',
+      }}
+    >
+      <Container containerStyles={{ flex: 1, alignContent: 'center' }}>
+        <ButtonUnstyled>Button</ButtonUnstyled>
+      </Container>
+      <Container containerStyles={{ flex: 1, alignContent: 'center' }}>
+        <ButtonUnstyled>
+          <Alert>
+            <AlertIcon icon={Info} />
+            <AlertBody>
+              <Text size="subbody">This is the latest version of Chroma.</Text>
+            </AlertBody>
+          </Alert>
+        </ButtonUnstyled>
+      </Container>
+    </Container>
+  );
+};
+
+storiesOf('Components/ButtonUnstyled', module).add(
+  'Default',
+  () => <ButtonUnstyledStory />,
+  {
+    readme: {
+      content: md,
+    },
+  }
+);

--- a/stories/components/ButtonUnstyled/default.md
+++ b/stories/components/ButtonUnstyled/default.md
@@ -56,8 +56,6 @@ A class name can be provided.
   - Pressing `Space` or `Enter` triggers the click action.
 - When the Button has focus, Space and Enter keys activates it.
 - When the Button is disabled, the tabIndex is set to `-1`.
-- The icon of Button has `role="img"` and `aria-hidden` attributes so that it
-  does not get picked up by screen readers.
 
 ## Links
 

--- a/stories/components/ButtonUnstyled/default.md
+++ b/stories/components/ButtonUnstyled/default.md
@@ -1,4 +1,4 @@
-# Button
+# Button Unstyled
 
 A Button component with no button styles.
 

--- a/stories/components/ButtonUnstyled/default.md
+++ b/stories/components/ButtonUnstyled/default.md
@@ -1,0 +1,65 @@
+# Button
+
+A Button component with no button styles.
+
+## Import
+
+```js
+import { ButtonUnstyled } from '@lifeomic/chroma-react/components/ButtonUnstyled';
+```
+
+<!-- STORY -->
+
+## Usage
+
+### Children
+
+The content to render inside of a button.
+
+```jsx
+<ButtonUnstyled>Button</ButtonUnstyled>
+```
+
+### Full Width
+
+To set the width of the button to take 100% of the width, use the `fullWidth`
+prop.
+
+```jsx
+<ButtonUnstyled fullWidth>Button</ButtonUnstyled>
+```
+
+### onClick
+
+```jsx
+<ButtonUnstyled onClick={() => console.log('clicked!')}>Button</ButtonUnstyled>
+```
+
+### Disabled
+
+```jsx
+<ButtonUnstyled disabled>Button</ButtonUnstyled>
+```
+
+### Class Name
+
+A class name can be provided.
+
+```jsx
+<ButtonUnstyled className="mr-4">Button</ButtonUnstyled>
+```
+
+## Accessibility
+
+- The Button has `type="button"`.
+  - Pressing `Tab` will set focus to the element
+  - Pressing `Space` or `Enter` triggers the click action.
+- When the Button has focus, Space and Enter keys activates it.
+- When the Button is disabled, the tabIndex is set to `-1`.
+- The icon of Button has `role="img"` and `aria-hidden` attributes so that it
+  does not get picked up by screen readers.
+
+## Links
+
+- [Component Source](https://github.com/lifeomic/chroma-react/blob/master/src/components/Button/ButtonUnstyled.tsx)
+- [Story Source](https://github.com/lifeomic/chroma-react/blob/master/stories/components/Button/ButtonUnstyled.stories.tsx)


### PR DESCRIPTION
Clickable content should either be a button, link, or have `role="button" (with other additional attributes)`. We have several instances in PHC where the container has a clickable event but is missing several important accessibility attributes. It would be nice if we have a button that is unstyled in Chroma where we can just pass the `onClick` or `onKeyDown` prop through instead of needing to add `role="button"` `tabIndex={0}` `Onclick...` `onKeyDown...` to every clickable div.

**Changes**
- Added new `ButtonUnstyled` component

**Content Width _with text_**
![Screen Shot 2021-03-08 at 9 44 01 AM](https://user-images.githubusercontent.com/32574227/110338296-d6f41400-7ff4-11eb-9197-3c26b00a3424.png)
**Full Width**
![Screen Shot 2021-03-08 at 9 44 19 AM](https://user-images.githubusercontent.com/32574227/110338298-d78caa80-7ff4-11eb-920a-23ff5c7a2e7a.png)
**Content Width _with children components_**
![Screen Shot 2021-03-08 at 9 43 19 AM](https://user-images.githubusercontent.com/32574227/110338302-d78caa80-7ff4-11eb-91aa-9dfcbcc48b27.png)
**Full Width**
![Screen Shot 2021-03-08 at 9 44 56 AM](https://user-images.githubusercontent.com/32574227/110338301-d78caa80-7ff4-11eb-893f-cf4251fb21f3.png)
![Screen Shot 2021-03-08 at 9 57 39 AM](https://user-images.githubusercontent.com/32574227/110338300-d78caa80-7ff4-11eb-8fea-02b0b90387f1.png)
