### PR TITLE
PHC-1157

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifeomic/chroma-react",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Chroma Design System",
   "sideEffects": false,
   "repository": "git@github.com:lifeomic/chroma-react.git",

--- a/src/components/TableModule/TableModuleActions.tsx
+++ b/src/components/TableModule/TableModuleActions.tsx
@@ -13,9 +13,10 @@ export const useStyles = makeStyles(
       // Handle the case where an IconButton or IconbuttonLink is in a cell
       // We don't want it to be too large to push out the height of the row!
       '& > button, & > a': {
-        padding: 0,
         display: 'flex',
+        height: theme.pxToRem(26),
         marginRight: theme.spacing(2.5),
+        padding: 0,
         '& > svg': {
           height: theme.pxToRem(15),
           width: theme.pxToRem(15),


### PR DESCRIPTION
Correcting a minor icon misalignment on IE.

2px comes from the 2rem height of the container minus the 6px of padding (for a total height of 26px).