### PR TITLE
WELL-706 - Fix GroupHeading rendering

### DIFF
--- a/src/components/Select/GroupHeading.test.tsx
+++ b/src/components/Select/GroupHeading.test.tsx
@@ -1,13 +1,20 @@
 import * as React from 'react';
 import { renderWithTheme } from '../../testUtils/renderWithTheme';
-import { GroupHeading } from './index';
+import { GroupHeading, GroupHeadingProps } from './index';
 
 const testId = 'GroupHeading';
 
+const getBaseProps = (): GroupHeadingProps => ({
+  ['data-select-role']: 'heading',
+});
+
 test('it renders a GroupHeading', async () => {
+  const props = getBaseProps();
   const text = 'a heading';
   const { findByTestId } = renderWithTheme(
-    <GroupHeading data-testid={testId}>{text}</GroupHeading>
+    <GroupHeading {...props} data-testid={testId}>
+      {text}
+    </GroupHeading>
   );
 
   const heading = await findByTestId(testId);
@@ -16,8 +23,9 @@ test('it renders a GroupHeading', async () => {
 });
 
 test('it applies the provided className', async () => {
+  const props = getBaseProps();
   const { findByTestId } = renderWithTheme(
-    <GroupHeading data-testid={testId} className="custom-class-name">
+    <GroupHeading {...props} data-testid={testId} className="custom-class-name">
       Heading
     </GroupHeading>
   );

--- a/src/components/Select/GroupHeading.tsx
+++ b/src/components/Select/GroupHeading.tsx
@@ -28,11 +28,13 @@ export type GroupHeadingClasses = GetClasses<typeof useStyles>;
 
 export interface GroupHeadingProps {
   className?: string;
+  ['data-select-role']: 'heading';
 }
 
 export const GroupHeading: React.FC<GroupHeadingProps> = ({
   children,
   className,
+  ['data-select-role']: dataSelectRole,
   ...rootProps
 }) => {
   const classes = useStyles({});

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -148,7 +148,9 @@ test('it renders the provided group headings', async () => {
   const props = getBaseProps();
   const { findByTestId, findByRole } = renderWithTheme(
     <Select {...props} data-testid={testId}>
-      <GroupHeading data-testid={headingId}>Group 1</GroupHeading>
+      <GroupHeading data-select-role="heading" data-testid={headingId}>
+        Group 1
+      </GroupHeading>
       <SelectOption title="option1" value="option1" />
     </Select>
   );
@@ -180,7 +182,9 @@ test('it *does not* render the group headings if select not clicked', async () =
   const props = getBaseProps();
   const { queryByTestId } = renderWithTheme(
     <Select {...props}>
-      <GroupHeading data-testid={headingId}>Group 1</GroupHeading>
+      <GroupHeading data-select-role="heading" data-testid={headingId}>
+        Group 1
+      </GroupHeading>
       <SelectOption title="option1" value="option1" />
     </Select>
   );
@@ -283,9 +287,9 @@ test('it can be operated using only the keyboard with headings', async () => {
 
   const { findByTestId, findAllByRole } = renderWithTheme(
     <Select {...props} onChange={mockFn} data-testid={testId}>
-      <GroupHeading>Group 1</GroupHeading>
+      <GroupHeading data-select-role="heading">Group 1</GroupHeading>
       <SelectOption title="option1" value="option1" />
-      <GroupHeading>Group 2</GroupHeading>
+      <GroupHeading data-select-role="heading">Group 2</GroupHeading>
       <SelectOption title="option2" value="option2" />
     </Select>
   );

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -22,7 +22,6 @@ import { generateUniqueId } from '../_private/UniqueId';
 import { Text } from '../Text';
 import { SelectOptionProps } from './SelectOption';
 import { motion, useReducedMotion } from 'framer-motion';
-import { GroupHeading } from './GroupHeading';
 import { RoverOption } from './RoverOption';
 import { useRoverState } from 'reakit/Rover';
 import { getTestProps } from '../../testUtils/getTestProps';
@@ -285,6 +284,10 @@ const listItemMotionVariantsReduced = {
 
 export type SelectClasses = GetClasses<typeof useStyles>;
 
+const isHeadingElement = (element: React.ReactElement) => {
+  return element.props['data-select-role'] === 'heading';
+};
+
 export interface SelectProps
   extends Pick<
       BaseFormElement,
@@ -371,7 +374,7 @@ export const Select: React.FC<SelectProps> = ({
         return null;
       }
 
-      if (child.type === GroupHeading) {
+      if (isHeadingElement(child)) {
         return null;
       }
 
@@ -531,7 +534,7 @@ export const Select: React.FC<SelectProps> = ({
                     return null;
                   }
 
-                  if (child.type === GroupHeading) {
+                  if (isHeadingElement(child)) {
                     return child;
                   }
 

--- a/stories/components/Select/Select.stories.tsx
+++ b/stories/components/Select/Select.stories.tsx
@@ -136,10 +136,10 @@ const SelectStory: React.FC = () => {
             value={selectValue}
             onChange={(v: string) => setSelectValue(v)}
           >
-            <GroupHeading>Group 1</GroupHeading>
+            <GroupHeading data-select-role="heading">Group 1</GroupHeading>
             <SelectOption title="Option 1" value="option 1" />
             <SelectOption title="Option 2" value="option 2" />
-            <GroupHeading>Group 2</GroupHeading>
+            <GroupHeading data-select-role="heading">Group 2</GroupHeading>
             <SelectOption title="Option 3" value="option 3" />
             <SelectOption title="Option 4" value="option 4" />
           </Select>
@@ -259,10 +259,10 @@ const SelectStory: React.FC = () => {
             value={selectValue}
             onChange={(v: string) => setSelectValue(v)}
           >
-            <GroupHeading>Group 1</GroupHeading>
+            <GroupHeading data-select-role="heading">Group 1</GroupHeading>
             <SelectOption title="Option 1" value="option 1" />
             <SelectOption title="Option 2" value="option 2" />
-            <GroupHeading>Group 2</GroupHeading>
+            <GroupHeading data-select-role="heading">Group 2</GroupHeading>
             <SelectOption title="Option 3" value="option 3" />
             <SelectOption title="Option 4" value="option 4" />
           </Select>
@@ -394,10 +394,10 @@ const SelectStory: React.FC = () => {
             onChange={(v: string) => setSelectValue(v)}
             color="inverse"
           >
-            <GroupHeading>Group 1</GroupHeading>
+            <GroupHeading data-select-role="heading">Group 1</GroupHeading>
             <SelectOption title="Option 1" value="option 1" />
             <SelectOption title="Option 2" value="option 2" />
-            <GroupHeading>Group 2</GroupHeading>
+            <GroupHeading data-select-role="heading">Group 2</GroupHeading>
             <SelectOption title="Option 3" value="option 3" />
             <SelectOption title="Option 4" value="option 4" />
           </Select>
@@ -529,10 +529,10 @@ const SelectStory: React.FC = () => {
             onChange={(v: string) => setSelectValue(v)}
             color="inverse"
           >
-            <GroupHeading>Group 1</GroupHeading>
+            <GroupHeading data-select-role="heading">Group 1</GroupHeading>
             <SelectOption title="Option 1" value="option 1" />
             <SelectOption title="Option 2" value="option 2" />
-            <GroupHeading>Group 2</GroupHeading>
+            <GroupHeading data-select-role="heading">Group 2</GroupHeading>
             <SelectOption title="Option 3" value="option 3" />
             <SelectOption title="Option 4" value="option 4" />
           </Select>

--- a/stories/components/Select/groupHeading.md
+++ b/stories/components/Select/groupHeading.md
@@ -23,10 +23,10 @@ import {
   value={selectValue}
   onChange={(v: string) => setSelectValue(v)}
 >
-  <GroupHeading>Group 1</GroupHeading>
+  <GroupHeading data-select-role="heading">Group 1</GroupHeading>
   <SelectOption title="Option 1" value="option 1" />
   <SelectOption title="Option 2" subtitle="subtitle" value="option 2" />
-  <GroupHeading>Group 2</GroupHeading>
+  <GroupHeading data-select-role="heading">Group 2</GroupHeading>
   <SelectOption title="Option 3" value="option 3" />
   <SelectOption title="Option 4" value="option 4" />
 </Select>
@@ -37,8 +37,14 @@ import {
 A class name can be provided.
 
 ```jsx
-<GroupHeading className="mr-4">Group 1</GroupHeading>
+<GroupHeading className="mr-4" data-select-role="heading">
+  Group 1
+</GroupHeading>
 ```
+
+### Select Role
+
+Required. This provides a hint to the `<Select>` parent for how to handle rendering. Currently `heading` is the only valid value.
 
 ## Links
 


### PR DESCRIPTION
The built code loses the `type` attribute information. Using a
data-* attribute is preserved across the build.