### PR TITLE
a11y Checkbox

### DIFF
--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -155,13 +155,13 @@ const tickVariants = {
 const disabledDefaultTickVariants = {
   checked: {
     stroke: 'var(--tick-disabled)',
-    strokeOpacity: 0.35,
+    strokeOpacity: 0.65,
     pathLength: 1,
   },
   unchecked: {
     pathLength: 0,
     stroke: 'var(--tick-disabled)',
-    strokeOpacity: 0.35,
+    strokeOpacity: 0.65,
   },
 };
 
@@ -169,12 +169,12 @@ const disabledInverseTickVariants = {
   checked: {
     pathLength: 1,
     stroke: 'var(--tick-primary)',
-    strokeOpacity: 0.35,
+    strokeOpacity: 0.65,
   },
   unchecked: {
     pathLength: 0,
     stroke: 'var(--tick-primary)',
-    strokeOpacity: 0.35,
+    strokeOpacity: 0.65,
   },
 };
 
@@ -193,12 +193,12 @@ const indeterminateDisabledTickVariants = {
   checked: {
     pathLength: 1,
     stroke: 'var(--tick-disabled)',
-    strokeOpacity: 0.35,
+    strokeOpacity: 0.65,
   },
   unchecked: {
     pathLength: 0,
     stroke: 'var(--tick-disabled)',
-    strokeOpacity: 0.35,
+    strokeOpacity: 0.65,
   },
 };
 

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -23,8 +23,8 @@ export const useStyles = makeStyles(
     root: {
       // All values that are animated to/from need to be specified as css variables for the
       // framer-motion library to handle the animations correctly (no mix of hex/rgb + variables)
-      '--checkbox-primary': theme.palette.primary[600],
-      '--checkbox-emphasis': theme.palette.primary[800],
+      '--checkbox-primary': theme.palette.primary.main,
+      '--checkbox-emphasis': theme.palette.primary[900],
       '--checkbox-secondary': theme.palette.graphite[100],
       '--checkbox-secondary-emphasis': theme.palette.graphite[900],
       '--checkbox-error': theme.palette.error[900],

--- a/stories/components/Checkbox/Checkbox.stories.tsx
+++ b/stories/components/Checkbox/Checkbox.stories.tsx
@@ -185,7 +185,7 @@ const CheckboxStory: React.FC = () => {
 
       <Container
         containerStyles={{
-          background: '#0096e1',
+          background: '#006eb7',
           flex: 1,
           flexFlow: 'column',
           padding: 0,


### PR DESCRIPTION
Add contrast to checkbox-primary, checkbox-emphasis and tick mark stroke

NOTE: Top-left checkbox is hover state

BEFORE | AFTER
-- | --
<img width="1029" alt="Screen Shot 2021-03-15 at 4 28 12 PM" src="https://user-images.githubusercontent.com/485903/111217076-86a82380-85ab-11eb-9719-00730deee8e6.png"> | <img width="1029" alt="Screen Shot 2021-03-15 at 4 27 32 PM" src="https://user-images.githubusercontent.com/485903/111217074-860f8d00-85ab-11eb-8b65-513b0a465c41.png">



