### PR TITLE
Flex modal form height

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -63,6 +63,11 @@ export const useStyles = makeStyles(
         maxWidth: '480px',
         width: 'unset',
       },
+      '& form': {
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+      }
     },
     contentFullWidth: {
       width: 'calc(100% - 6rem)',
@@ -98,6 +103,7 @@ export const useStyles = makeStyles(
       alignItems: 'center',
       borderBottom: `1px solid ${theme.palette.divider}`,
       display: 'flex',
+      height: theme.pxToRem(43),
       justifyContent: 'space-between',
       '&:only-child': {
         borderBottom: 'none',

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -103,7 +103,6 @@ export const useStyles = makeStyles(
       alignItems: 'center',
       borderBottom: `1px solid ${theme.palette.divider}`,
       display: 'flex',
-      height: theme.pxToRem(43),
       justifyContent: 'space-between',
       '&:only-child': {
         borderBottom: 'none',


### PR DESCRIPTION
Modal footer was being hidden on short viewports. This PR flexes modal form height.

&nbsp; | BEFORE | AFTER
-- | -- | --
Short desktop viewport | <img width="681" alt="01-Screen Shot 2021-04-27 at 12 00 07 PM" src="https://user-images.githubusercontent.com/485903/116274634-d8b69a00-a750-11eb-9ca6-f4697c2af771.png"> | <img width="681" alt="Screen Shot 2021-04-27 at 12 00 12 PM" src="https://user-images.githubusercontent.com/485903/116274641-d9e7c700-a750-11eb-8281-f6fe84ef7a4a.png">
Short mobile viewport | <img width="402" alt="Screen Shot 2021-04-27 at 12 03 13 PM" src="https://user-images.githubusercontent.com/485903/116274643-d9e7c700-a750-11eb-8e6a-1c18034ce201.png"> | <img width="402" alt="Screen Shot 2021-04-27 at 12 03 20 PM" src="https://user-images.githubusercontent.com/485903/116274646-d9e7c700-a750-11eb-86c2-08b4c8b867ee.png">

