### PR TITLE
Select - add tooltipMessage and icon

### DIFF
--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -11,6 +11,7 @@ import {
 } from './index';
 import { waitFor } from '@testing-library/dom';
 import { press } from 'reakit-test-utils';
+import { IconComponent } from '../../testUtils/IconComponent';
 
 const headingId = 'GroupHeading';
 const testId = 'Select';
@@ -38,6 +39,37 @@ test('it renders the provided label', async () => {
 
   const label = await findByText('Select one');
   expect(label).toBeInTheDocument();
+});
+
+test('it renders an icon when icon and tooltipMessage are provided', async () => {
+  const props = getBaseProps();
+  const { findByTestId } = renderWithTheme(
+    <Select
+      {...props}
+      icon={IconComponent}
+      tooltipMessage="tooltipMessage"
+      data-testid={testId}
+    />
+  );
+
+  const icon = await findByTestId('iconComponent');
+  expect(icon).toHaveClass('ChromaSelect-labelIcon');
+});
+
+test('it renders an inverse color icon when icon and tooltipMessage are provided', async () => {
+  const props = getBaseProps();
+  const { findByTestId } = renderWithTheme(
+    <Select
+      {...props}
+      color="inverse"
+      icon={IconComponent}
+      tooltipMessage="tooltipMessage"
+      data-testid={testId}
+    />
+  );
+
+  const icon = await findByTestId('iconComponent');
+  expect(icon).toHaveClass('ChromaSelect-labelIconInverse');
 });
 
 test('it renders the provided secondaryLabel', async () => {

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -26,6 +26,7 @@ import { RoverOption } from './RoverOption';
 import { useRoverState } from 'reakit/Rover';
 import { getTestProps } from '../../testUtils/getTestProps';
 import { screenreaderOnlyStyles } from '../../styles/screenreaderOnly';
+import { Tooltip } from '../Tooltip';
 
 export const testIds = {
   placeholderText: 'select-placeholderText',
@@ -69,6 +70,17 @@ export const useStyles = makeStyles(
       '&$labelSecondary': {
         opacity: 0.9,
       },
+    },
+    labelIcon: {
+      marginLeft: theme.spacing(0.75),
+      color: theme.palette.primary.main,
+    },
+    labelIconInverse: {
+      mixBlendMode: 'screen',
+    },
+    tooltipContainer: {
+      display: 'flex',
+      outline: 'none',
     },
     button: {
       alignItems: 'center',
@@ -307,6 +319,7 @@ export interface SelectProps
   ['aria-label']?: string;
   secondaryLabel?: string;
   fullWidth?: boolean;
+  icon?: React.ComponentType<React.SVGProps<SVGSVGElement>>;
   onChange?: (value: string, meta: any) => void;
   placeholder?: string;
   placement?:
@@ -326,6 +339,7 @@ export interface SelectProps
   selectedOptionDisplay?: (
     option: SelectOptionProps
   ) => string | null | undefined | React.ReactNode;
+  tooltipMessage?: string;
 }
 
 export const Select: React.FC<SelectProps> = ({
@@ -337,6 +351,7 @@ export const Select: React.FC<SelectProps> = ({
   fullWidth,
   hasError,
   helpMessage,
+  icon: Icon,
   id,
   label,
   secondaryLabel,
@@ -345,6 +360,7 @@ export const Select: React.FC<SelectProps> = ({
   placement,
   popoverAriaLabel,
   selectedOptionDisplay,
+  tooltipMessage,
   value,
   ...rootProps
 }) => {
@@ -418,6 +434,22 @@ export const Select: React.FC<SelectProps> = ({
         htmlFor={uniqueId}
       >
         {label || ariaLabel}
+        {!!Icon && tooltipMessage && (
+          <Tooltip title={tooltipMessage}>
+            <span className={classes.tooltipContainer}>
+              <Icon
+                className={clsx(
+                  classes.labelIcon,
+                  color === 'inverse' && classes.labelIconInverse
+                )}
+                width={16}
+                height={16}
+                role="img"
+                aria-hidden
+              />
+            </span>
+          </Tooltip>
+        )}
         {secondaryLabel ? (
           <span
             className={clsx(

--- a/stories/components/Select/Select.stories.tsx
+++ b/stories/components/Select/Select.stories.tsx
@@ -6,6 +6,7 @@ import {
   Select,
   SelectOption,
 } from '../../../src/components/Select';
+import { HelpCircle } from '../../../src/icons/lined';
 import { Container } from '../../storyComponents/Container';
 import { Noop } from '../../storyComponents/Noop';
 import defaultMd from './default.md';
@@ -63,11 +64,13 @@ const SelectStory: React.FC = () => {
             <SelectOption title="Option 4" value="option 4" />
           </Select>
           <Select
+            icon={HelpCircle}
             label="Select an option"
             secondaryLabel="Optional"
             placeholder="Optionally pick one…"
             value={selectValue}
             onChange={(v: string) => setSelectValue(v)}
+            tooltipMessage="Perhaps you don't want to use help text? You can stow it here."
           >
             <SelectOption title="Option 1" value="option 1" />
             <SelectOption
@@ -186,11 +189,13 @@ const SelectStory: React.FC = () => {
             <SelectOption title="Option 4" value="option 4" />
           </Select>
           <Select
+            icon={HelpCircle}
             label="Select an option"
             secondaryLabel="Optional"
             placeholder="Optionally pick one…"
             value={selectValue}
             onChange={(v: string) => setSelectValue(v)}
+            tooltipMessage="Perhaps you don't want to use help text? You can stow it here."
           >
             <SelectOption title="Option 1" value="option 1" />
             <SelectOption
@@ -311,12 +316,14 @@ const SelectStory: React.FC = () => {
             <SelectOption title="Option 4" value="option 4" />
           </Select>
           <Select
+            icon={HelpCircle}
             label="Select an option"
             secondaryLabel="Optional"
             placeholder="Optionally pick one…"
             value={selectValue}
             onChange={(v: string) => setSelectValue(v)}
             color="inverse"
+            tooltipMessage="Perhaps you don't want to use help text? You can stow it here."
           >
             <SelectOption title="Option 1" value="option 1" />
             <SelectOption
@@ -446,12 +453,14 @@ const SelectStory: React.FC = () => {
             <SelectOption title="Option 4" value="option 4" />
           </Select>
           <Select
+            icon={HelpCircle}
             label="Select an option"
             secondaryLabel="Optional"
             placeholder="Optionally pick one…"
             value={selectValue}
             onChange={(v: string) => setSelectValue(v)}
             color="inverse"
+            tooltipMessage="Perhaps you don't want to use help text? You can stow it here."
           >
             <SelectOption title="Option 1" value="option 1" />
             <SelectOption

--- a/stories/components/Select/default.md
+++ b/stories/components/Select/default.md
@@ -61,6 +61,20 @@ Makes the element take 100% of the width.
 <Select fullWidth />
 ```
 
+### Icon + Tooltip Message
+
+An additional icon and tooltip element can be used to provide additional context
+for the user on how the entry will be used.
+
+```jsx
+<Select
+  label="Name"
+  secondaryLabel="Optional"
+  icon={HelpCircle}
+  tooltipMessage="If you provide your name, you'll get free tacos!"
+/>
+```
+
 ### Help Message
 
 Caption, help text to display underneath the element. This should be


### PR DESCRIPTION
**Changes**
- Added `tooltipMessage` and `icon` props to Select
  -  We already do this for `Textfield` and `Textarea` to provide additional information.

**BEFORE**
![Screen Shot 2021-05-26 at 7 12 28 PM](https://user-images.githubusercontent.com/32574227/119742858-b2227680-be56-11eb-9073-9ddbee349a27.png)

**AFTER**
![Screen Shot 2021-05-26 at 7 15 32 PM](https://user-images.githubusercontent.com/32574227/119742882-c1a1bf80-be56-11eb-9c1f-f49f07b85b03.png)

