### PR TITLE
WELL-933 - Don't hide modal actions

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -46,6 +46,8 @@ export const useStyles = makeStyles(
     content: {
       background: theme.palette.common.white,
       borderRadius: theme.pxToRem(10),
+      display: 'flex',
+      flexDirection: 'column',
       margin: '10vh auto',
       outline: 'none',
       paddingTop: theme.spacing(0.25),


### PR DESCRIPTION
With the addition of `overflow: 'hidden'` the modal actions can
be clipped on small screens.