### PR TITLE
Align first and last column table headers

### DIFF
--- a/src/components/TableModule/TableHeaderCell.tsx
+++ b/src/components/TableModule/TableHeaderCell.tsx
@@ -37,10 +37,10 @@ export const useStyles = makeStyles(
         borderBottom: `4px solid ${theme.palette.primary.main}`,
       },
       // First and last headers have additional spacing intentionally
-      '&:first-of-type': {
+      '&:first-child': {
         paddingLeft: theme.spacing(4),
       },
-      '&:last-of-type': {
+      '&:last-child': {
         paddingRight: theme.spacing(4),
       },
     },


### PR DESCRIPTION
This bug revealed itself when we went to `td` for empty table header cells instead of `th` for a11y reasons.

BEFORE | AFTER
-- | --
The last (far-right) columns' table headers have extra right padding  ![screencapture-localhost-9001-iframe-html-2021-03-31-10_32_27](https://user-images.githubusercontent.com/485903/113162145-06212e00-920d-11eb-839d-ff1fc80a6da1.png) | ![screencapture-localhost-9001-iframe-html-2021-03-31-10_31_00](https://user-images.githubusercontent.com/485903/113162143-04f00100-920d-11eb-9dfe-7e4517a8065f.png)
