### PR TITLE
Soften gradient of highlight pill

### DIFF
--- a/src/components/Pill/Pill.tsx
+++ b/src/components/Pill/Pill.tsx
@@ -25,7 +25,7 @@ export const useStyles = makeStyles(
       background: theme.palette.primary.main,
     },
     highlight: {
-      background: `linear-gradient(135deg, ${theme.palette.primary.light} 0%, ${theme.palette.primary.main} 22%, rgb(166, 66, 254) 92%)`,
+      background: `linear-gradient(135deg, ${theme.palette.primary.light} 0%, ${theme.palette.primary.main} 40%, rgb(166, 66, 254) 92%)`,
       boxShadow: theme.boxShadows.table,
       borderRadius: theme.spacing(0.25, 1),
       borderBottom: 'solid 1px rgba(0, 83, 154, 0.75)',


### PR DESCRIPTION
Gradient seems a bit too harsh after `primary.main` color shift. Softening the highlight effect in this PR.

BEFORE | AFTER
-- | --
<img width="104" alt="Screen Shot 2021-03-31 at 11 23 26 AM" src="https://user-images.githubusercontent.com/485903/113169857-ff49e980-9213-11eb-8e8e-37e59738eeb5.png"> | <img width="104" alt="Screen Shot 2021-03-31 at 11 22 28 AM" src="https://user-images.githubusercontent.com/485903/113169852-feb15300-9213-11eb-9e0c-8653859b0d83.png">

