### PR TITLE
LR-217 Modal content size updates (Slight API change)

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -48,12 +48,11 @@ export const useStyles = makeStyles(
       borderRadius: theme.pxToRem(10),
       display: 'flex',
       flexDirection: 'column',
-      margin: '10vh auto',
+      margin: 'auto',
       outline: 'none',
       paddingTop: theme.spacing(0.25),
       paddingBottom: theme.spacing(0.25),
       width: theme.pxToRem(384),
-      maxWidth: theme.pxToRem(600),
       overflow: 'hidden',
       '@media screen and (max-width: 480px)': {
         marginBottom: theme.spacing(0.75),
@@ -65,9 +64,11 @@ export const useStyles = makeStyles(
       },
     },
     contentFullWidth: {
-      width: 'calc(100% - 6rem)',
+      width: 'unset',
+      minWidth: theme.pxToRem(600),
+      maxWidth: 'calc(100vw - 6rem)',
       '@media screen and (max-width: 480px)': {
-        width: 'unset',
+        maxWidth: 'unset',
       },
     },
     contentSize0: {
@@ -78,6 +79,12 @@ export const useStyles = makeStyles(
     },
     contentSize1: {
       maxHeight: theme.pxToRem(480),
+      '@media screen and (max-width: 480px)': {
+        maxHeight: 'unset',
+      },
+    },
+    contentSize2: {
+      maxHeight: 'calc(100vh - 9rem)',
       '@media screen and (max-width: 480px)': {
         maxHeight: 'unset',
       },
@@ -182,7 +189,7 @@ export interface ModalProps
   disableDismissOnClickOutside?: boolean;
   onFormSubmit?: (data: any) => void;
   poses?: Variants;
-  size?: 0 | 1;
+  size?: 0 | 1 | 2;
   title?: string;
 }
 
@@ -354,6 +361,7 @@ const Content = React.forwardRef<HTMLDivElement, ModalProps>(
                 {
                   [classes.contentSize0]: size === 0,
                   [classes.contentSize1]: size === 1,
+                  [classes.contentSize2]: size === 2,
                 },
                 contentClassName
               )}

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -67,6 +67,12 @@ export const useStyles = makeStyles(
       width: 'unset',
       minWidth: theme.pxToRem(600),
       maxWidth: 'calc(100vw - 6rem)',
+      // Allow minWidth to dynamically shrink on smaller
+      // screens that are wider than 480px.
+      // 43.5rem is 37.5rem (600px) plus the margin of 6rem
+      '@media screen and (max-width: 43.5rem)': {
+        minWidth: 'calc(100vw - 6rem)',
+      },
       '@media screen and (max-width: 480px)': {
         maxWidth: 'unset',
       },

--- a/stories/components/Modal/Modal.stories.tsx
+++ b/stories/components/Modal/Modal.stories.tsx
@@ -1,7 +1,8 @@
-import { boolean, select, text } from '@storybook/addon-knobs';
+import { boolean, select, text, number } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 import * as React from 'react';
 import { Button } from '../../../src/components/Button';
+import { Box } from '../../../src/components/Box';
 import { Checkbox } from '../../../src/components/Checkbox';
 import { FormBox } from '../../../src/components/FormBox';
 import { Modal } from '../../../src/components/Modal';
@@ -25,8 +26,15 @@ const ModalStory: React.FC = () => {
       <Modal
         isOpen={isOpen}
         title={text('title', 'Dialog Example')}
-        fullWidth={boolean('is full width?', false)}
-        size={select('size', [0, 1], 0)}
+        fullWidth={boolean('fullWidth', false)}
+        size={
+          number('size', 0, {
+            range: false,
+            min: 0,
+            max: 2,
+            step: 1,
+          }) as any
+        }
         onDismiss={() => {
           console.log('closing...');
           setIsOpen(false);
@@ -35,10 +43,46 @@ const ModalStory: React.FC = () => {
           'disableDismissOnClickOutside',
           false
         )}
-      />
+      >
+        <Content />
+      </Modal>
     </Container>
   );
 };
+
+function Content() {
+  const [width, setWidth] = React.useState(32);
+  const [height, setHeight] = React.useState(16);
+
+  const setSize = (width: number, height: number) => {
+    setHeight(height);
+    setWidth(width);
+  };
+
+  return (
+    <div>
+      <Box
+        margin={0}
+        padding={2}
+        width={width}
+        height={height}
+        bgColor="blue.200"
+        style={{ display: 'box' }}
+      >
+        <Box direction="column">
+          <Box margin={1} width={18} justify="space-between">
+            <Button onClick={() => setSize(32, 16)}>Small</Button>
+            <Button onClick={() => setSize(256, 256)}>Large</Button>
+          </Box>
+          <Box margin={1} width={18} justify="space-between">
+            <Button onClick={() => setSize(width, height + 16)}>Taller</Button>
+            <Button onClick={() => setSize(width + 16, height)}>Wider</Button>
+          </Box>
+        </Box>
+      </Box>
+    </div>
+  );
+}
 
 const ActionsModalStory: React.FC = () => {
   const [isOpen, setIsOpen] = React.useState(false);
@@ -55,8 +99,15 @@ const ActionsModalStory: React.FC = () => {
       <Modal
         isOpen={isOpen}
         title={text('title', 'Actions Example')}
-        fullWidth={boolean('is full width?', false)}
-        size={select('size', [0, 1], 0)}
+        fullWidth={boolean('fullWidth', false)}
+        size={
+          number('size', 0, {
+            range: false,
+            min: 0,
+            max: 2,
+            step: 1,
+          }) as any
+        }
         onDismiss={() => {
           console.log('closing...');
           setIsOpen(false);
@@ -102,8 +153,15 @@ const FormModalStory: React.FC = () => {
       <Modal
         isOpen={isOpen}
         title={text('title', 'Actions Example')}
-        fullWidth={boolean('is full width?', false)}
-        size={select('size', [0, 1], 0)}
+        fullWidth={boolean('fullWidth', false)}
+        size={
+          number('size', 0, {
+            range: false,
+            min: 0,
+            max: 2,
+            step: 1,
+          }) as any
+        }
         onDismiss={() => {
           console.log('closing...');
           setIsOpen(false);


### PR DESCRIPTION


## Changes
- Add a `size={2}` option to allow vertical size increase of Modal up to screen size minus margin
- Update the `fullWidth` option to allow horizontal size increase of Modal up to screen size minus margin

## Purpose

PHC and other products have fairly complicated UI's that require more flexibility than two Modal sizes.  The existing solution is to use the full-screen option.  However, there are a couple reasons the full-screen option is not adequate for some use cases.

1. **Overkill.**  The largest non-full-screen option is still fairly small.  When a UI requires Modal only slightly larger than this, it must use the full-screen option.  The result can be a lot of extra whitespace and a suboptimal user experience.
2. **Loss of context.**  The full-screen Modal option isn't great for sub-tasks because it is more like navigating to a new page.  While editing the many options of a Survey question for example, there is no visual reminder of the main task because the whole screen is hidden.  This is compounded when you have a full-screen Modal opening another full-screen Modal.

 Currently the width and height of the Modal are controlled by the values of `fullWidth` and `size`.
 - `fullWidth={false}` causes the model `width` to be set to a hard `480px`
 - `fullWidth={true}` causes the model `width` to be set to a hard `600px`
 - `size={0}` causes the model `height` to be able to expand with the content up to `256px`
 - `size={1}` causes the model `height` to be able to expand with the content up to `480px`

Content larger than the above values becomes scrollable within the Modal. This is sometimes okay for vertical scrolling but horizontal scrolling is almost always suboptimal.

## BEFORE
https://user-images.githubusercontent.com/220893/114229770-489de580-9946-11eb-8288-7e7066c7fdff.mp4
 
## Non-breaking change

The first change this PR proposes is an additional `size` value of `2`.  When set to `size={2}` the `height` is allowed to expand with the content up to the size of the screen minus a significant margin of 3rem (48px) on the top and bottom.   This won't affect any existing apps.

## Breaking change

The second change is with `fullWidth={true}`.  Previously this produced a hard width of `600px`.  Now the `width` starts at a minimum of `600px`, but allows the content to expand the Modal up to the width of the screen minus a margin of 3rem (48px) on the left and right.

Technically a breaking change in the API, but in practice, I'm unaware of any use of the Modal that relies on horizontal scrolling of it's content.  As mentioned, a slightly wider Modal is almost always better than horizontal scrolling.

## Near full-screen

If required by the design, the PR allows for the creation of near full screen Modals that allow for a lot of UI real estate, yet retain a significant border of 48px, enough to provide a visual reminder of the main task a user is involved with.

## AFTER
https://user-images.githubusercontent.com/220893/114233353-265a9680-994b-11eb-8e45-9bc0a2c59b12.mp4


## Consistency

We don't want a Modal that only expands to whatever size it's content happens to be. This could produce an app with an handful of randomly sized Modals over time.  This PR attempts to keep existing defaults and several good presized options, while at the same time providing the ability create a new size.

When a specific design calls for a bunch of Modals opening at `400x750` to accommodate the UI, this makes that possible.  It is easy to limit the size of the content itself, allowing the Modal to constantly enclose itself around that content.

## PHC BEFORE:
https://user-images.githubusercontent.com/220893/114750526-131c4200-9d22-11eb-8183-4cf16e1526d5.mp4

## PHC AFTER
https://user-images.githubusercontent.com/220893/114750685-41018680-9d22-11eb-97ab-de59fa0ef1ea.mp4
