### PR TITLE
Make table configuration types generic over an Item

### DIFF
--- a/src/components/TableModule/TableModule.tsx
+++ b/src/components/TableModule/TableModule.tsx
@@ -194,12 +194,12 @@ export const useStyles = makeStyles(
 
 export type TableModuleClasses = GetClasses<typeof useStyles>;
 
-export interface TableModuleProps
+export interface TableModuleProps<Item = any>
   extends React.DetailedHTMLProps<
     React.HTMLAttributes<HTMLTableElement>,
     HTMLTableElement
   > {
-  config?: Array<TableConfiguration>;
+  config?: Array<TableConfiguration<Item>>;
   data?: Array<any>;
   isLoading?: boolean;
   onRowClick?: (row: any) => void;

--- a/src/components/TableModule/types.ts
+++ b/src/components/TableModule/types.ts
@@ -33,13 +33,13 @@ export interface TableHeader extends TableAlignOptions {
   className?: string;
 }
 
-export interface TableCell extends TableAlignOptions {
+export interface TableCell<Item = any> extends TableAlignOptions {
   valuePath?: string;
-  content?(cell: any): any;
+  content?(cell: Item): any;
   className?: string;
 }
 
-export interface TableConfiguration {
+export interface TableConfiguration<Item = any> {
   header: TableHeader;
-  cell: TableCell;
+  cell: TableCell<Item>;
 }


### PR DESCRIPTION
## Motivation
Adding the capability to specify a generic type for TableModule configuration types, in a non-breaking way.

I _think_ this is correct, but would love confirmation from someone more knowledgeable.