### PR TITLE
Add number format inputs from connect-web-console

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@types/react": "^16.9.34",
     "@types/react-dom": "^16.9.6",
     "@types/react-json-tree": "^0.6.11",
+    "@types/react-phone-number-input": "^3.0.7",
     "@types/react-router-dom": "^5.1.4",
     "@types/storybook__react": "^5.2.1",
     "@typescript-eslint/eslint-plugin": "^4.0.1",
@@ -90,6 +91,7 @@
     "react-feather": "^2.0.4",
     "react-focus-lock": "^2.3.1",
     "react-hotkeys": "^2.0.0",
+    "react-phone-number-input": "^3.1.23",
     "react-remove-scroll": "^2.3.0",
     "reakit": "1.0.0-rc.1"
   }

--- a/src/components/NumberFormat/PhoneNumberFormatField.test.tsx
+++ b/src/components/NumberFormat/PhoneNumberFormatField.test.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { renderWithTheme } from '../../testUtils/renderWithTheme';
+import { PhoneNumberFormatField } from './';
+
+test('rendering PhoneNumberFormatField renders a PhoneInput', async () => {
+  const onChange = jest.fn();
+  const value = '1234567890';
+  const view = renderWithTheme(
+    <PhoneNumberFormatField value={value} onChange={onChange} />
+  );
+  const field = await view.getByRole('textbox');
+  expect(field).toBeInTheDocument();
+  expect(field).toHaveAttribute('value', value);
+});

--- a/src/components/NumberFormat/PhoneNumberFormatField.tsx
+++ b/src/components/NumberFormat/PhoneNumberFormatField.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { TextFieldProps, TextField } from '../TextField';
+// @ts-ignore The flags module is not typed
+import flags from 'react-phone-number-input/flags';
+import PhoneInput, { PhoneInputProps } from 'react-phone-number-input';
+import { makeStyles } from '../../styles';
+import clsx from 'clsx';
+
+const useStyles = ({
+  about,
+  errorMessage,
+}: {
+  about?: string;
+  errorMessage?: string;
+}) =>
+  makeStyles((theme) => ({
+    textField: {
+      marginTop: theme.spacing(2),
+      marginBottom: theme.spacing(1),
+    },
+    phoneInputRoot: {
+      display: 'flex',
+      width: '100%',
+      position: 'relative',
+      '& > .PhoneInputCountry': {
+        position: 'absolute',
+        bottom: theme.spacing(about || errorMessage ? 5.25 : 2.5),
+        left: theme.spacing(1),
+        '& .PhoneInputCountryIcon--border': {
+          boxShadow: 'unset',
+          backgroundColor: 'unset',
+        },
+      },
+    },
+    phoneInput: {
+      '& > input': {
+        paddingLeft: theme.spacing(6),
+      },
+    },
+  }))({});
+
+const PhoneInputCompatibleChromaInput = React.forwardRef<
+  HTMLInputElement,
+  Omit<TextFieldProps, 'color'>
+>((props, ref) => {
+  const classes = useStyles({});
+  const { className, ...textFieldProps } = props;
+  return (
+    <TextField
+      fullWidth
+      label="Phone Number"
+      helpMessage={props.about}
+      ref={ref}
+      {...textFieldProps}
+      className={clsx(classes.phoneInput, classes.textField, className)}
+    />
+  );
+});
+
+export type PhoneNumberFormatFieldProps = Omit<
+  PhoneInputProps,
+  'value' | 'onChange'
+> & {
+  label?: string;
+  value: string;
+  onChange: (val: string) => void;
+  hasError?: boolean;
+  errorMessage?: string;
+};
+export const PhoneNumberFormatField: React.FC<PhoneNumberFormatFieldProps> = ({
+  className,
+  ...props
+}) => {
+  const { value, onChange, errorMessage } = props;
+  const classes = useStyles(props);
+  return (
+    <PhoneInput
+      className={clsx(classes.phoneInputRoot, className)}
+      defaultCountry="US"
+      flags={flags}
+      {...props}
+      // @ts-ignore defaultValue has type mismatch
+      inputComponent={PhoneInputCompatibleChromaInput}
+      value={value}
+      onChange={onChange}
+      error={errorMessage}
+    />
+  );
+};

--- a/src/components/NumberFormat/PhoneNumberFormatField.tsx
+++ b/src/components/NumberFormat/PhoneNumberFormatField.tsx
@@ -5,6 +5,9 @@ import flags from 'react-phone-number-input/flags';
 import PhoneInput, { PhoneInputProps } from 'react-phone-number-input';
 import { makeStyles } from '../../styles';
 import clsx from 'clsx';
+import { GetClasses } from '../../typeUtils';
+
+export const PhoneNumberFormatFieldStylesKey = 'ChromaPhoneNumberFormatField';
 
 const useStyles = ({
   about,
@@ -13,31 +16,36 @@ const useStyles = ({
   about?: string;
   errorMessage?: string;
 }) =>
-  makeStyles((theme) => ({
-    textField: {
-      marginTop: theme.spacing(2),
-      marginBottom: theme.spacing(1),
-    },
-    phoneInputRoot: {
-      display: 'flex',
-      width: '100%',
-      position: 'relative',
-      '& > .PhoneInputCountry': {
-        position: 'absolute',
-        bottom: theme.spacing(about || errorMessage ? 5.25 : 2.5),
-        left: theme.spacing(1),
-        '& .PhoneInputCountryIcon--border': {
-          boxShadow: 'unset',
-          backgroundColor: 'unset',
+  makeStyles(
+    (theme) => ({
+      textField: {
+        marginTop: theme.spacing(2),
+        marginBottom: theme.spacing(1),
+      },
+      phoneInputRoot: {
+        display: 'flex',
+        width: '100%',
+        position: 'relative',
+        '& > .PhoneInputCountry': {
+          position: 'absolute',
+          bottom: theme.spacing(about || errorMessage ? 5.25 : 2.5),
+          left: theme.spacing(1),
+          '& .PhoneInputCountryIcon--border': {
+            boxShadow: 'unset',
+            backgroundColor: 'unset',
+          },
         },
       },
-    },
-    phoneInput: {
-      '& > input': {
-        paddingLeft: theme.spacing(6),
+      phoneInput: {
+        '& > input': {
+          paddingLeft: theme.spacing(6),
+        },
       },
-    },
-  }))({});
+    }),
+    { name: PhoneNumberFormatFieldStylesKey }
+  )({});
+
+export type PhoneNumberFormatFieldClasses = GetClasses<typeof useStyles>;
 
 const PhoneInputCompatibleChromaInput = React.forwardRef<
   HTMLInputElement,

--- a/src/components/NumberFormat/UnitNumberFormatField.test.tsx
+++ b/src/components/NumberFormat/UnitNumberFormatField.test.tsx
@@ -1,0 +1,361 @@
+import * as React from 'react';
+import { renderWithTheme } from '../../testUtils/renderWithTheme';
+import {
+  PercentFormatField,
+  PriceFormatField,
+  UnitNumberFormatField,
+} from './';
+import { fireEvent } from '@testing-library/react';
+
+test('UnitNumberFormatField renders a TextField with min/max and formatted value', async () => {
+  const onChange = jest.fn();
+  const value = 10;
+  const view = renderWithTheme(
+    <UnitNumberFormatField value={value} onChange={onChange} units="tests" />
+  );
+
+  const textfield = await view.getByRole('textbox');
+  expect(textfield).toBeInTheDocument();
+  expect(textfield).toHaveAttribute('min', '0');
+  expect(textfield).toHaveAttribute('max', Number.MAX_SAFE_INTEGER.toString());
+  expect(textfield).toHaveAttribute('value', '10 tests');
+});
+
+test('UnitNumberFormatField does not include a space for short units', async () => {
+  const onChange = jest.fn();
+  const value = 10;
+  const view = renderWithTheme(
+    <UnitNumberFormatField value={value} onChange={onChange} units="m" />
+  );
+
+  const textfield = await view.getByRole('textbox');
+  expect(textfield).toBeInTheDocument();
+  expect(textfield).toHaveAttribute('value', '10m');
+});
+
+test('UnitNumberFormatField rerenders a TextField with min/max and formatted value', async () => {
+  const onChange = jest.fn();
+  const value = 10;
+  const view = renderWithTheme(
+    <UnitNumberFormatField onChange={onChange} value={value} units={'tests'} />
+  );
+  const textfield = await view.getByRole('textbox');
+  expect(textfield).toBeInTheDocument();
+  expect(textfield).toHaveAttribute('min', '0');
+  expect(textfield).toHaveAttribute('max', Number.MAX_SAFE_INTEGER.toString());
+  expect(textfield).toHaveAttribute('value', '10 tests');
+
+  view.rerender(
+    <UnitNumberFormatField onChange={onChange} value={200} units={'tests'} />
+  );
+  expect(textfield).toHaveAttribute('value', '200 tests');
+});
+
+test('UnitNumberFormatField call onChange when the text input value change', async () => {
+  const onChange = jest.fn();
+  const value = 10;
+  const view = renderWithTheme(
+    <UnitNumberFormatField value={value} onChange={onChange} units="m" />
+  );
+  const textfield = await view.getByRole('textbox');
+  expect(textfield).toBeInTheDocument();
+
+  fireEvent.change(textfield, { target: { value: '200' } });
+
+  expect(onChange).toHaveBeenCalledWith(200);
+});
+
+test('UnitNumberFormatField handles moving the cursor for a decimal overwrite', async () => {
+  const onChange = jest.fn();
+  const value = 10.0;
+
+  const view = renderWithTheme(
+    <UnitNumberFormatField
+      value={value}
+      onChange={onChange}
+      units="m"
+      decimalScale={2}
+    />
+  );
+
+  const textfield = await view.getByRole('textbox');
+  const el = textfield as HTMLInputElement;
+  jest.spyOn(el, 'setSelectionRange');
+  fireEvent.change(textfield, { target: { value: '10..00' } });
+  expect(textfield).toHaveAttribute('value', '10.00m');
+
+  expect(el.setSelectionRange).toHaveBeenCalledWith(3, 3);
+});
+
+test('UnitNumberFormatField handles moving the cursor when formatting changes abrubtly', async () => {
+  const onChange = jest.fn();
+  const value = 10.0;
+
+  const viewProps = {
+    value,
+    onChange,
+    units: '$',
+    prefixUnits: true,
+    decimalScale: 2,
+  };
+
+  const view = renderWithTheme(<UnitNumberFormatField {...viewProps} />);
+
+  view.rerender(<UnitNumberFormatField {...viewProps} />);
+
+  const fakeStateSet = (value: number) => {
+    view.rerender(
+      <UnitNumberFormatField
+        {...viewProps}
+        onChange={fakeStateSet}
+        value={value}
+      />
+    );
+  };
+
+  view.rerender(
+    <UnitNumberFormatField {...viewProps} onChange={fakeStateSet} />
+  );
+
+  const textfield = await view.getByRole('textbox');
+  const el = textfield as HTMLInputElement;
+  jest.spyOn(el, 'setSelectionRange');
+  fireEvent.change(textfield, { target: { value: '1.2' } });
+  expect(textfield).toHaveAttribute('value', '$1.20');
+
+  expect(el.setSelectionRange).toHaveBeenCalledWith(4, 4); // cursor after last sig fig
+
+  fireEvent.change(textfield, { target: { value: '1' } });
+  expect(textfield).toHaveAttribute('value', '$1.00');
+  expect(el.setSelectionRange).toHaveBeenCalledWith(2, 2); // cursor after last sig fig
+
+  fireEvent.change(textfield, { target: { value: '10.25' } });
+  expect(textfield).toHaveAttribute('value', '$10.25');
+  expect(el.setSelectionRange).toHaveBeenCalledWith(6, 6); // cursor after last sig fig
+});
+
+test('UnitNumberFormatField sets the selection to the entire input on focus', async () => {
+  const onChange = jest.fn();
+  const value = 25;
+
+  const view = renderWithTheme(
+    <UnitNumberFormatField value={value} onChange={onChange} units={'m'} />
+  );
+
+  const textfield = await view.getByRole('textbox');
+  const el = textfield as HTMLInputElement;
+
+  jest.spyOn(el, 'setSelectionRange');
+  fireEvent.focus(el);
+
+  expect(el.setSelectionRange).toHaveBeenCalledWith(0, 2);
+});
+
+test('UnitNumberFormatField sets the selection to the entire input on focus (prefixed units)', async () => {
+  const onChange = jest.fn();
+  const value = 10.25;
+
+  const view = renderWithTheme(
+    <UnitNumberFormatField
+      value={value}
+      onChange={onChange}
+      units="$"
+      prefixUnits={true}
+      decimalScale={2}
+    />
+  );
+
+  const textfield = await view.getByRole('textbox');
+  const el = textfield as HTMLInputElement;
+  jest.spyOn(el, 'setSelectionRange');
+  fireEvent.focus(textfield);
+
+  expect(el.setSelectionRange).toHaveBeenCalledWith(1, 6); // after $, til the end
+});
+
+test('UnitNumberFormatField resets to 0 on a garbage input', async () => {
+  const onChange = jest.fn();
+  const value = 25;
+
+  const view = renderWithTheme(
+    <UnitNumberFormatField value={value} onChange={onChange} units={'m'} />
+  );
+
+  const textfield = await view.getByRole('textbox');
+  const el = textfield as HTMLInputElement;
+  jest.spyOn(el, 'setSelectionRange');
+  fireEvent.change(textfield, { target: { value: 'asdfasdf' } });
+
+  expect(onChange).toHaveBeenCalledWith(0);
+});
+
+test('UnitNumberFormatField does not update the underlying value when only units are entered', async () => {
+  const onChange = jest.fn();
+  const value = 25;
+
+  const view = renderWithTheme(
+    <UnitNumberFormatField value={value} onChange={onChange} units={'units'} />
+  );
+
+  const textfield = await view.getByRole('textbox');
+  const el = textfield as HTMLInputElement;
+  jest.spyOn(el, 'setSelectionRange');
+  fireEvent.change(textfield, { target: { value: ' units' } });
+
+  expect(onChange).not.toHaveBeenCalled();
+
+  expect(el.setSelectionRange).toHaveBeenCalledWith(0, 0);
+});
+
+test('UnitNumberFormatField does not update the underlying value when only units are entered with prefixed units', async () => {
+  const onChange = jest.fn();
+  const value = 25;
+
+  const view = renderWithTheme(
+    <UnitNumberFormatField
+      value={value}
+      onChange={onChange}
+      units={'$'}
+      prefixUnits={true}
+    />
+  );
+
+  const textfield = await view.getByRole('textbox');
+  const el = textfield as HTMLInputElement;
+  jest.spyOn(el, 'setSelectionRange');
+  fireEvent.change(textfield, { target: { value: '$' } });
+
+  expect(onChange).not.toHaveBeenCalled();
+
+  expect(el.setSelectionRange).toHaveBeenCalledWith(1, 1);
+});
+
+test('UnitNumberFormatField has an onBlur that resets the textFieldValue to the underlying value', async () => {
+  const onChange = jest.fn();
+  const onBlur = jest.fn();
+  const value = 25;
+
+  const view = renderWithTheme(
+    <UnitNumberFormatField
+      value={value}
+      onChange={onChange}
+      onBlur={onBlur}
+      units={'units'}
+    />
+  );
+
+  const textfield = await view.getByRole('textbox');
+  fireEvent.change(textfield, { target: { value: ' units' } });
+  fireEvent.blur(textfield);
+
+  expect(textfield).toHaveAttribute('value', '25 units');
+  expect(onBlur).toHaveBeenCalledTimes(1);
+});
+
+test('UnitNumberFormatField sets the value to inside min/max onBlur', async () => {
+  const onChange = jest.fn();
+  const value = 4;
+
+  const view = renderWithTheme(
+    <UnitNumberFormatField
+      value={value}
+      min={5}
+      onChange={onChange}
+      units={'units'}
+    />
+  );
+
+  const textfield = await view.getByRole('textbox');
+
+  fireEvent.blur(textfield);
+  expect(textfield).toHaveAttribute('value', '5 units');
+});
+
+test('UnitNumberFormatField correctly positions the cursor when typing in the decimal part', async () => {
+  const onChange = jest.fn();
+  const value = 25;
+
+  const view = renderWithTheme(
+    <UnitNumberFormatField
+      value={value}
+      onChange={onChange}
+      units={'$'}
+      prefixUnits={true}
+      decimalScale={2}
+    />
+  );
+
+  const textfield = await view.getByRole('textbox');
+  const el = textfield as HTMLInputElement;
+  jest.spyOn(el, 'setSelectionRange');
+  const setSelectionRange = el.setSelectionRange as jest.Mock;
+
+  fireEvent.change(textfield, { target: { value: '$25.000' } });
+
+  expect(setSelectionRange).toHaveBeenCalledWith(5, 5);
+  setSelectionRange.mockClear();
+
+  fireEvent.change(textfield, { target: { value: '$25.500' } });
+
+  expect(setSelectionRange).toHaveBeenCalledWith(5, 5);
+  setSelectionRange.mockClear();
+
+  fireEvent.change(textfield, { target: { value: '$25.520' } });
+
+  expect(setSelectionRange).toHaveBeenCalledWith(6, 6);
+  setSelectionRange.mockClear();
+});
+
+test('UnitNumberFormatField correctly positions the cursor when typing in the decimal part', async () => {
+  const onChange = jest.fn();
+  const value = 25;
+
+  const view = renderWithTheme(
+    <UnitNumberFormatField
+      value={value}
+      onChange={onChange}
+      units={'units'}
+      prefixUnits={false}
+      decimalScale={2}
+    />
+  );
+
+  const textfield = await view.getByRole('textbox');
+  const el = textfield as HTMLInputElement;
+  jest.spyOn(el, 'setSelectionRange');
+  const setSelectionRange = el.setSelectionRange as jest.Mock;
+
+  fireEvent.change(textfield, { target: { value: '25.000 units' } });
+  expect(setSelectionRange).toHaveBeenCalledWith(4, 4);
+  setSelectionRange.mockClear();
+
+  fireEvent.change(textfield, { target: { value: '25.500 units' } });
+  expect(setSelectionRange).toHaveBeenCalledWith(4, 4);
+  setSelectionRange.mockClear();
+
+  fireEvent.change(textfield, { target: { value: '25.520 units' } });
+  expect(setSelectionRange).toHaveBeenCalledWith(5, 5);
+  setSelectionRange.mockClear();
+});
+
+test('rendering a PercentFormatField renders a UnitNumberFormatField with % units', async () => {
+  const onChange = jest.fn();
+  const value = 10;
+  const view = renderWithTheme(
+    <PercentFormatField value={value} onChange={onChange} />
+  );
+  const textfield = await view.getByRole('textbox');
+  expect(textfield).toBeInTheDocument();
+  expect(textfield).toHaveAttribute('value', '10%');
+});
+
+test('rendering a PriceFormatField renders a UnitNumberFormatField with $ prefixed units', async () => {
+  const onChange = jest.fn();
+  const value = 10;
+  const view = renderWithTheme(
+    <PriceFormatField value={value} onChange={onChange} />
+  );
+  const textfield = await view.getByRole('textbox');
+  expect(textfield).toBeInTheDocument();
+  expect(textfield).toHaveAttribute('value', '$10.00');
+});

--- a/src/components/NumberFormat/UnitNumberFormatField.tsx
+++ b/src/components/NumberFormat/UnitNumberFormatField.tsx
@@ -3,13 +3,21 @@ import { TextFieldProps, TextField } from '../TextField';
 
 import { makeStyles } from '../../styles';
 import clsx from 'clsx';
+import { GetClasses } from '../../typeUtils';
 
-const useStyles = makeStyles((theme) => ({
-  textField: {
-    marginTop: theme.spacing(2),
-    marginBottom: theme.spacing(1),
-  },
-}));
+export const UnitNumberFormatFieldStylesKey = 'ChromaUnitNumberFormatField';
+
+const useStyles = makeStyles(
+  (theme) => ({
+    textField: {
+      marginTop: theme.spacing(2),
+      marginBottom: theme.spacing(1),
+    },
+  }),
+  { name: UnitNumberFormatFieldStylesKey }
+);
+
+export type UnitNumberFormatFieldClasses = GetClasses<typeof useStyles>;
 
 export const UnitNumberFormatField: React.FC<
   Omit<TextFieldProps, 'onChange' | 'value'> & {

--- a/src/components/NumberFormat/UnitNumberFormatField.tsx
+++ b/src/components/NumberFormat/UnitNumberFormatField.tsx
@@ -1,0 +1,198 @@
+import React, { ChangeEvent, useEffect } from 'react';
+import { TextFieldProps, TextField } from '../TextField';
+
+import { makeStyles } from '../../styles';
+import clsx from 'clsx';
+
+const useStyles = makeStyles((theme) => ({
+  textField: {
+    marginTop: theme.spacing(2),
+    marginBottom: theme.spacing(1),
+  },
+}));
+
+export const UnitNumberFormatField: React.FC<
+  Omit<TextFieldProps, 'onChange' | 'value'> & {
+    min?: number;
+    max?: number;
+    value: number;
+    units: string;
+    decimalScale?: number;
+    prefixUnits?: boolean;
+    onChange: (val: number) => void;
+  }
+> = (props) => {
+  const {
+    onChange,
+    onBlur,
+    value,
+    min = 0,
+    max = Number.MAX_SAFE_INTEGER,
+    units,
+    decimalScale = 0,
+    prefixUnits = false,
+    className,
+    ...other
+  } = props;
+  // formatting helper. Prefixes units if specified, otherwise suffix.
+  // also automatically adds a space if the units string is > 2 e.g $10.00 30%, 12ml, 10 slots
+  const format = (val: number) =>
+    prefixUnits
+      ? `${units}${val.toFixed(decimalScale)}`
+      : `${val.toFixed(decimalScale)}${units.length > 2 ? ' ' : ''}${units}`;
+  const [textFieldValue, setTextFieldValue] = React.useState(format(value));
+
+  const classes = useStyles({});
+
+  const [rawValue, setRawValue] = React.useState(format(value));
+
+  // when the text input changes, call onChange handler
+  const handleValueChange = (value: ChangeEvent<HTMLInputElement>) => {
+    const rawNewValue = value.target.value;
+
+    // user deleted value, set text field value without updating underlying value
+    if (rawNewValue.trim() === units) {
+      setTextFieldValue(rawNewValue);
+      return;
+    }
+
+    setRawValue(rawNewValue);
+
+    // default to 0 to handle garbage NaN input
+    const newValue = parseFloat(
+      (parseFloat(rawNewValue.replace(units, '')) || 0).toFixed(decimalScale)
+    );
+    setTextFieldValue(format(newValue));
+    onChange(newValue);
+  };
+
+  // when the provided value changes, update the displayed value
+  useEffect(() => {
+    setTextFieldValue(format(value));
+  }, [value]);
+
+  const textFieldRef = React.useRef<HTMLInputElement | null>(null);
+
+  // This useEffect keeps the position of the cursor from jumping after the value is formatted
+  useEffect(() => {
+    if (textFieldValue === rawValue || !textFieldRef.current) {
+      return;
+    }
+
+    // user deleted value, set cursor beside units
+    if (textFieldValue.trim() === units) {
+      const position = prefixUnits ? units.length : 0;
+      textFieldRef.current.setSelectionRange(position, position);
+      return;
+    }
+
+    // user typed a decimal next to a decimal, move cursor and throw it away
+    if (rawValue.indexOf('..') > -1) {
+      const position = textFieldValue.indexOf('.') + 1;
+      textFieldRef.current.setSelectionRange(position, position);
+      setRawValue(textFieldValue);
+      return;
+    }
+
+    // handle positioning cursor when typing in decimal part
+    const rawDecimalPart = rawValue.replace(units, '').split('.')[1];
+    if (
+      decimalScale > 0 &&
+      rawDecimalPart &&
+      rawDecimalPart.length > decimalScale
+    ) {
+      const rawNumberParts = `${parseFloat(
+        textFieldValue.replace(units, '')
+      ).toFixed(decimalScale)}`.split('.');
+      const decimalPart = rawNumberParts[1].replace(/0+$/g, ''); // trim trailing 0s
+      const position =
+        rawNumberParts[0].length + // length before decimal
+        1 + // the decimal
+        Math.max(decimalPart.length, 1) + // at least one character after decimal
+        (prefixUnits ? units.length : 0); // length of units, if they're prefixed
+      textFieldRef.current.setSelectionRange(position, position);
+      setRawValue(textFieldValue);
+      return;
+    }
+
+    const position =
+      `${parseFloat(textFieldValue.replace(units, ''))}`.length +
+      (prefixUnits ? units.length : 0);
+    textFieldRef.current.setSelectionRange(position, position);
+    setRawValue(textFieldValue);
+  }, [textFieldValue, rawValue]);
+
+  // handles selecting just the value (not the units) on focus
+  const handleFocus = React.useCallback(() => {
+    /* istanbul ignore next */
+    if (!textFieldRef.current) {
+      return;
+    }
+    const inputLength = textFieldValue.replace(units, '').length;
+    const inputStart = prefixUnits ? units.length : 0;
+
+    // focus can only fire if the input ref has been set
+    textFieldRef.current.setSelectionRange(
+      inputStart,
+      inputStart + inputLength
+    );
+  }, [textFieldValue]);
+
+  // if the user deleted value and left only units, this restores the text field to valid value
+  const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+    const newValue = parseFloat(
+      Math.max(
+        Math.min(parseFloat(rawValue.replace(units, '')), Number(max)),
+        min
+      ).toFixed(decimalScale)
+    );
+    setTextFieldValue(format(newValue));
+    onChange(newValue);
+    onBlur && onBlur(event);
+  };
+
+  return (
+    <TextField
+      {...other}
+      className={clsx(classes.textField, className)}
+      value={textFieldValue}
+      min={min}
+      max={max}
+      onChange={handleValueChange}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
+      ref={textFieldRef}
+    />
+  );
+};
+
+export const PercentFormatField: React.FC<
+  Omit<TextFieldProps, 'onChange' | 'value'> & {
+    min?: number;
+    max?: number;
+    value: number;
+    onChange: (val: number) => void;
+  }
+> = (props) => {
+  return (
+    <UnitNumberFormatField {...props} units={'%'} max={props.max || 100} />
+  );
+};
+
+export const PriceFormatField: React.FC<
+  Omit<TextFieldProps, 'onChange' | 'value'> & {
+    min?: number;
+    max?: number;
+    value: number;
+    onChange: (val: number) => void;
+  }
+> = (props) => {
+  return (
+    <UnitNumberFormatField
+      {...props}
+      prefixUnits={true}
+      units={'$'}
+      decimalScale={2}
+    />
+  );
+};

--- a/src/components/NumberFormat/index.ts
+++ b/src/components/NumberFormat/index.ts
@@ -1,7 +1,13 @@
 export {
   UnitNumberFormatField,
+  UnitNumberFormatFieldStylesKey,
+  UnitNumberFormatFieldClasses,
   PriceFormatField,
   PercentFormatField,
 } from './UnitNumberFormatField';
 
-export { PhoneNumberFormatField } from './PhoneNumberFormatField';
+export {
+  PhoneNumberFormatField,
+  PhoneNumberFormatFieldStylesKey,
+  PhoneNumberFormatFieldClasses,
+} from './PhoneNumberFormatField';

--- a/src/components/NumberFormat/index.ts
+++ b/src/components/NumberFormat/index.ts
@@ -1,0 +1,7 @@
+export {
+  UnitNumberFormatField,
+  PriceFormatField,
+  PercentFormatField,
+} from './UnitNumberFormatField';
+
+export { PhoneNumberFormatField } from './PhoneNumberFormatField';

--- a/src/styles/overrides/ChromaOverrides.ts
+++ b/src/styles/overrides/ChromaOverrides.ts
@@ -185,6 +185,12 @@ import {
 import { ToggleClasses, ToggleStylesKey } from '../../components/Toggle';
 import { TooltipClasses, TooltipStylesKey } from '../../components/Tooltip';
 import {
+  UnitNumberFormatFieldClasses,
+  UnitNumberFormatFieldStylesKey,
+  PhoneNumberFormatFieldClasses,
+  PhoneNumberFormatFieldStylesKey,
+} from '../../components/NumberFormat';
+import {
   ButtonUnstyledClasses,
   ButtonUnstyledStylesKey,
 } from '../../components/ButtonUnstyled';
@@ -234,6 +240,7 @@ export interface ChromaComponentNameToClassKey {
   [PageHeaderStylesKey]: PageHeaderClasses;
   [PageLayoutStylesKey]: PageLayoutClasses;
   [PaperStylesKey]: PaperClasses;
+  [PhoneNumberFormatFieldStylesKey]: PhoneNumberFormatFieldClasses;
   [PillStylesKey]: PillClasses;
   [PopoverActionsStylesKey]: PopoverActionsClasses;
   [PopoverStylesKey]: PopoverClasses;
@@ -270,4 +277,5 @@ export interface ChromaComponentNameToClassKey {
   [TextFieldStylesKey]: TextFieldClasses;
   [ToggleStylesKey]: ToggleClasses;
   [TooltipStylesKey]: TooltipClasses;
+  [UnitNumberFormatFieldStylesKey]: UnitNumberFormatFieldClasses;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3329,6 +3329,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-phone-number-input@^3.0.4":
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/@types/react-phone-number-input/-/react-phone-number-input-3.0.7.tgz#11eb743af21dd9e5ad248e3d73be020a4d386586"
+  integrity sha512-CM7atL6w89Q8WNSC3Gbjvi/28v1DSJaYF8Ig2jPLtuKfelyoeW58dTNv5/6XP3dhB6DTpXM7QxI69gYS9GzgtA==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-router-dom@^5.1.4":
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-5.1.4.tgz#8d3e0306df74af301cc896309e7d4758f1a4bf71"
@@ -5690,6 +5697,11 @@ cosmiconfig@^6.0.0:
     parse-json "^5.0.0"
     path-type "^4.0.0"
     yaml "^1.7.2"
+
+country-flag-icons@^1.0.2:
+  version "1.2.10"
+  resolved "https://registry.yarnpkg.com/country-flag-icons/-/country-flag-icons-1.2.10.tgz#c60fdf25883abacd28fbbf3842b920890f944591"
+  integrity sha512-nG+kGe4wVU9M+EsLUhP4buSuNdBH0leTm0Fv6RToXxO9BbbxUKV9VUq+9AcztnW7nEnweK7WYdtJsfyNLmQugQ==
 
 create-ecdh@^4.0.0:
   version "4.0.3"
@@ -8158,6 +8170,13 @@ ini@^1.3.4, ini@^1.3.5:
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
+input-format@^0.3.6:
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/input-format/-/input-format-0.3.6.tgz#b9b167dbd16435eb3c0012347964b230ea0024c8"
+  integrity sha512-SbUu43CDVV5GlC8Xi6NYBUoiU+tLpN/IMYyQl0mzSXDiU1w0ql8wpcwjDOFpaCVLySLoreLUimhI82IA5y42Pw==
+  dependencies:
+    prop-types "^15.7.2"
+
 inquirer@6.2.2:
   version "6.2.2"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.2.2.tgz#46941176f65c9eb20804627149b743a218f25406"
@@ -9490,6 +9509,11 @@ levn@~0.3.0:
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
+
+libphonenumber-js@^1.9.19:
+  version "1.9.19"
+  resolved "https://registry.yarnpkg.com/libphonenumber-js/-/libphonenumber-js-1.9.19.tgz#2e49c86185ed1aa67f2906fb20d752c8837a5c29"
+  integrity sha512-RjStfSE63LvXQEBw7pgQHPkY35z8feiMjC9wLvL1Hbt8PbhxpRrACwMXmLQgabb+IpVdcEx+olh8ll7UDXXkfA==
 
 lines-and-columns@^1.1.6:
   version "1.1.6"
@@ -11817,6 +11841,17 @@ react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
+react-phone-number-input@^3.1.23:
+  version "3.1.23"
+  resolved "https://registry.yarnpkg.com/react-phone-number-input/-/react-phone-number-input-3.1.23.tgz#8e8d2b7fb98d94514721d05ca5c58bd31f8d06e1"
+  integrity sha512-UuIRC4UIwjuC7itrLKH0slq7f6ZDulQt9TB6clPhoevYeu/0yB86bQLKoHaTWCxxY1rYUPGctzR1OzNgBngP/Q==
+  dependencies:
+    classnames "^2.2.5"
+    country-flag-icons "^1.0.2"
+    input-format "^0.3.6"
+    libphonenumber-js "^1.9.19"
+    prop-types "^15.7.2"
 
 react-popper-tooltip@^2.8.0:
   version "2.8.2"


### PR DESCRIPTION
## Changes
This adds the number input fields from https://github.com/lifeomic/connect-web-console/blob/master/src/elements/Form/NumberFormats.test.tsx. All the tests are included as well, with minor changes due to the different testing library.

## Purpose
These input fields are useful for multiple projects, including `wellness-admin-app`.

## What it looks like
![image](https://user-images.githubusercontent.com/45705859/121730317-855c9900-cabd-11eb-9ec6-4d1cccd935f3.png)
