### PR TITLE
fix: ButtonFilePicker cursor dead area

### DIFF
--- a/src/components/ButtonFilePicker/ButtonFilePicker.tsx
+++ b/src/components/ButtonFilePicker/ButtonFilePicker.tsx
@@ -157,6 +157,9 @@ export const useStyles = makeStyles(
       height: '100%',
       width: '100%',
       cursor: 'pointer',
+      '&::-webkit-file-upload-button:hover': {
+        cursor: 'pointer',
+      },
     },
     disabled: {
       cursor: 'not-allowed',


### PR DESCRIPTION
### Changes

- Fix ButtonFilePicker dead cursor area
  - https://developer.mozilla.org/en-US/docs/Web/CSS/::file-selector-button

### OLD

https://user-images.githubusercontent.com/8069555/111808705-a2ad0d00-88aa-11eb-8793-0f32176aa95c.mov

### NEW

https://user-images.githubusercontent.com/8069555/111808739-ab9dde80-88aa-11eb-96c1-9256fa5e12aa.mov

