### PR TITLE
a11y Radio group minimal color contrast and story updates

### DIFF
--- a/src/components/Radio/RadioGroupMinimal.tsx
+++ b/src/components/Radio/RadioGroupMinimal.tsx
@@ -122,6 +122,7 @@ export const useStyles = makeStyles(
     },
     directionRow: {
       flexDirection: 'row',
+      justifyContent: 'space-between',
       '& label': {
         whiteSpace: 'nowrap',
       },

--- a/src/components/Radio/RadioGroupMinimal.tsx
+++ b/src/components/Radio/RadioGroupMinimal.tsx
@@ -97,7 +97,7 @@ export const useStyles = makeStyles(
       },
     },
     radiosInverse: {
-      background: 'rgba(230, 231, 237, 0.25)',
+      background: 'rgba(230, 231, 237, 0.1125)',
       '& input:checked + div': {
         '&::before': {
           background: 'rgba(255, 255, 255, 0.5)',

--- a/src/components/Radio/RadioGroupMinimal.tsx
+++ b/src/components/Radio/RadioGroupMinimal.tsx
@@ -74,7 +74,7 @@ export const useStyles = makeStyles(
             transform: 'scale3d(1, 1, 1)',
             transition: '0.2s cubic-bezier(0.34, 1.56, 0.64, 1)',
             transitionProperty: 'transform, opacity',
-            background: theme.palette.primary[700],
+            background: theme.palette.primary.main,
           },
           '& label > p': {
             color: theme.palette.common.white,

--- a/src/components/Radio/RadioGroupMinimal.tsx
+++ b/src/components/Radio/RadioGroupMinimal.tsx
@@ -23,7 +23,17 @@ export const useStyles = makeStyles(
       width: '100%',
     },
     legend: {
-      display: 'none',
+      color: theme.palette.black[800],
+      fontSize: theme.pxToRem(14),
+      fontWeight: theme.typography.fontWeightBold,
+      marginBottom: theme.spacing(1.5),
+      padding: 0,
+      '&:empty': {
+        marginBottom: theme.spacing(0),
+      },
+    },
+    legendInverse: {
+      color: theme.palette.common.white,
     },
     radios: {
       background: 'rgba(132, 137, 166, 0.15)',
@@ -186,7 +196,15 @@ export const RadioGroupMinimal: React.FC<RadioGroupMinimalProps> = ({
         role="radiogroup"
         {...rootProps}
       >
-        <legend className={clsx(!title && ariaLabel && classes.srOnly)}>
+        <legend
+          className={clsx(
+            classes.legend,
+            {
+              [classes.legendInverse]: color === 'inverse',
+            },
+            !title && ariaLabel && classes.srOnly
+          )}
+        >
           {title || ariaLabel}
         </legend>
         <div

--- a/stories/components/Radio/Radio.stories.tsx
+++ b/stories/components/Radio/Radio.stories.tsx
@@ -103,17 +103,17 @@ const RadioStory: React.FC = () => {
           <RadioGroup
             aria-label="RadioGroup with no title"
             title=""
-            name="chroma1"
-            value="opt2"
+            name="chroma2"
+            value="opt5"
             onChange={handleChange}
             {...getPropOptions()}
           >
-            <Radio value="opt1" label="Option 1" />
-            <Radio value="opt2" label="Option 2" />
-            <Radio value="opt3" disabled label="Disabled (not selectable)" />
+            <Radio value="opt5" label="Option 5" />
+            <Radio value="opt6" label="Option 6" />
+            <Radio value="opt7" disabled label="Disabled (not selectable)" />
             <Radio
-              value="opt4"
-              label="Option 4"
+              value="opt8"
+              label="Option 8"
               helpMessage="This is some helper text."
             />
           </RadioGroup>
@@ -131,23 +131,21 @@ const RadioStory: React.FC = () => {
         <FormBox padding={2}>
           <RadioGroup
             title="Select an option"
-            name="chroma2"
-            value="opt1"
+            name="chroma3"
+            value="opt9"
             onChange={handleChange}
             {...getPropOptions()}
           >
-            <Radio name="chroma2" value="opt1" label="Option 1" />
-            <Radio name="chroma2" value="opt2" label="Option 2" />
+            <Radio value="opt9" label="Option 9" />
+            <Radio value="opt10" label="Option 10" />
             <Radio
-              name="chroma2"
-              value="opt3"
+              value="opt11"
               disabled
               label="Disabled (not selectable)"
             />
             <Radio
-              name="chroma2"
-              value="opt4"
-              label="Option 4"
+              value="opt12"
+              label="Option 12"
               helpMessage="This is some helper text."
             />
           </RadioGroup>
@@ -157,17 +155,17 @@ const RadioStory: React.FC = () => {
           <RadioGroup
             aria-label="RadioGroup with no title"
             title=""
-            name="chroma1"
-            value="opt2"
+            name="chroma4"
+            value="opt13"
             onChange={handleChange}
             {...getPropOptions()}
           >
-            <Radio value="opt1" label="Option 1" />
-            <Radio value="opt2" label="Option 2" />
-            <Radio value="opt3" disabled label="Disabled (not selectable)" />
+            <Radio value="opt13" label="Option 13" />
+            <Radio value="opt14" label="Option 14" />
+            <Radio value="opt15" disabled label="Disabled (not selectable)" />
             <Radio
-              value="opt4"
-              label="Option 4"
+              value="opt16"
+              label="Option 16"
               helpMessage="This is some helper text."
             />
           </RadioGroup>
@@ -186,23 +184,23 @@ const RadioStory: React.FC = () => {
           <RadioGroup
             title="Select an option"
             color="inverse"
-            name="chroma3"
-            value="opt1"
+            name="chroma5"
+            value="opt17"
             onChange={handleChange}
             {...getPropOptions()}
           >
-            <Radio name="chroma3" value="opt1" label="Option 1" />
-            <Radio name="chroma3" value="opt2" label="Option 2" />
+            <Radio value="opt17" label="Option 17" />
+            <Radio value="opt18" label="Option 18" />
             <Radio
-              name="chroma3"
-              value="opt3"
+            
+              value="opt19"
               disabled
               label="Disabled (not selectable)"
             />
             <Radio
-              name="chroma3"
-              value="opt4"
-              label="Option 4"
+            
+              value="opt20"
+              label="Option 20"
               helpMessage="This is some helper text."
             />
           </RadioGroup>
@@ -212,18 +210,18 @@ const RadioStory: React.FC = () => {
           <RadioGroup
             aria-label="RadioGroup with no title"
             title=""
-            name="chroma1"
-            value="opt2"
+            name="chroma6"
+            value="opt21"
             onChange={handleChange}
             color="inverse"
             {...getPropOptions()}
           >
-            <Radio value="opt1" label="Option 1" />
-            <Radio value="opt2" label="Option 2" />
-            <Radio value="opt3" disabled label="Disabled (not selectable)" />
+            <Radio value="opt21" label="Option 21" />
+            <Radio value="opt22" label="Option 22" />
+            <Radio value="opt23" disabled label="Disabled (not selectable)" />
             <Radio
-              value="opt4"
-              label="Option 4"
+              value="opt24"
+              label="Option 24"
               helpMessage="This is some helper text."
             />
           </RadioGroup>
@@ -242,23 +240,22 @@ const RadioStory: React.FC = () => {
           <RadioGroup
             title="Select an option"
             color="inverse"
-            name="chroma4"
-            value="opt4"
+            name="chroma7"
+            value="opt25"
             onChange={handleChange}
             {...getPropOptions()}
           >
-            <Radio name="chroma4" value="opt1" label="Option 1" />
-            <Radio name="chroma4" value="opt2" label="Option 2" />
+            <Radio value="opt25" label="Option 25" />
+            <Radio value="opt26" label="Option 26" />
             <Radio
-              name="chroma4"
-              value="opt3"
+            
+              value="opt27"
               disabled
               label="Disabled (not selectable)"
             />
             <Radio
-              name="chroma4"
-              value="opt4"
-              label="Option 4"
+              value="opt28"
+              label="Option 28"
               helpMessage="This is some helper text."
             />
           </RadioGroup>
@@ -268,18 +265,18 @@ const RadioStory: React.FC = () => {
           <RadioGroup
             aria-label="RadioGroup with no title"
             title=""
-            name="chroma1"
-            value="opt2"
+            name="chroma8"
+            value="opt29"
             onChange={handleChange}
             color="inverse"
             {...getPropOptions()}
           >
-            <Radio value="opt1" label="Option 1" />
-            <Radio value="opt2" label="Option 2" />
-            <Radio value="opt3" disabled label="Disabled (not selectable)" />
+            <Radio value="opt29" label="Option 29" />
+            <Radio value="opt30" label="Option 30" />
+            <Radio value="opt31" disabled label="Disabled (not selectable)" />
             <Radio
-              value="opt4"
-              label="Option 4"
+              value="opt32"
+              label="Option 32"
               helpMessage="This is some helper text."
             />
           </RadioGroup>

--- a/stories/components/Radio/Radio.stories.tsx
+++ b/stories/components/Radio/Radio.stories.tsx
@@ -81,7 +81,7 @@ const RadioStory: React.FC = () => {
       >
         <FormBox padding={2}>
           <RadioGroup
-            title=""
+            title="Select an option"
             aria-label="Select an option"
             name="chroma1"
             value="opt2"

--- a/stories/components/Radio/Radio.stories.tsx
+++ b/stories/components/Radio/Radio.stories.tsx
@@ -98,7 +98,7 @@ const RadioStory: React.FC = () => {
             />
           </RadioGroup>
 
-          <Divider />
+          <Divider style={{ marginBottom: '1.5rem' }} />
 
           <RadioGroup
             aria-label="RadioGroup with no title"
@@ -152,7 +152,7 @@ const RadioStory: React.FC = () => {
             />
           </RadioGroup>
 
-          <Divider />
+          <Divider style={{ marginBottom: '1.5rem' }} />
 
           <RadioGroup
             aria-label="RadioGroup with no title"
@@ -207,7 +207,7 @@ const RadioStory: React.FC = () => {
             />
           </RadioGroup>
 
-          <Divider />
+          <Divider style={{ marginBottom: '1.5rem' }} />
 
           <RadioGroup
             aria-label="RadioGroup with no title"
@@ -263,7 +263,7 @@ const RadioStory: React.FC = () => {
             />
           </RadioGroup>
 
-          <Divider />
+          <Divider style={{ marginBottom: '1.5rem' }} />
 
           <RadioGroup
             aria-label="RadioGroup with no title"
@@ -310,6 +310,7 @@ const RadioMinimalStory: React.FC = () => {
         <FormBox padding={2}>
           <RadioGroupMinimal
             title="Select an option"
+            aria-label="Select an option"
             name="chroma1"
             value="opt2"
             onChange={handleChange}
@@ -319,6 +320,22 @@ const RadioMinimalStory: React.FC = () => {
             <Radio value="opt2" label="Option 2" />
             <Radio value="opt3" label="Option 3" />
           </RadioGroupMinimal>
+
+          <Divider style={{ marginBottom: '1.5rem' }} />
+
+          <RadioGroupMinimal
+            aria-label="RadioGroup with no title"
+            title=""
+            name="chroma2"
+            value="opt5"
+            onChange={handleChange}
+            {...getMinimalPropOptions()}
+          >
+            <Radio value="opt4" label="Option 4" />
+            <Radio value="opt5" label="Option 5" />
+            <Radio value="opt6" label="Option 6" />
+          </RadioGroupMinimal>
+
         </FormBox>
       </Container>
 
@@ -331,15 +348,31 @@ const RadioMinimalStory: React.FC = () => {
       >
         <FormBox padding={2}>
           <RadioGroupMinimal
+            aria-label="Select an option"
             title="Select an option"
-            name="chroma2"
-            value="opt1"
+            name="chroma3"
+            value="opt7"
             onChange={handleChange}
             {...getMinimalPropOptions()}
-          >
-            <Radio name="chroma2" value="opt1" label="Option 1" />
-            <Radio name="chroma2" value="opt2" label="Option 2" />
-            <Radio name="chroma2" value="opt3" label="Option 3" />
+            >
+            <Radio value="opt7" label="Option 7" />
+            <Radio value="opt8" label="Option 8" />
+            <Radio value="opt9" label="Option 9" />
+          </RadioGroupMinimal>
+
+          <Divider style={{ marginBottom: '1.5rem' }} />
+  
+          <RadioGroupMinimal
+            aria-label="RadioGroup with no title"
+            title=""
+            name="chroma4"
+            value="opt10"
+            onChange={handleChange}
+            {...getMinimalPropOptions()}
+            >
+            <Radio value="opt10" label="Option 10" />
+            <Radio value="opt11" label="Option 11" />
+            <Radio value="opt12" label="Option 12" />
           </RadioGroupMinimal>
         </FormBox>
       </Container>
@@ -350,19 +383,36 @@ const RadioMinimalStory: React.FC = () => {
           flexFlow: 'column',
           padding: 0,
         }}
-      >
+        >
         <FormBox padding={2}>
           <RadioGroupMinimal
+            aria-label="Select an option"
             title="Select an option"
             color="inverse"
-            name="chroma3"
-            value="opt1"
+            name="chroma5"
+            value="opt13"
             onChange={handleChange}
             {...getMinimalPropOptions()}
-          >
-            <Radio name="chroma3" value="opt1" label="Option 1" />
-            <Radio name="chroma3" value="opt2" label="Option 2" />
-            <Radio name="chroma3" value="opt3" label="Option 3" />
+            >
+            <Radio value="opt13" label="Option 13" />
+            <Radio value="opt14" label="Option 14" />
+            <Radio value="opt15" label="Option 15" />
+          </RadioGroupMinimal>
+
+          <Divider style={{ marginBottom: '1.5rem' }} />
+
+          <RadioGroupMinimal
+            aria-label="RadioGroup with no title"
+            title=""
+            color="inverse"
+            name="chroma6"
+            value="opt16"
+            onChange={handleChange}
+            {...getMinimalPropOptions()}
+            >
+            <Radio value="opt16" label="Option 16" />
+            <Radio value="opt17" label="Option 17" />
+            <Radio value="opt18" label="Option 18" />
           </RadioGroupMinimal>
         </FormBox>
       </Container>
@@ -373,19 +423,36 @@ const RadioMinimalStory: React.FC = () => {
           flexFlow: 'column',
           padding: 0,
         }}
-      >
+        >
         <FormBox padding={2}>
           <RadioGroupMinimal
+            aria-label="Select an option"
             title="Select an option"
             color="inverse"
-            name="chroma4"
-            value="opt1"
+            name="chroma7"
+            value="opt19"
             onChange={handleChange}
             {...getMinimalPropOptions()}
           >
-            <Radio name="chroma4" value="opt1" label="Option 1" />
-            <Radio name="chroma4" value="opt2" label="Option 2" />
-            <Radio name="chroma4" value="opt3" label="Option 3" />
+            <Radio value="opt19" label="Option 19" />
+            <Radio value="opt20" label="Option 20" />
+            <Radio value="opt21" label="Option 21" />
+          </RadioGroupMinimal>
+
+          <Divider style={{ marginBottom: '1.5rem' }} />
+
+          <RadioGroupMinimal
+            aria-label="RadioGroup with no title"
+            title=""
+            color="inverse"
+            name="chroma8"
+            value="opt22"
+            onChange={handleChange}
+            {...getMinimalPropOptions()}
+          >
+            <Radio value="opt22" label="Option 22" />
+            <Radio value="opt23" label="Option 23" />
+            <Radio value="opt24" label="Option 24" />
           </RadioGroupMinimal>
         </FormBox>
       </Container>

--- a/stories/components/Radio/Radio.stories.tsx
+++ b/stories/components/Radio/Radio.stories.tsx
@@ -176,7 +176,7 @@ const RadioStory: React.FC = () => {
 
       <Container
         containerStyles={{
-          background: '#0096e1',
+          background: '#006eb7',
           flex: 1,
           flexFlow: 'column',
           padding: 0,
@@ -346,7 +346,7 @@ const RadioMinimalStory: React.FC = () => {
 
       <Container
         containerStyles={{
-          background: '#0096e1',
+          background: '#006eb7',
           flexFlow: 'column',
           padding: 0,
         }}


### PR DESCRIPTION
- Improve color contrast for Radio Group Minimal
- Fix broken demo in Radio Group and Radio Group Minimal stories
- Make Radio Group Minimal legend behavior and style match Radio Group legend (support inverse legend)


BEFORE | AFTER | &nbsp;
-- | -- | --
<img width="888" alt="Screen Shot 2021-03-16 at 2 58 18 PM" src="https://user-images.githubusercontent.com/485903/111364893-3216ae00-8668-11eb-99c4-2888d4de34eb.png"> | <img width="888" alt="Screen Shot 2021-03-16 at 2 58 27 PM" src="https://user-images.githubusercontent.com/485903/111364897-32af4480-8668-11eb-81ef-9c5272037543.png"> | Radio Group
<img width="1182" alt="Screen Shot 2021-03-16 at 2 46 25 PM" src="https://user-images.githubusercontent.com/485903/111363701-b831f500-8666-11eb-8f10-efd51adf4290.png"> | <img width="1256" alt="Screen Shot 2021-03-16 at 2 46 39 PM" src="https://user-images.githubusercontent.com/485903/111363703-b831f500-8666-11eb-9ddc-350361230650.png"> | Radio Group Minimal Row; add demo for no title/legend
<img width="533" alt="Screen Shot 2021-03-16 at 2 47 20 PM" src="https://user-images.githubusercontent.com/485903/111363705-b8ca8b80-8666-11eb-85f9-90c01f30891c.png"> | <img width="529" alt="Screen Shot 2021-03-16 at 2 47 30 PM" src="https://user-images.githubusercontent.com/485903/111363708-b8ca8b80-8666-11eb-94b3-e89b0eac859c.png"> | Radio Group Minimal Column; add demo for no title/legend
