### PR TITLE
Change green on DotLoader

### DIFF
--- a/src/components/DotLoader/DotLoader.tsx
+++ b/src/components/DotLoader/DotLoader.tsx
@@ -45,7 +45,7 @@ export const useStyles = makeStyles(
     },
     bounce4: {
       animation: '$bounce 1s 0.6s infinite',
-      fill: theme.palette.green.main,
+      fill: theme.palette.green.light,
     },
   }),
   { name: DotLoaderStylesKey }


### PR DESCRIPTION
Changing green here to get it closer to the original green used before `palette.green` shift

BEFORE | AFTER
-- | --
<img width="102" alt="Screen Shot 2021-03-31 at 11 41 41 AM" src="https://user-images.githubusercontent.com/485903/113172357-5cdf3580-9216-11eb-9342-6561c322b311.png"> | <img width="102" alt="Screen Shot 2021-03-31 at 11 41 15 AM" src="https://user-images.githubusercontent.com/485903/113172355-5c469f00-9216-11eb-9110-8aeb2061e2e3.png">

