### PR TITLE
Remove scale from full screen modal opening/closing transition

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -395,7 +395,6 @@ const FullScreenContent = React.forwardRef<HTMLDivElement, ModalProps>(
     ref
   ) => {
     const classes = useStyles({});
-    const shouldReduceMotion = useReducedMotion();
 
     return (
       <motion.div
@@ -410,18 +409,15 @@ const FullScreenContent = React.forwardRef<HTMLDivElement, ModalProps>(
         })}
         ref={ref}
         initial={
-          shouldReduceMotion ? { opacity: 0 } : { opacity: 0, scale: 0.2 }
+          { opacity: 0 }
         }
         animate={
-          shouldReduceMotion
-            ? { opacity: 1 }
-            : {
-                opacity: 1,
-                scale: 1,
-                transition: { duration: 0.3, ease: 'easeOut' },
-              }
+          {
+            opacity: 1,
+            transition: { duration: 0.1, ease: [0.16, 1, 0.3, 1] }, // https://easings.net/#easeOutExpo
+          }
         }
-        exit={{ opacity: 0, transition: { duration: 0.2, ease: 'easeIn' } }}
+        exit={{ opacity: 0, transition: { duration: 0.08, ease: [0.7, 0, 0.84, 0] } }} // https://easings.net/#easeInExpo
         {...rootProps}
       >
         {customHeader ? (


### PR DESCRIPTION
Transitioning scale on opening / closing of `fullScreen` modal is pretty sluggish, especially on larger screens.

- Remove `scale` from full screen modal transition
- Remove `shouldReduceMotion` from full screen modal transition since we're only changing opacity

### BEFORE

https://user-images.githubusercontent.com/485903/116299501-c7c75200-a76b-11eb-92c6-ec71f696fe92.mov

### AFTER

https://user-images.githubusercontent.com/485903/116299504-c8f87f00-a76b-11eb-9dd4-7543b308edc7.mov