### PR TITLE
Toggle contrast

### DIFF
--- a/src/components/Toggle/Toggle.tsx
+++ b/src/components/Toggle/Toggle.tsx
@@ -83,12 +83,12 @@ export const useStyles = makeStyles(
       },
     },
     inputInverse: {
-      background: 'rgba(230, 231, 237, 0.25)',
+      backgroundColor: 'rgba(230, 231, 237, 0.1)',
       border: '1px solid rgba(255, 255, 255, 0.2)',
       mixBlendMode: 'hard-light',
       '&:checked': {
-        background: theme.palette.secondary.main,
-        border: `1px solid ${theme.palette.secondary.main}`,
+        background: theme.palette.secondary[500],
+        border: `1px solid ${theme.palette.secondary[500]}`,
       },
       '&:focus': {
         boxShadow: '0 0 0 2px rgba(255, 255, 255, .3)',


### PR DESCRIPTION
No a11y checks were failing here but styles need to be consistent with other form components.

BEFORE | AFTER
-- | --
<img width="1178" alt="Screen Shot 2021-03-18 at 9 11 46 AM" src="https://user-images.githubusercontent.com/485903/111631753-26db9380-87ca-11eb-8594-64f8979c16b2.png"> | <img width="1178" alt="Screen Shot 2021-03-18 at 9 08 16 AM" src="https://user-images.githubusercontent.com/485903/111631751-2642fd00-87ca-11eb-834b-94e9c1a07290.png">

