### PR TITLE
Deprecate Chroma icons in favor of Chromicons

### DIFF
--- a/src/icons/lined/Activity.tsx
+++ b/src/icons/lined/Activity.tsx
@@ -1,6 +1,13 @@
 import { Activity as FeatherActivity, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Activity: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherActivity data-icon="activity" {...rootProps} />
 );

--- a/src/icons/lined/Airplay.tsx
+++ b/src/icons/lined/Airplay.tsx
@@ -1,6 +1,13 @@
 import { Airplay as FeatherAirplay, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Airplay: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherAirplay data-icon="airplay" {...rootProps} />
 );

--- a/src/icons/lined/AlertCircle.tsx
+++ b/src/icons/lined/AlertCircle.tsx
@@ -1,6 +1,13 @@
 import { AlertCircle as FeatherAlertCircle, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const AlertCircle: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherAlertCircle data-icon="alertcircle" {...rootProps} />
 );

--- a/src/icons/lined/AlertOctagon.tsx
+++ b/src/icons/lined/AlertOctagon.tsx
@@ -1,6 +1,12 @@
 import { AlertOctagon as FeatherAlertOctagon, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const AlertOctagon: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherAlertOctagon data-icon="alertoctagon" {...rootProps} />
 );

--- a/src/icons/lined/AlignCenter.tsx
+++ b/src/icons/lined/AlignCenter.tsx
@@ -1,6 +1,13 @@
 import { AlignCenter as FeatherAlignCenter, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const AlignCenter: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherAlignCenter data-icon="aligncenter" {...rootProps} />
 );

--- a/src/icons/lined/AlignJustify.tsx
+++ b/src/icons/lined/AlignJustify.tsx
@@ -1,6 +1,13 @@
 import { AlignJustify as FeatherAlignJustify, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const AlignJustify: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherAlignJustify data-icon="alignjustify" {...rootProps} />
 );

--- a/src/icons/lined/AlignLeft.tsx
+++ b/src/icons/lined/AlignLeft.tsx
@@ -1,6 +1,13 @@
 import { AlignLeft as FeatherAlignLeft, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const AlignLeft: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherAlignLeft data-icon="alignleft" {...rootProps} />
 );

--- a/src/icons/lined/AlignRight.tsx
+++ b/src/icons/lined/AlignRight.tsx
@@ -1,6 +1,13 @@
 import { AlignRight as FeatherAlignRight, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const AlignRight: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherAlignRight data-icon="alignright" {...rootProps} />
 );

--- a/src/icons/lined/Anchor.tsx
+++ b/src/icons/lined/Anchor.tsx
@@ -1,6 +1,13 @@
 import { Anchor as FeatherAnchor, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Anchor: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherAnchor data-icon="anchor" {...rootProps} />
 );

--- a/src/icons/lined/Aperture.tsx
+++ b/src/icons/lined/Aperture.tsx
@@ -1,6 +1,13 @@
 import { Aperture as FeatherAperture, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Aperture: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherAperture data-icon="aperture" {...rootProps} />
 );

--- a/src/icons/lined/Archive.tsx
+++ b/src/icons/lined/Archive.tsx
@@ -1,6 +1,13 @@
 import { Archive as FeatherArchive, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Archive: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherArchive data-icon="archive" {...rootProps} />
 );

--- a/src/icons/lined/ArrowDown.tsx
+++ b/src/icons/lined/ArrowDown.tsx
@@ -1,6 +1,13 @@
 import { ArrowDown as FeatherArrowDown, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const ArrowDown: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherArrowDown data-icon="arrowdown" {...rootProps} />
 );

--- a/src/icons/lined/ArrowDownCircle.tsx
+++ b/src/icons/lined/ArrowDownCircle.tsx
@@ -4,6 +4,13 @@ import {
 } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const ArrowDownCircle: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherArrowDownCircle data-icon="arrowdowncircle" {...rootProps} />
 );

--- a/src/icons/lined/ArrowDownLeft.tsx
+++ b/src/icons/lined/ArrowDownLeft.tsx
@@ -1,6 +1,13 @@
 import { ArrowDownLeft as FeatherArrowDownLeft, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const ArrowDownLeft: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherArrowDownLeft data-icon="arrowdownleft" {...rootProps} />
 );

--- a/src/icons/lined/ArrowDownRight.tsx
+++ b/src/icons/lined/ArrowDownRight.tsx
@@ -1,6 +1,13 @@
 import { ArrowDownRight as FeatherArrowDownRight, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const ArrowDownRight: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherArrowDownRight data-icon="arrowdownright" {...rootProps} />
 );

--- a/src/icons/lined/ArrowLeft.tsx
+++ b/src/icons/lined/ArrowLeft.tsx
@@ -1,6 +1,13 @@
 import { ArrowLeft as FeatherArrowLeft, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const ArrowLeft: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherArrowLeft data-icon="arrowleft" {...rootProps} />
 );

--- a/src/icons/lined/ArrowLeftCircle.tsx
+++ b/src/icons/lined/ArrowLeftCircle.tsx
@@ -4,6 +4,13 @@ import {
 } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const ArrowLeftCircle: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherArrowLeftCircle data-icon="arrowleftcircle" {...rootProps} />
 );

--- a/src/icons/lined/ArrowRight.tsx
+++ b/src/icons/lined/ArrowRight.tsx
@@ -1,6 +1,13 @@
 import { ArrowRight as FeatherArrowRight, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const ArrowRight: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherArrowRight data-icon="arrowright" {...rootProps} />
 );

--- a/src/icons/lined/ArrowRightCircle.tsx
+++ b/src/icons/lined/ArrowRightCircle.tsx
@@ -4,6 +4,13 @@ import {
 } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const ArrowRightCircle: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherArrowRightCircle data-icon="arrowrightcircle" {...rootProps} />
 );

--- a/src/icons/lined/ArrowUp.tsx
+++ b/src/icons/lined/ArrowUp.tsx
@@ -1,6 +1,13 @@
 import { ArrowUp as FeatherArrowUp, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const ArrowUp: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherArrowUp data-icon="arrowup" {...rootProps} />
 );

--- a/src/icons/lined/ArrowUpCircle.tsx
+++ b/src/icons/lined/ArrowUpCircle.tsx
@@ -1,6 +1,13 @@
 import { ArrowUpCircle as FeatherArrowUpCircle, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const ArrowUpCircle: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherArrowUpCircle data-icon="arrowupcircle" {...rootProps} />
 );

--- a/src/icons/lined/ArrowUpLeft.tsx
+++ b/src/icons/lined/ArrowUpLeft.tsx
@@ -1,6 +1,13 @@
 import { ArrowUpLeft as FeatherArrowUpLeft, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const ArrowUpLeft: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherArrowUpLeft data-icon="arrowupleft" {...rootProps} />
 );

--- a/src/icons/lined/ArrowUpRight.tsx
+++ b/src/icons/lined/ArrowUpRight.tsx
@@ -1,6 +1,13 @@
 import { ArrowUpRight as FeatherArrowUpRight, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const ArrowUpRight: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherArrowUpRight data-icon="arrowupright" {...rootProps} />
 );

--- a/src/icons/lined/AtSign.tsx
+++ b/src/icons/lined/AtSign.tsx
@@ -1,6 +1,13 @@
 import { AtSign as FeatherAtSign, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const AtSign: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherAtSign data-icon="atsign" {...rootProps} />
 );

--- a/src/icons/lined/Award.tsx
+++ b/src/icons/lined/Award.tsx
@@ -1,6 +1,13 @@
 import { Award as FeatherAward, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Award: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherAward data-icon="award" {...rootProps} />
 );

--- a/src/icons/lined/BarChart.tsx
+++ b/src/icons/lined/BarChart.tsx
@@ -1,6 +1,13 @@
 import { BarChart2 as FeatherBarChart, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const BarChart: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherBarChart data-icon="barchart" {...rootProps} />
 );

--- a/src/icons/lined/Battery.tsx
+++ b/src/icons/lined/Battery.tsx
@@ -1,6 +1,13 @@
 import { Battery as FeatherBattery, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Battery: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherBattery data-icon="battery" {...rootProps} />
 );

--- a/src/icons/lined/BatteryCharging.tsx
+++ b/src/icons/lined/BatteryCharging.tsx
@@ -4,6 +4,13 @@ import {
 } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const BatteryCharging: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherBatteryCharging data-icon="batterycharging" {...rootProps} />
 );

--- a/src/icons/lined/Bell.tsx
+++ b/src/icons/lined/Bell.tsx
@@ -1,6 +1,13 @@
 import { Bell as FeatherBell, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Bell: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherBell data-icon="bell" {...rootProps} />
 );

--- a/src/icons/lined/BellOff.tsx
+++ b/src/icons/lined/BellOff.tsx
@@ -1,6 +1,13 @@
 import { BellOff as FeatherBellOff, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const BellOff: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherBellOff data-icon="belloff" {...rootProps} />
 );

--- a/src/icons/lined/Bluetooth.tsx
+++ b/src/icons/lined/Bluetooth.tsx
@@ -1,6 +1,13 @@
 import { Bluetooth as FeatherBluetooth, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Bluetooth: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherBluetooth data-icon="bluetooth" {...rootProps} />
 );

--- a/src/icons/lined/Bold.tsx
+++ b/src/icons/lined/Bold.tsx
@@ -1,6 +1,13 @@
 import { Bold as FeatherBold, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Bold: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherBold data-icon="bold" {...rootProps} />
 );

--- a/src/icons/lined/Book.tsx
+++ b/src/icons/lined/Book.tsx
@@ -1,6 +1,13 @@
 import { Book as FeatherBook, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Book: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherBook data-icon="book" {...rootProps} />
 );

--- a/src/icons/lined/BookOpen.tsx
+++ b/src/icons/lined/BookOpen.tsx
@@ -1,6 +1,13 @@
 import { BookOpen as FeatherBookOpen, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const BookOpen: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherBookOpen data-icon="bookopen" {...rootProps} />
 );

--- a/src/icons/lined/Bookmark.tsx
+++ b/src/icons/lined/Bookmark.tsx
@@ -1,6 +1,13 @@
 import { Bookmark as FeatherBookmark, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Bookmark: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherBookmark data-icon="bookmark" {...rootProps} />
 );

--- a/src/icons/lined/Box.tsx
+++ b/src/icons/lined/Box.tsx
@@ -1,6 +1,13 @@
 import { Box as FeatherBox, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Box: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherBox data-icon="box" {...rootProps} />
 );

--- a/src/icons/lined/Briefcase.tsx
+++ b/src/icons/lined/Briefcase.tsx
@@ -1,6 +1,13 @@
 import { Briefcase as FeatherBriefcase, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Briefcase: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherBriefcase data-icon="briefcase" {...rootProps} />
 );

--- a/src/icons/lined/Calendar.tsx
+++ b/src/icons/lined/Calendar.tsx
@@ -1,6 +1,13 @@
 import { Calendar as FeatherCalendar, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Calendar: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherCalendar data-icon="calendar" {...rootProps} />
 );

--- a/src/icons/lined/Camera.tsx
+++ b/src/icons/lined/Camera.tsx
@@ -1,6 +1,13 @@
 import { Camera as FeatherCamera, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Camera: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherCamera data-icon="camera" {...rootProps} />
 );

--- a/src/icons/lined/CameraOff.tsx
+++ b/src/icons/lined/CameraOff.tsx
@@ -1,6 +1,13 @@
 import { CameraOff as FeatherCameraOff, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const CameraOff: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherCameraOff data-icon="cameraoff" {...rootProps} />
 );

--- a/src/icons/lined/Cast.tsx
+++ b/src/icons/lined/Cast.tsx
@@ -1,6 +1,13 @@
 import { Cast as FeatherCast, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Cast: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherCast data-icon="cast" {...rootProps} />
 );

--- a/src/icons/lined/Check.tsx
+++ b/src/icons/lined/Check.tsx
@@ -1,6 +1,13 @@
 import { Check as FeatherCheck, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Check: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherCheck data-icon="check" {...rootProps} />
 );

--- a/src/icons/lined/CheckCircle.tsx
+++ b/src/icons/lined/CheckCircle.tsx
@@ -1,6 +1,13 @@
 import { CheckCircle as FeatherCheckCircle, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const CheckCircle: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherCheckCircle data-icon="checkcircle" {...rootProps} />
 );

--- a/src/icons/lined/CheckSquare.tsx
+++ b/src/icons/lined/CheckSquare.tsx
@@ -1,6 +1,13 @@
 import { CheckSquare as FeatherCheckSquare, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const CheckSquare: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherCheckSquare data-icon="checksquare" {...rootProps} />
 );

--- a/src/icons/lined/ChevronDown.tsx
+++ b/src/icons/lined/ChevronDown.tsx
@@ -1,6 +1,13 @@
 import { ChevronDown as FeatherChevronDown, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const ChevronDown: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherChevronDown data-icon="chevrondown" {...rootProps} />
 );

--- a/src/icons/lined/ChevronLeft.tsx
+++ b/src/icons/lined/ChevronLeft.tsx
@@ -1,6 +1,13 @@
 import { ChevronLeft as FeatherChevronLeft, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const ChevronLeft: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherChevronLeft data-icon="chevronleft" {...rootProps} />
 );

--- a/src/icons/lined/ChevronRight.tsx
+++ b/src/icons/lined/ChevronRight.tsx
@@ -1,6 +1,13 @@
 import { ChevronRight as FeatherChevronRight, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const ChevronRight: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherChevronRight data-icon="chevronright" {...rootProps} />
 );

--- a/src/icons/lined/ChevronUp.tsx
+++ b/src/icons/lined/ChevronUp.tsx
@@ -1,6 +1,13 @@
 import { ChevronUp as FeatherChevronUp, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const ChevronUp: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherChevronUp data-icon="chevronup" {...rootProps} />
 );

--- a/src/icons/lined/ChevronsDown.tsx
+++ b/src/icons/lined/ChevronsDown.tsx
@@ -1,6 +1,13 @@
 import { ChevronsDown as FeatherChevronsDown, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const ChevronsDown: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherChevronsDown data-icon="chevronsdown" {...rootProps} />
 );

--- a/src/icons/lined/ChevronsLeft.tsx
+++ b/src/icons/lined/ChevronsLeft.tsx
@@ -1,6 +1,13 @@
 import { ChevronsLeft as FeatherChevronsLeft, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const ChevronsLeft: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherChevronsLeft data-icon="chevronsleft" {...rootProps} />
 );

--- a/src/icons/lined/ChevronsRight.tsx
+++ b/src/icons/lined/ChevronsRight.tsx
@@ -1,6 +1,13 @@
 import { ChevronsRight as FeatherChevronsRight, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const ChevronsRight: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherChevronsRight data-icon="chevronsright" {...rootProps} />
 );

--- a/src/icons/lined/ChevronsUp.tsx
+++ b/src/icons/lined/ChevronsUp.tsx
@@ -1,6 +1,13 @@
 import { ChevronsUp as FeatherChevronsUp, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const ChevronsUp: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherChevronsUp data-icon="chevronsup" {...rootProps} />
 );

--- a/src/icons/lined/Chrome.tsx
+++ b/src/icons/lined/Chrome.tsx
@@ -1,6 +1,13 @@
 import { Chrome as FeatherChrome, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Chrome: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherChrome data-icon="chrome" {...rootProps} />
 );

--- a/src/icons/lined/Circle.tsx
+++ b/src/icons/lined/Circle.tsx
@@ -1,6 +1,13 @@
 import { Circle as FeatherCircle, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Circle: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherCircle data-icon="circle" {...rootProps} />
 );

--- a/src/icons/lined/Clipboard.tsx
+++ b/src/icons/lined/Clipboard.tsx
@@ -1,6 +1,13 @@
 import { Clipboard as FeatherClipboard, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Clipboard: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherClipboard data-icon="clipboard" {...rootProps} />
 );

--- a/src/icons/lined/Clock.tsx
+++ b/src/icons/lined/Clock.tsx
@@ -1,6 +1,13 @@
 import { Clock as FeatherClock, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Clock: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherClock data-icon="clock" {...rootProps} />
 );

--- a/src/icons/lined/Cloud.tsx
+++ b/src/icons/lined/Cloud.tsx
@@ -1,6 +1,13 @@
 import { Cloud as FeatherCloud, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Cloud: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherCloud data-icon="cloud" {...rootProps} />
 );

--- a/src/icons/lined/CloudDrizzle.tsx
+++ b/src/icons/lined/CloudDrizzle.tsx
@@ -1,6 +1,13 @@
 import { CloudDrizzle as FeatherCloudDrizzle, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const CloudDrizzle: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherCloudDrizzle data-icon="clouddrizzle" {...rootProps} />
 );

--- a/src/icons/lined/CloudLightning.tsx
+++ b/src/icons/lined/CloudLightning.tsx
@@ -1,6 +1,13 @@
 import { CloudLightning as FeatherCloudLightning, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const CloudLightning: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherCloudLightning data-icon="cloudlightning" {...rootProps} />
 );

--- a/src/icons/lined/CloudOff.tsx
+++ b/src/icons/lined/CloudOff.tsx
@@ -1,6 +1,13 @@
 import { CloudOff as FeatherCloudOff, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const CloudOff: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherCloudOff data-icon="cloudoff" {...rootProps} />
 );

--- a/src/icons/lined/CloudRain.tsx
+++ b/src/icons/lined/CloudRain.tsx
@@ -1,6 +1,13 @@
 import { CloudRain as FeatherCloudRain, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const CloudRain: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherCloudRain data-icon="cloudrain" {...rootProps} />
 );

--- a/src/icons/lined/CloudSnow.tsx
+++ b/src/icons/lined/CloudSnow.tsx
@@ -1,6 +1,13 @@
 import { CloudSnow as FeatherCloudSnow, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const CloudSnow: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherCloudSnow data-icon="cloudsnow" {...rootProps} />
 );

--- a/src/icons/lined/Code.tsx
+++ b/src/icons/lined/Code.tsx
@@ -1,6 +1,13 @@
 import { Code as FeatherCode, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Code: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherCode data-icon="code" {...rootProps} />
 );

--- a/src/icons/lined/Codepen.tsx
+++ b/src/icons/lined/Codepen.tsx
@@ -1,6 +1,13 @@
 import { Codepen as FeatherCodepen, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Codepen: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherCodepen data-icon="codepen" {...rootProps} />
 );

--- a/src/icons/lined/Coffee.tsx
+++ b/src/icons/lined/Coffee.tsx
@@ -1,6 +1,13 @@
 import { Coffee as FeatherCoffee, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Coffee: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherCoffee data-icon="coffee" {...rootProps} />
 );

--- a/src/icons/lined/Command.tsx
+++ b/src/icons/lined/Command.tsx
@@ -1,6 +1,13 @@
 import { Command as FeatherCommand, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Command: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherCommand data-icon="command" {...rootProps} />
 );

--- a/src/icons/lined/Compass.tsx
+++ b/src/icons/lined/Compass.tsx
@@ -1,6 +1,13 @@
 import { Compass as FeatherCompass, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Compass: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherCompass data-icon="compass" {...rootProps} />
 );

--- a/src/icons/lined/Copy.tsx
+++ b/src/icons/lined/Copy.tsx
@@ -1,6 +1,13 @@
 import { Copy as FeatherCopy, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Copy: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherCopy data-icon="copy" {...rootProps} />
 );

--- a/src/icons/lined/CornerDownLeft.tsx
+++ b/src/icons/lined/CornerDownLeft.tsx
@@ -1,6 +1,13 @@
 import { CornerDownLeft as FeatherCornerDownLeft, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const CornerDownLeft: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherCornerDownLeft data-icon="cornerdownleft" {...rootProps} />
 );

--- a/src/icons/lined/CornerDownRight.tsx
+++ b/src/icons/lined/CornerDownRight.tsx
@@ -4,6 +4,13 @@ import {
 } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const CornerDownRight: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherCornerDownRight data-icon="cornerdownright" {...rootProps} />
 );

--- a/src/icons/lined/CornerLeftDown.tsx
+++ b/src/icons/lined/CornerLeftDown.tsx
@@ -1,6 +1,13 @@
 import { CornerLeftDown as FeatherCornerLeftDown, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const CornerLeftDown: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherCornerLeftDown data-icon="cornerleftdown" {...rootProps} />
 );

--- a/src/icons/lined/CornerLeftUp.tsx
+++ b/src/icons/lined/CornerLeftUp.tsx
@@ -1,6 +1,13 @@
 import { CornerLeftUp as FeatherCornerLeftUp, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const CornerLeftUp: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherCornerLeftUp data-icon="cornerleftup" {...rootProps} />
 );

--- a/src/icons/lined/CornerRightDown.tsx
+++ b/src/icons/lined/CornerRightDown.tsx
@@ -4,6 +4,13 @@ import {
 } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const CornerRightDown: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherCornerRightDown data-icon="cornerrightdown" {...rootProps} />
 );

--- a/src/icons/lined/CornerRightUp.tsx
+++ b/src/icons/lined/CornerRightUp.tsx
@@ -1,6 +1,13 @@
 import { CornerRightUp as FeatherCornerRightUp, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const CornerRightUp: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherCornerRightUp data-icon="cornerrightup" {...rootProps} />
 );

--- a/src/icons/lined/CornerUpLeft.tsx
+++ b/src/icons/lined/CornerUpLeft.tsx
@@ -1,6 +1,13 @@
 import { CornerUpLeft as FeatherCornerUpLeft, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const CornerUpLeft: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherCornerUpLeft data-icon="cornerupleft" {...rootProps} />
 );

--- a/src/icons/lined/CornerUpRight.tsx
+++ b/src/icons/lined/CornerUpRight.tsx
@@ -1,6 +1,13 @@
 import { CornerUpRight as FeatherCornerUpRight, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const CornerUpRight: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherCornerUpRight data-icon="cornerupright" {...rootProps} />
 );

--- a/src/icons/lined/Cpu.tsx
+++ b/src/icons/lined/Cpu.tsx
@@ -1,6 +1,13 @@
 import { Cpu as FeatherCpu, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Cpu: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherCpu data-icon="cpu" {...rootProps} />
 );

--- a/src/icons/lined/CreditCard.tsx
+++ b/src/icons/lined/CreditCard.tsx
@@ -1,6 +1,13 @@
 import { CreditCard as FeatherCreditCard, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const CreditCard: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherCreditCard data-icon="creditcard" {...rootProps} />
 );

--- a/src/icons/lined/Crop.tsx
+++ b/src/icons/lined/Crop.tsx
@@ -1,6 +1,13 @@
 import { Crop as FeatherCrop, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Crop: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherCrop data-icon="crop" {...rootProps} />
 );

--- a/src/icons/lined/Crosshair.tsx
+++ b/src/icons/lined/Crosshair.tsx
@@ -1,6 +1,13 @@
 import { Crosshair as FeatherCrosshair, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Crosshair: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherCrosshair data-icon="crosshair" {...rootProps} />
 );

--- a/src/icons/lined/Database.tsx
+++ b/src/icons/lined/Database.tsx
@@ -1,6 +1,13 @@
 import { Database as FeatherDatabase, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Database: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherDatabase data-icon="database" {...rootProps} />
 );

--- a/src/icons/lined/Delete.tsx
+++ b/src/icons/lined/Delete.tsx
@@ -1,6 +1,13 @@
 import { Delete as FeatherDelete, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Delete: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherDelete data-icon="delete" {...rootProps} />
 );

--- a/src/icons/lined/Disc.tsx
+++ b/src/icons/lined/Disc.tsx
@@ -1,6 +1,13 @@
 import { Disc as FeatherDisc, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Disc: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherDisc data-icon="disc" {...rootProps} />
 );

--- a/src/icons/lined/DollarSign.tsx
+++ b/src/icons/lined/DollarSign.tsx
@@ -1,6 +1,13 @@
 import { DollarSign as FeatherDollarSign, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const DollarSign: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherDollarSign data-icon="dollarsign" {...rootProps} />
 );

--- a/src/icons/lined/Download.tsx
+++ b/src/icons/lined/Download.tsx
@@ -1,6 +1,13 @@
 import { Download as FeatherDownload, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Download: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherDownload data-icon="download" {...rootProps} />
 );

--- a/src/icons/lined/DownloadCloud.tsx
+++ b/src/icons/lined/DownloadCloud.tsx
@@ -1,6 +1,13 @@
 import { DownloadCloud as FeatherDownloadCloud, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const DownloadCloud: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherDownloadCloud data-icon="downloadcloud" {...rootProps} />
 );

--- a/src/icons/lined/Droplet.tsx
+++ b/src/icons/lined/Droplet.tsx
@@ -1,6 +1,13 @@
 import { Droplet as FeatherDroplet, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Droplet: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherDroplet data-icon="droplet" {...rootProps} />
 );

--- a/src/icons/lined/Edit.tsx
+++ b/src/icons/lined/Edit.tsx
@@ -1,6 +1,13 @@
 import { Edit as FeatherEdit, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Edit: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherEdit data-icon="edit" {...rootProps} />
 );

--- a/src/icons/lined/ExternalLink.tsx
+++ b/src/icons/lined/ExternalLink.tsx
@@ -1,6 +1,13 @@
 import { ExternalLink as FeatherExternalLink, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const ExternalLink: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherExternalLink data-icon="externallink" {...rootProps} />
 );

--- a/src/icons/lined/Eye.tsx
+++ b/src/icons/lined/Eye.tsx
@@ -1,6 +1,13 @@
 import { Eye as FeatherEye, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Eye: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherEye data-icon="eye" {...rootProps} />
 );

--- a/src/icons/lined/EyeOff.tsx
+++ b/src/icons/lined/EyeOff.tsx
@@ -1,6 +1,13 @@
 import { EyeOff as FeatherEyeOff, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const EyeOff: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherEyeOff data-icon="eyeoff" {...rootProps} />
 );

--- a/src/icons/lined/Facebook.tsx
+++ b/src/icons/lined/Facebook.tsx
@@ -1,6 +1,13 @@
 import { Facebook as FeatherFacebook, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Facebook: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherFacebook data-icon="facebook" {...rootProps} />
 );

--- a/src/icons/lined/FastForward.tsx
+++ b/src/icons/lined/FastForward.tsx
@@ -1,6 +1,13 @@
 import { FastForward as FeatherFastForward, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const FastForward: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherFastForward data-icon="fastforward" {...rootProps} />
 );

--- a/src/icons/lined/Feather.tsx
+++ b/src/icons/lined/Feather.tsx
@@ -1,6 +1,13 @@
 import { Feather as FeatherFeather, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Feather: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherFeather data-icon="feather" {...rootProps} />
 );

--- a/src/icons/lined/File.tsx
+++ b/src/icons/lined/File.tsx
@@ -1,6 +1,13 @@
 import { File as FeatherFile, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const File: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherFile data-icon="file" {...rootProps} />
 );

--- a/src/icons/lined/FileMinus.tsx
+++ b/src/icons/lined/FileMinus.tsx
@@ -1,6 +1,13 @@
 import { FileMinus as FeatherFileMinus, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const FileMinus: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherFileMinus data-icon="fileminus" {...rootProps} />
 );

--- a/src/icons/lined/FilePlus.tsx
+++ b/src/icons/lined/FilePlus.tsx
@@ -1,6 +1,13 @@
 import { FilePlus as FeatherFilePlus, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const FilePlus: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherFilePlus data-icon="fileplus" {...rootProps} />
 );

--- a/src/icons/lined/FileText.tsx
+++ b/src/icons/lined/FileText.tsx
@@ -1,6 +1,13 @@
 import { FileText as FeatherFileText, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const FileText: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherFileText data-icon="filetext" {...rootProps} />
 );

--- a/src/icons/lined/Film.tsx
+++ b/src/icons/lined/Film.tsx
@@ -1,6 +1,13 @@
 import { Film as FeatherFilm, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Film: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherFilm data-icon="film" {...rootProps} />
 );

--- a/src/icons/lined/Filter.tsx
+++ b/src/icons/lined/Filter.tsx
@@ -1,6 +1,13 @@
 import { Filter as FeatherFilter, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Filter: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherFilter data-icon="filter" {...rootProps} />
 );

--- a/src/icons/lined/Flag.tsx
+++ b/src/icons/lined/Flag.tsx
@@ -1,6 +1,13 @@
 import { Flag as FeatherFlag, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Flag: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherFlag data-icon="flag" {...rootProps} />
 );

--- a/src/icons/lined/Folder.tsx
+++ b/src/icons/lined/Folder.tsx
@@ -1,6 +1,13 @@
 import { Folder as FeatherFolder, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Folder: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherFolder data-icon="folder" {...rootProps} />
 );

--- a/src/icons/lined/FolderMinus.tsx
+++ b/src/icons/lined/FolderMinus.tsx
@@ -1,6 +1,13 @@
 import { FolderMinus as FeatherFolderMinus, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const FolderMinus: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherFolderMinus data-icon="folderminus" {...rootProps} />
 );

--- a/src/icons/lined/FolderPlus.tsx
+++ b/src/icons/lined/FolderPlus.tsx
@@ -1,6 +1,13 @@
 import { FolderPlus as FeatherFolderPlus, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const FolderPlus: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherFolderPlus data-icon="folderplus" {...rootProps} />
 );

--- a/src/icons/lined/Frown.tsx
+++ b/src/icons/lined/Frown.tsx
@@ -1,6 +1,13 @@
 import { Frown as FeatherFrown, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Frown: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherFrown data-icon="frown" {...rootProps} />
 );

--- a/src/icons/lined/Gift.tsx
+++ b/src/icons/lined/Gift.tsx
@@ -1,6 +1,13 @@
 import { Gift as FeatherGift, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Gift: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherGift data-icon="gift" {...rootProps} />
 );

--- a/src/icons/lined/GitBranch.tsx
+++ b/src/icons/lined/GitBranch.tsx
@@ -1,6 +1,13 @@
 import { GitBranch as FeatherGitBranch, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const GitBranch: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherGitBranch data-icon="gitbranch" {...rootProps} />
 );

--- a/src/icons/lined/GitCommit.tsx
+++ b/src/icons/lined/GitCommit.tsx
@@ -1,6 +1,13 @@
 import { GitCommit as FeatherGitCommit, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const GitCommit: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherGitCommit data-icon="gitcommit" {...rootProps} />
 );

--- a/src/icons/lined/GitHub.tsx
+++ b/src/icons/lined/GitHub.tsx
@@ -1,6 +1,13 @@
 import { GitHub as FeatherGitHub, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const GitHub: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherGitHub data-icon="github" {...rootProps} />
 );

--- a/src/icons/lined/GitMerge.tsx
+++ b/src/icons/lined/GitMerge.tsx
@@ -1,6 +1,13 @@
 import { GitMerge as FeatherGitMerge, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const GitMerge: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherGitMerge data-icon="gitmerge" {...rootProps} />
 );

--- a/src/icons/lined/GitPullRequest.tsx
+++ b/src/icons/lined/GitPullRequest.tsx
@@ -1,6 +1,13 @@
 import { GitPullRequest as FeatherGitPullRequest, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const GitPullRequest: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherGitPullRequest data-icon="gitpullrequest" {...rootProps} />
 );

--- a/src/icons/lined/Gitlab.tsx
+++ b/src/icons/lined/Gitlab.tsx
@@ -1,6 +1,13 @@
 import { Gitlab as FeatherGitlab, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Gitlab: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherGitlab data-icon="gitlab" {...rootProps} />
 );

--- a/src/icons/lined/Globe.tsx
+++ b/src/icons/lined/Globe.tsx
@@ -1,6 +1,13 @@
 import { Globe as FeatherGlobe, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Globe: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherGlobe data-icon="globe" {...rootProps} />
 );

--- a/src/icons/lined/Grid.tsx
+++ b/src/icons/lined/Grid.tsx
@@ -1,6 +1,13 @@
 import { Grid as FeatherGrid, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Grid: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherGrid data-icon="grid" {...rootProps} />
 );

--- a/src/icons/lined/HardDrive.tsx
+++ b/src/icons/lined/HardDrive.tsx
@@ -1,6 +1,13 @@
 import { HardDrive as FeatherHardDrive, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const HardDrive: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherHardDrive data-icon="harddrive" {...rootProps} />
 );

--- a/src/icons/lined/Hash.tsx
+++ b/src/icons/lined/Hash.tsx
@@ -1,6 +1,13 @@
 import { Hash as FeatherHash, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Hash: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherHash data-icon="hash" {...rootProps} />
 );

--- a/src/icons/lined/Headphones.tsx
+++ b/src/icons/lined/Headphones.tsx
@@ -1,6 +1,13 @@
 import { Headphones as FeatherHeadphones, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Headphones: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherHeadphones data-icon="headphones" {...rootProps} />
 );

--- a/src/icons/lined/Heart.tsx
+++ b/src/icons/lined/Heart.tsx
@@ -1,6 +1,13 @@
 import { Heart as FeatherHeart, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Heart: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherHeart data-icon="heart" {...rootProps} />
 );

--- a/src/icons/lined/HelpCircle.tsx
+++ b/src/icons/lined/HelpCircle.tsx
@@ -1,6 +1,13 @@
 import { HelpCircle as FeatherHelpCircle, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const HelpCircle: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherHelpCircle data-icon="helpcircle" {...rootProps} />
 );

--- a/src/icons/lined/Home.tsx
+++ b/src/icons/lined/Home.tsx
@@ -1,6 +1,13 @@
 import { Home as FeatherHome, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Home: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherHome data-icon="home" {...rootProps} />
 );

--- a/src/icons/lined/Image.tsx
+++ b/src/icons/lined/Image.tsx
@@ -1,6 +1,13 @@
 import { Image as FeatherImage, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Image: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherImage data-icon="image" {...rootProps} />
 );

--- a/src/icons/lined/Inbox.tsx
+++ b/src/icons/lined/Inbox.tsx
@@ -1,6 +1,13 @@
 import { Inbox as FeatherInbox, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Inbox: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherInbox data-icon="inbox" {...rootProps} />
 );

--- a/src/icons/lined/Info.tsx
+++ b/src/icons/lined/Info.tsx
@@ -1,6 +1,13 @@
 import { Info as FeatherInfo, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Info: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherInfo data-icon="info" {...rootProps} />
 );

--- a/src/icons/lined/Instagram.tsx
+++ b/src/icons/lined/Instagram.tsx
@@ -1,6 +1,13 @@
 import { Instagram as FeatherInstagram, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Instagram: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherInstagram data-icon="instagram" {...rootProps} />
 );

--- a/src/icons/lined/Italic.tsx
+++ b/src/icons/lined/Italic.tsx
@@ -1,6 +1,13 @@
 import { Italic as FeatherItalic, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Italic: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherItalic data-icon="italic" {...rootProps} />
 );

--- a/src/icons/lined/Key.tsx
+++ b/src/icons/lined/Key.tsx
@@ -1,6 +1,13 @@
 import { Key as FeatherKey, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Key: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherKey data-icon="key" {...rootProps} />
 );

--- a/src/icons/lined/Layers.tsx
+++ b/src/icons/lined/Layers.tsx
@@ -1,6 +1,13 @@
 import { Layers as FeatherLayers, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Layers: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherLayers data-icon="layers" {...rootProps} />
 );

--- a/src/icons/lined/Layout.tsx
+++ b/src/icons/lined/Layout.tsx
@@ -1,6 +1,13 @@
 import { Layout as FeatherLayout, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Layout: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherLayout data-icon="layout" {...rootProps} />
 );

--- a/src/icons/lined/LifeBuoy.tsx
+++ b/src/icons/lined/LifeBuoy.tsx
@@ -1,6 +1,13 @@
 import { LifeBuoy as FeatherLifeBuoy, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const LifeBuoy: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherLifeBuoy data-icon="lifebuoy" {...rootProps} />
 );

--- a/src/icons/lined/Link.tsx
+++ b/src/icons/lined/Link.tsx
@@ -1,6 +1,13 @@
 import { Link as FeatherLink, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Link: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherLink data-icon="link" {...rootProps} />
 );

--- a/src/icons/lined/Link2.tsx
+++ b/src/icons/lined/Link2.tsx
@@ -1,6 +1,13 @@
 import { Link2 as FeatherLink2, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Link2: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherLink2 data-icon="link2" {...rootProps} />
 );

--- a/src/icons/lined/Linkedin.tsx
+++ b/src/icons/lined/Linkedin.tsx
@@ -1,6 +1,13 @@
 import { Linkedin as FeatherLinkedin, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Linkedin: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherLinkedin data-icon="linkedin" {...rootProps} />
 );

--- a/src/icons/lined/List.tsx
+++ b/src/icons/lined/List.tsx
@@ -1,6 +1,13 @@
 import { List as FeatherList, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const List: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherList data-icon="list" {...rootProps} />
 );

--- a/src/icons/lined/Loader.tsx
+++ b/src/icons/lined/Loader.tsx
@@ -1,6 +1,13 @@
 import { Loader as FeatherLoader, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Loader: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherLoader data-icon="loader" {...rootProps} />
 );

--- a/src/icons/lined/Lock.tsx
+++ b/src/icons/lined/Lock.tsx
@@ -1,6 +1,13 @@
 import { Lock as FeatherLock, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Lock: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherLock data-icon="lock" {...rootProps} />
 );

--- a/src/icons/lined/LogIn.tsx
+++ b/src/icons/lined/LogIn.tsx
@@ -1,6 +1,13 @@
 import { LogIn as FeatherLogIn, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const LogIn: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherLogIn data-icon="login" {...rootProps} />
 );

--- a/src/icons/lined/LogOut.tsx
+++ b/src/icons/lined/LogOut.tsx
@@ -1,6 +1,13 @@
 import { LogOut as FeatherLogOut, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const LogOut: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherLogOut data-icon="logout" {...rootProps} />
 );

--- a/src/icons/lined/Mail.tsx
+++ b/src/icons/lined/Mail.tsx
@@ -1,6 +1,13 @@
 import { Mail as FeatherMail, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Mail: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherMail data-icon="mail" {...rootProps} />
 );

--- a/src/icons/lined/Map.tsx
+++ b/src/icons/lined/Map.tsx
@@ -1,6 +1,13 @@
 import { Map as FeatherMap, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Map: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherMap data-icon="map" {...rootProps} />
 );

--- a/src/icons/lined/MapPin.tsx
+++ b/src/icons/lined/MapPin.tsx
@@ -1,6 +1,13 @@
 import { MapPin as FeatherMapPin, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const MapPin: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherMapPin data-icon="mappin" {...rootProps} />
 );

--- a/src/icons/lined/Maximize.tsx
+++ b/src/icons/lined/Maximize.tsx
@@ -1,6 +1,13 @@
 import { Maximize as FeatherMaximize, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Maximize: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherMaximize data-icon="maximize" {...rootProps} />
 );

--- a/src/icons/lined/Maximize2.tsx
+++ b/src/icons/lined/Maximize2.tsx
@@ -1,6 +1,13 @@
 import { Maximize2 as FeatherMaximize2, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Maximize2: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherMaximize2 data-icon="maximize2" {...rootProps} />
 );

--- a/src/icons/lined/Meh.tsx
+++ b/src/icons/lined/Meh.tsx
@@ -1,6 +1,13 @@
 import { Meh as FeatherMeh, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Meh: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherMeh data-icon="meh" {...rootProps} />
 );

--- a/src/icons/lined/Menu.tsx
+++ b/src/icons/lined/Menu.tsx
@@ -1,6 +1,13 @@
 import { Menu as FeatherMenu, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Menu: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherMenu data-icon="menu" {...rootProps} />
 );

--- a/src/icons/lined/MessageCircle.tsx
+++ b/src/icons/lined/MessageCircle.tsx
@@ -1,6 +1,13 @@
 import { MessageCircle as FeatherMessageCircle, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const MessageCircle: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherMessageCircle data-icon="messagecircle" {...rootProps} />
 );

--- a/src/icons/lined/MessageSquare.tsx
+++ b/src/icons/lined/MessageSquare.tsx
@@ -1,6 +1,13 @@
 import { MessageSquare as FeatherMessageSquare, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const MessageSquare: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherMessageSquare data-icon="messagesquare" {...rootProps} />
 );

--- a/src/icons/lined/Mic.tsx
+++ b/src/icons/lined/Mic.tsx
@@ -1,6 +1,13 @@
 import { Mic as FeatherMic, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Mic: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherMic data-icon="mic" {...rootProps} />
 );

--- a/src/icons/lined/MicOff.tsx
+++ b/src/icons/lined/MicOff.tsx
@@ -1,6 +1,13 @@
 import { MicOff as FeatherMicOff, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const MicOff: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherMicOff data-icon="micoff" {...rootProps} />
 );

--- a/src/icons/lined/Minimize.tsx
+++ b/src/icons/lined/Minimize.tsx
@@ -1,6 +1,13 @@
 import { Minimize as FeatherMinimize, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Minimize: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherMinimize data-icon="minimize" {...rootProps} />
 );

--- a/src/icons/lined/Minimize2.tsx
+++ b/src/icons/lined/Minimize2.tsx
@@ -1,6 +1,13 @@
 import { Minimize2 as FeatherMinimize2, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Minimize2: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherMinimize2 data-icon="minimize2" {...rootProps} />
 );

--- a/src/icons/lined/Minus.tsx
+++ b/src/icons/lined/Minus.tsx
@@ -1,6 +1,13 @@
 import { Minus as FeatherMinus, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Minus: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherMinus data-icon="minus" {...rootProps} />
 );

--- a/src/icons/lined/MinusCircle.tsx
+++ b/src/icons/lined/MinusCircle.tsx
@@ -1,6 +1,13 @@
 import { MinusCircle as FeatherMinusCircle, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const MinusCircle: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherMinusCircle data-icon="minuscircle" {...rootProps} />
 );

--- a/src/icons/lined/MinusSquare.tsx
+++ b/src/icons/lined/MinusSquare.tsx
@@ -1,6 +1,13 @@
 import { MinusSquare as FeatherMinusSquare, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const MinusSquare: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherMinusSquare data-icon="minussquare" {...rootProps} />
 );

--- a/src/icons/lined/Monitor.tsx
+++ b/src/icons/lined/Monitor.tsx
@@ -1,6 +1,13 @@
 import { Monitor as FeatherMonitor, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Monitor: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherMonitor data-icon="monitor" {...rootProps} />
 );

--- a/src/icons/lined/Moon.tsx
+++ b/src/icons/lined/Moon.tsx
@@ -1,6 +1,13 @@
 import { Moon as FeatherMoon, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Moon: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherMoon data-icon="moon" {...rootProps} />
 );

--- a/src/icons/lined/MoreHorizontal.tsx
+++ b/src/icons/lined/MoreHorizontal.tsx
@@ -1,6 +1,13 @@
 import { MoreHorizontal as FeatherMoreHorizontal, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const MoreHorizontal: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherMoreHorizontal data-icon="morehorizontal" {...rootProps} />
 );

--- a/src/icons/lined/MoreVertical.tsx
+++ b/src/icons/lined/MoreVertical.tsx
@@ -1,6 +1,13 @@
 import { MoreVertical as FeatherMoreVertical, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const MoreVertical: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherMoreVertical data-icon="morevertical" {...rootProps} />
 );

--- a/src/icons/lined/Move.tsx
+++ b/src/icons/lined/Move.tsx
@@ -1,6 +1,13 @@
 import { Move as FeatherMove, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Move: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherMove data-icon="move" {...rootProps} />
 );

--- a/src/icons/lined/Music.tsx
+++ b/src/icons/lined/Music.tsx
@@ -1,6 +1,13 @@
 import { Music as FeatherMusic, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Music: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherMusic data-icon="music" {...rootProps} />
 );

--- a/src/icons/lined/Navigation.tsx
+++ b/src/icons/lined/Navigation.tsx
@@ -1,6 +1,13 @@
 import { Navigation as FeatherNavigation, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Navigation: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherNavigation data-icon="navigation" {...rootProps} />
 );

--- a/src/icons/lined/Navigation2.tsx
+++ b/src/icons/lined/Navigation2.tsx
@@ -1,6 +1,13 @@
 import { Navigation2 as FeatherNavigation2, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Navigation2: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherNavigation2 data-icon="navigation2" {...rootProps} />
 );

--- a/src/icons/lined/Octagon.tsx
+++ b/src/icons/lined/Octagon.tsx
@@ -1,6 +1,13 @@
 import { Octagon as FeatherOctagon, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Octagon: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherOctagon data-icon="octagon" {...rootProps} />
 );

--- a/src/icons/lined/Package.tsx
+++ b/src/icons/lined/Package.tsx
@@ -1,6 +1,13 @@
 import { Package as FeatherPackage, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Package: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherPackage data-icon="package" {...rootProps} />
 );

--- a/src/icons/lined/Paperclip.tsx
+++ b/src/icons/lined/Paperclip.tsx
@@ -1,6 +1,13 @@
 import { Paperclip as FeatherPaperclip, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Paperclip: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherPaperclip data-icon="paperclip" {...rootProps} />
 );

--- a/src/icons/lined/Pause.tsx
+++ b/src/icons/lined/Pause.tsx
@@ -1,6 +1,13 @@
 import { Pause as FeatherPause, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Pause: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherPause data-icon="pause" {...rootProps} />
 );

--- a/src/icons/lined/PauseCircle.tsx
+++ b/src/icons/lined/PauseCircle.tsx
@@ -1,6 +1,13 @@
 import { PauseCircle as FeatherPauseCircle, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const PauseCircle: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherPauseCircle data-icon="pausecircle" {...rootProps} />
 );

--- a/src/icons/lined/Percent.tsx
+++ b/src/icons/lined/Percent.tsx
@@ -1,6 +1,13 @@
 import { Percent as FeatherPercent, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Percent: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherPercent data-icon="percent" {...rootProps} />
 );

--- a/src/icons/lined/Phone.tsx
+++ b/src/icons/lined/Phone.tsx
@@ -1,6 +1,13 @@
 import { Phone as FeatherPhone, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Phone: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherPhone data-icon="phone" {...rootProps} />
 );

--- a/src/icons/lined/PhoneCall.tsx
+++ b/src/icons/lined/PhoneCall.tsx
@@ -1,6 +1,13 @@
 import { PhoneCall as FeatherPhoneCall, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const PhoneCall: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherPhoneCall data-icon="phonecall" {...rootProps} />
 );

--- a/src/icons/lined/PhoneForwarded.tsx
+++ b/src/icons/lined/PhoneForwarded.tsx
@@ -1,6 +1,13 @@
 import { PhoneForwarded as FeatherPhoneForwarded, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const PhoneForwarded: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherPhoneForwarded data-icon="phoneforwarded" {...rootProps} />
 );

--- a/src/icons/lined/PhoneIncoming.tsx
+++ b/src/icons/lined/PhoneIncoming.tsx
@@ -1,6 +1,13 @@
 import { PhoneIncoming as FeatherPhoneIncoming, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const PhoneIncoming: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherPhoneIncoming data-icon="phoneincoming" {...rootProps} />
 );

--- a/src/icons/lined/PhoneMissed.tsx
+++ b/src/icons/lined/PhoneMissed.tsx
@@ -1,6 +1,13 @@
 import { PhoneMissed as FeatherPhoneMissed, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const PhoneMissed: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherPhoneMissed data-icon="phonemissed" {...rootProps} />
 );

--- a/src/icons/lined/PhoneOff.tsx
+++ b/src/icons/lined/PhoneOff.tsx
@@ -1,6 +1,13 @@
 import { PhoneOff as FeatherPhoneOff, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const PhoneOff: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherPhoneOff data-icon="phoneoff" {...rootProps} />
 );

--- a/src/icons/lined/PhoneOutgoing.tsx
+++ b/src/icons/lined/PhoneOutgoing.tsx
@@ -1,6 +1,13 @@
 import { PhoneOutgoing as FeatherPhoneOutgoing, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const PhoneOutgoing: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherPhoneOutgoing data-icon="phoneoutgoing" {...rootProps} />
 );

--- a/src/icons/lined/PieChart.tsx
+++ b/src/icons/lined/PieChart.tsx
@@ -1,6 +1,13 @@
 import { PieChart as FeatherPieChart, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const PieChart: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherPieChart data-icon="piechart" {...rootProps} />
 );

--- a/src/icons/lined/Play.tsx
+++ b/src/icons/lined/Play.tsx
@@ -1,6 +1,13 @@
 import { Play as FeatherPlay, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Play: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherPlay data-icon="play" {...rootProps} />
 );

--- a/src/icons/lined/PlayCircle.tsx
+++ b/src/icons/lined/PlayCircle.tsx
@@ -1,6 +1,13 @@
 import { PlayCircle as FeatherPlayCircle, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const PlayCircle: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherPlayCircle data-icon="playcircle" {...rootProps} />
 );

--- a/src/icons/lined/Plus.tsx
+++ b/src/icons/lined/Plus.tsx
@@ -1,6 +1,13 @@
 import { Plus as FeatherPlus, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Plus: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherPlus data-icon="plus" {...rootProps} />
 );

--- a/src/icons/lined/PlusCircle.tsx
+++ b/src/icons/lined/PlusCircle.tsx
@@ -1,6 +1,13 @@
 import { PlusCircle as FeatherPlusCircle, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const PlusCircle: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherPlusCircle data-icon="pluscircle" {...rootProps} />
 );

--- a/src/icons/lined/PlusSquare.tsx
+++ b/src/icons/lined/PlusSquare.tsx
@@ -1,6 +1,13 @@
 import { PlusSquare as FeatherPlusSquare, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const PlusSquare: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherPlusSquare data-icon="plussquare" {...rootProps} />
 );

--- a/src/icons/lined/Pocket.tsx
+++ b/src/icons/lined/Pocket.tsx
@@ -1,6 +1,13 @@
 import { Pocket as FeatherPocket, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Pocket: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherPocket data-icon="pocket" {...rootProps} />
 );

--- a/src/icons/lined/Power.tsx
+++ b/src/icons/lined/Power.tsx
@@ -1,6 +1,13 @@
 import { Power as FeatherPower, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Power: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherPower data-icon="power" {...rootProps} />
 );

--- a/src/icons/lined/Printer.tsx
+++ b/src/icons/lined/Printer.tsx
@@ -1,6 +1,13 @@
 import { Printer as FeatherPrinter, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Printer: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherPrinter data-icon="printer" {...rootProps} />
 );

--- a/src/icons/lined/Radio.tsx
+++ b/src/icons/lined/Radio.tsx
@@ -1,6 +1,13 @@
 import { Radio as FeatherRadio, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Radio: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherRadio data-icon="radio" {...rootProps} />
 );

--- a/src/icons/lined/RefreshCcw.tsx
+++ b/src/icons/lined/RefreshCcw.tsx
@@ -1,6 +1,13 @@
 import { RefreshCcw as FeatherRefreshCcw, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const RefreshCcw: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherRefreshCcw data-icon="refreshccw" {...rootProps} />
 );

--- a/src/icons/lined/RefreshCw.tsx
+++ b/src/icons/lined/RefreshCw.tsx
@@ -1,6 +1,13 @@
 import { RefreshCw as FeatherRefreshCw, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const RefreshCw: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherRefreshCw data-icon="refreshcw" {...rootProps} />
 );

--- a/src/icons/lined/Repeat.tsx
+++ b/src/icons/lined/Repeat.tsx
@@ -1,6 +1,13 @@
 import { Repeat as FeatherRepeat, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Repeat: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherRepeat data-icon="repeat" {...rootProps} />
 );

--- a/src/icons/lined/Rewind.tsx
+++ b/src/icons/lined/Rewind.tsx
@@ -1,6 +1,13 @@
 import { Rewind as FeatherRewind, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Rewind: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherRewind data-icon="rewind" {...rootProps} />
 );

--- a/src/icons/lined/RotateCcw.tsx
+++ b/src/icons/lined/RotateCcw.tsx
@@ -1,6 +1,13 @@
 import { RotateCcw as FeatherRotateCcw, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const RotateCcw: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherRotateCcw data-icon="rotateccw" {...rootProps} />
 );

--- a/src/icons/lined/RotateCw.tsx
+++ b/src/icons/lined/RotateCw.tsx
@@ -1,6 +1,13 @@
 import { RotateCw as FeatherRotateCw, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const RotateCw: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherRotateCw data-icon="rotatecw" {...rootProps} />
 );

--- a/src/icons/lined/Rss.tsx
+++ b/src/icons/lined/Rss.tsx
@@ -1,6 +1,13 @@
 import { Rss as FeatherRss, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Rss: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherRss data-icon="rss" {...rootProps} />
 );

--- a/src/icons/lined/Save.tsx
+++ b/src/icons/lined/Save.tsx
@@ -1,6 +1,13 @@
 import { Save as FeatherSave, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Save: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherSave data-icon="save" {...rootProps} />
 );

--- a/src/icons/lined/Scissors.tsx
+++ b/src/icons/lined/Scissors.tsx
@@ -1,6 +1,13 @@
 import { Scissors as FeatherScissors, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Scissors: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherScissors data-icon="scissors" {...rootProps} />
 );

--- a/src/icons/lined/Search.tsx
+++ b/src/icons/lined/Search.tsx
@@ -1,6 +1,13 @@
 import { Search as FeatherSearch, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Search: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherSearch data-icon="search" {...rootProps} />
 );

--- a/src/icons/lined/Send.tsx
+++ b/src/icons/lined/Send.tsx
@@ -1,6 +1,13 @@
 import { Send as FeatherSend, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Send: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherSend data-icon="send" {...rootProps} />
 );

--- a/src/icons/lined/Server.tsx
+++ b/src/icons/lined/Server.tsx
@@ -1,6 +1,13 @@
 import { Server as FeatherServer, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Server: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherServer data-icon="server" {...rootProps} />
 );

--- a/src/icons/lined/Settings.tsx
+++ b/src/icons/lined/Settings.tsx
@@ -1,6 +1,13 @@
 import { Settings as FeatherSettings, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Settings: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherSettings data-icon="settings" {...rootProps} />
 );

--- a/src/icons/lined/Share.tsx
+++ b/src/icons/lined/Share.tsx
@@ -1,6 +1,13 @@
 import { Share as FeatherShare, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Share: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherShare data-icon="share" {...rootProps} />
 );

--- a/src/icons/lined/Share2.tsx
+++ b/src/icons/lined/Share2.tsx
@@ -1,6 +1,13 @@
 import { Share2 as FeatherShare2, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Share2: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherShare2 data-icon="share2" {...rootProps} />
 );

--- a/src/icons/lined/Shield.tsx
+++ b/src/icons/lined/Shield.tsx
@@ -1,6 +1,13 @@
 import { Shield as FeatherShield, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Shield: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherShield data-icon="shield" {...rootProps} />
 );

--- a/src/icons/lined/ShieldOff.tsx
+++ b/src/icons/lined/ShieldOff.tsx
@@ -1,6 +1,13 @@
 import { ShieldOff as FeatherShieldOff, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const ShieldOff: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherShieldOff data-icon="shieldoff" {...rootProps} />
 );

--- a/src/icons/lined/ShoppingBag.tsx
+++ b/src/icons/lined/ShoppingBag.tsx
@@ -1,6 +1,13 @@
 import { ShoppingBag as FeatherShoppingBag, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const ShoppingBag: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherShoppingBag data-icon="shoppingbag" {...rootProps} />
 );

--- a/src/icons/lined/ShoppingCart.tsx
+++ b/src/icons/lined/ShoppingCart.tsx
@@ -1,6 +1,13 @@
 import { ShoppingCart as FeatherShoppingCart, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const ShoppingCart: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherShoppingCart data-icon="shoppingcart" {...rootProps} />
 );

--- a/src/icons/lined/Shuffle.tsx
+++ b/src/icons/lined/Shuffle.tsx
@@ -1,6 +1,13 @@
 import { Shuffle as FeatherShuffle, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Shuffle: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherShuffle data-icon="shuffle" {...rootProps} />
 );

--- a/src/icons/lined/Sidebar.tsx
+++ b/src/icons/lined/Sidebar.tsx
@@ -1,6 +1,13 @@
 import { Sidebar as FeatherSidebar, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Sidebar: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherSidebar data-icon="sidebar" {...rootProps} />
 );

--- a/src/icons/lined/SkipBack.tsx
+++ b/src/icons/lined/SkipBack.tsx
@@ -1,6 +1,13 @@
 import { SkipBack as FeatherSkipBack, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const SkipBack: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherSkipBack data-icon="skipback" {...rootProps} />
 );

--- a/src/icons/lined/SkipForward.tsx
+++ b/src/icons/lined/SkipForward.tsx
@@ -1,6 +1,13 @@
 import { SkipForward as FeatherSkipForward, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const SkipForward: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherSkipForward data-icon="skipforward" {...rootProps} />
 );

--- a/src/icons/lined/Slack.tsx
+++ b/src/icons/lined/Slack.tsx
@@ -1,6 +1,13 @@
 import { Slack as FeatherSlack, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Slack: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherSlack data-icon="slack" {...rootProps} />
 );

--- a/src/icons/lined/Slash.tsx
+++ b/src/icons/lined/Slash.tsx
@@ -1,6 +1,13 @@
 import { Slash as FeatherSlash, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Slash: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherSlash data-icon="slash" {...rootProps} />
 );

--- a/src/icons/lined/Sliders.tsx
+++ b/src/icons/lined/Sliders.tsx
@@ -1,6 +1,13 @@
 import { Sliders as FeatherSliders, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Sliders: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherSliders data-icon="sliders" {...rootProps} />
 );

--- a/src/icons/lined/Smartphone.tsx
+++ b/src/icons/lined/Smartphone.tsx
@@ -1,6 +1,13 @@
 import { Smartphone as FeatherSmartphone, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Smartphone: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherSmartphone data-icon="smartphone" {...rootProps} />
 );

--- a/src/icons/lined/Smile.tsx
+++ b/src/icons/lined/Smile.tsx
@@ -1,6 +1,13 @@
 import { Smile as FeatherSmile, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Smile: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherSmile data-icon="smile" {...rootProps} />
 );

--- a/src/icons/lined/Speaker.tsx
+++ b/src/icons/lined/Speaker.tsx
@@ -1,6 +1,13 @@
 import { Speaker as FeatherSpeaker, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Speaker: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherSpeaker data-icon="speaker" {...rootProps} />
 );

--- a/src/icons/lined/Square.tsx
+++ b/src/icons/lined/Square.tsx
@@ -1,6 +1,13 @@
 import { Square as FeatherSquare, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Square: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherSquare data-icon="square" {...rootProps} />
 );

--- a/src/icons/lined/Star.tsx
+++ b/src/icons/lined/Star.tsx
@@ -1,6 +1,13 @@
 import { Star as FeatherStar, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Star: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherStar data-icon="star" {...rootProps} />
 );

--- a/src/icons/lined/StopCircle.tsx
+++ b/src/icons/lined/StopCircle.tsx
@@ -1,6 +1,13 @@
 import { StopCircle as FeatherStopCircle, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const StopCircle: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherStopCircle data-icon="stopcircle" {...rootProps} />
 );

--- a/src/icons/lined/Sun.tsx
+++ b/src/icons/lined/Sun.tsx
@@ -1,6 +1,13 @@
 import { Sun as FeatherSun, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Sun: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherSun data-icon="sun" {...rootProps} />
 );

--- a/src/icons/lined/Sunrise.tsx
+++ b/src/icons/lined/Sunrise.tsx
@@ -1,6 +1,13 @@
 import { Sunrise as FeatherSunrise, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Sunrise: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherSunrise data-icon="sunrise" {...rootProps} />
 );

--- a/src/icons/lined/Sunset.tsx
+++ b/src/icons/lined/Sunset.tsx
@@ -1,6 +1,13 @@
 import { Sunset as FeatherSunset, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Sunset: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherSunset data-icon="sunset" {...rootProps} />
 );

--- a/src/icons/lined/Tablet.tsx
+++ b/src/icons/lined/Tablet.tsx
@@ -1,6 +1,13 @@
 import { Tablet as FeatherTablet, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Tablet: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherTablet data-icon="tablet" {...rootProps} />
 );

--- a/src/icons/lined/Tag.tsx
+++ b/src/icons/lined/Tag.tsx
@@ -1,6 +1,13 @@
 import { Tag as FeatherTag, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Tag: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherTag data-icon="tag" {...rootProps} />
 );

--- a/src/icons/lined/Target.tsx
+++ b/src/icons/lined/Target.tsx
@@ -1,6 +1,13 @@
 import { Target as FeatherTarget, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Target: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherTarget data-icon="target" {...rootProps} />
 );

--- a/src/icons/lined/Terminal.tsx
+++ b/src/icons/lined/Terminal.tsx
@@ -1,6 +1,13 @@
 import { Terminal as FeatherTerminal, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Terminal: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherTerminal data-icon="terminal" {...rootProps} />
 );

--- a/src/icons/lined/Thermometer.tsx
+++ b/src/icons/lined/Thermometer.tsx
@@ -1,6 +1,13 @@
 import { Thermometer as FeatherThermometer, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Thermometer: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherThermometer data-icon="thermometer" {...rootProps} />
 );

--- a/src/icons/lined/ThumbsDown.tsx
+++ b/src/icons/lined/ThumbsDown.tsx
@@ -1,6 +1,13 @@
 import { ThumbsDown as FeatherThumbsDown, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const ThumbsDown: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherThumbsDown data-icon="thumbsdown" {...rootProps} />
 );

--- a/src/icons/lined/ThumbsUp.tsx
+++ b/src/icons/lined/ThumbsUp.tsx
@@ -1,6 +1,13 @@
 import { ThumbsUp as FeatherThumbsUp, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const ThumbsUp: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherThumbsUp data-icon="thumbsup" {...rootProps} />
 );

--- a/src/icons/lined/ToggleLeft.tsx
+++ b/src/icons/lined/ToggleLeft.tsx
@@ -1,6 +1,13 @@
 import { ToggleLeft as FeatherToggleLeft, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const ToggleLeft: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherToggleLeft data-icon="toggleleft" {...rootProps} />
 );

--- a/src/icons/lined/ToggleRight.tsx
+++ b/src/icons/lined/ToggleRight.tsx
@@ -1,6 +1,13 @@
 import { ToggleRight as FeatherToggleRight, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const ToggleRight: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherToggleRight data-icon="toggleright" {...rootProps} />
 );

--- a/src/icons/lined/Trash.tsx
+++ b/src/icons/lined/Trash.tsx
@@ -1,6 +1,13 @@
 import { Trash2 as FeatherTrash, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Trash: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherTrash data-icon="trash" {...rootProps} />
 );

--- a/src/icons/lined/Trello.tsx
+++ b/src/icons/lined/Trello.tsx
@@ -1,6 +1,13 @@
 import { Trello as FeatherTrello, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Trello: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherTrello data-icon="trello" {...rootProps} />
 );

--- a/src/icons/lined/TrendingDown.tsx
+++ b/src/icons/lined/TrendingDown.tsx
@@ -1,6 +1,13 @@
 import { TrendingDown as FeatherTrendingDown, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const TrendingDown: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherTrendingDown data-icon="trendingdown" {...rootProps} />
 );

--- a/src/icons/lined/TrendingUp.tsx
+++ b/src/icons/lined/TrendingUp.tsx
@@ -1,6 +1,13 @@
 import { TrendingUp as FeatherTrendingUp, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const TrendingUp: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherTrendingUp data-icon="trendingup" {...rootProps} />
 );

--- a/src/icons/lined/Triangle.tsx
+++ b/src/icons/lined/Triangle.tsx
@@ -1,6 +1,13 @@
 import { Triangle as FeatherTriangle, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Triangle: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherTriangle data-icon="triangle" {...rootProps} />
 );

--- a/src/icons/lined/Truck.tsx
+++ b/src/icons/lined/Truck.tsx
@@ -1,6 +1,13 @@
 import { Truck as FeatherTruck, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Truck: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherTruck data-icon="truck" {...rootProps} />
 );

--- a/src/icons/lined/Tv.tsx
+++ b/src/icons/lined/Tv.tsx
@@ -1,6 +1,13 @@
 import { Tv as FeatherTv, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Tv: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherTv data-icon="tv" {...rootProps} />
 );

--- a/src/icons/lined/Twitter.tsx
+++ b/src/icons/lined/Twitter.tsx
@@ -1,6 +1,13 @@
 import { Twitter as FeatherTwitter, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Twitter: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherTwitter data-icon="twitter" {...rootProps} />
 );

--- a/src/icons/lined/Type.tsx
+++ b/src/icons/lined/Type.tsx
@@ -1,6 +1,13 @@
 import { Type as FeatherType, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Type: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherType data-icon="type" {...rootProps} />
 );

--- a/src/icons/lined/Umbrella.tsx
+++ b/src/icons/lined/Umbrella.tsx
@@ -1,6 +1,13 @@
 import { Umbrella as FeatherUmbrella, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Umbrella: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherUmbrella data-icon="umbrella" {...rootProps} />
 );

--- a/src/icons/lined/Underline.tsx
+++ b/src/icons/lined/Underline.tsx
@@ -1,6 +1,13 @@
 import { Underline as FeatherUnderline, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Underline: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherUnderline data-icon="underline" {...rootProps} />
 );

--- a/src/icons/lined/Unlock.tsx
+++ b/src/icons/lined/Unlock.tsx
@@ -1,6 +1,13 @@
 import { Unlock as FeatherUnlock, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Unlock: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherUnlock data-icon="unlock" {...rootProps} />
 );

--- a/src/icons/lined/Upload.tsx
+++ b/src/icons/lined/Upload.tsx
@@ -1,6 +1,13 @@
 import { Upload as FeatherUpload, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Upload: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherUpload data-icon="upload" {...rootProps} />
 );

--- a/src/icons/lined/UploadCloud.tsx
+++ b/src/icons/lined/UploadCloud.tsx
@@ -1,6 +1,13 @@
 import { UploadCloud as FeatherUploadCloud, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const UploadCloud: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherUploadCloud data-icon="uploadcloud" {...rootProps} />
 );

--- a/src/icons/lined/User.tsx
+++ b/src/icons/lined/User.tsx
@@ -1,6 +1,13 @@
 import { User as FeatherUser, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const User: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherUser data-icon="user" {...rootProps} />
 );

--- a/src/icons/lined/UserCheck.tsx
+++ b/src/icons/lined/UserCheck.tsx
@@ -1,6 +1,13 @@
 import { UserCheck as FeatherUserCheck, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const UserCheck: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherUserCheck data-icon="usercheck" {...rootProps} />
 );

--- a/src/icons/lined/UserMinus.tsx
+++ b/src/icons/lined/UserMinus.tsx
@@ -1,6 +1,13 @@
 import { UserMinus as FeatherUserMinus, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const UserMinus: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherUserMinus data-icon="userminus" {...rootProps} />
 );

--- a/src/icons/lined/UserPlus.tsx
+++ b/src/icons/lined/UserPlus.tsx
@@ -1,6 +1,13 @@
 import { UserPlus as FeatherUserPlus, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const UserPlus: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherUserPlus data-icon="userplus" {...rootProps} />
 );

--- a/src/icons/lined/UserX.tsx
+++ b/src/icons/lined/UserX.tsx
@@ -1,6 +1,13 @@
 import { UserX as FeatherUserX, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const UserX: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherUserX data-icon="userx" {...rootProps} />
 );

--- a/src/icons/lined/Users.tsx
+++ b/src/icons/lined/Users.tsx
@@ -1,6 +1,13 @@
 import { Users as FeatherUsers, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Users: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherUsers data-icon="users" {...rootProps} />
 );

--- a/src/icons/lined/Video.tsx
+++ b/src/icons/lined/Video.tsx
@@ -1,6 +1,13 @@
 import { Video as FeatherVideo, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Video: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherVideo data-icon="video" {...rootProps} />
 );

--- a/src/icons/lined/VideoOff.tsx
+++ b/src/icons/lined/VideoOff.tsx
@@ -1,6 +1,13 @@
 import { VideoOff as FeatherVideoOff, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const VideoOff: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherVideoOff data-icon="videooff" {...rootProps} />
 );

--- a/src/icons/lined/Voicemail.tsx
+++ b/src/icons/lined/Voicemail.tsx
@@ -1,6 +1,13 @@
 import { Voicemail as FeatherVoicemail, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Voicemail: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherVoicemail data-icon="voicemail" {...rootProps} />
 );

--- a/src/icons/lined/Volume.tsx
+++ b/src/icons/lined/Volume.tsx
@@ -1,6 +1,13 @@
 import { Volume as FeatherVolume, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Volume: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherVolume data-icon="volume" {...rootProps} />
 );

--- a/src/icons/lined/Volume1.tsx
+++ b/src/icons/lined/Volume1.tsx
@@ -1,6 +1,13 @@
 import { Volume1 as FeatherVolume1, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Volume1: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherVolume1 data-icon="volume1" {...rootProps} />
 );

--- a/src/icons/lined/Volume2.tsx
+++ b/src/icons/lined/Volume2.tsx
@@ -1,6 +1,13 @@
 import { Volume2 as FeatherVolume2, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Volume2: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherVolume2 data-icon="volume2" {...rootProps} />
 );

--- a/src/icons/lined/VolumeX.tsx
+++ b/src/icons/lined/VolumeX.tsx
@@ -1,6 +1,13 @@
 import { VolumeX as FeatherVolumeX, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const VolumeX: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherVolumeX data-icon="volumex" {...rootProps} />
 );

--- a/src/icons/lined/Watch.tsx
+++ b/src/icons/lined/Watch.tsx
@@ -1,6 +1,13 @@
 import { Watch as FeatherWatch, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Watch: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherWatch data-icon="watch" {...rootProps} />
 );

--- a/src/icons/lined/Wifi.tsx
+++ b/src/icons/lined/Wifi.tsx
@@ -1,6 +1,13 @@
 import { Wifi as FeatherWifi, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Wifi: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherWifi data-icon="wifi" {...rootProps} />
 );

--- a/src/icons/lined/WifiOff.tsx
+++ b/src/icons/lined/WifiOff.tsx
@@ -1,6 +1,13 @@
 import { WifiOff as FeatherWifiOff, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const WifiOff: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherWifiOff data-icon="wifioff" {...rootProps} />
 );

--- a/src/icons/lined/Wind.tsx
+++ b/src/icons/lined/Wind.tsx
@@ -1,6 +1,13 @@
 import { Wind as FeatherWind, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Wind: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherWind data-icon="wind" {...rootProps} />
 );

--- a/src/icons/lined/X.tsx
+++ b/src/icons/lined/X.tsx
@@ -1,6 +1,13 @@
 import { X as FeatherX, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const X: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherX data-icon="x" {...rootProps} />
 );

--- a/src/icons/lined/XCircle.tsx
+++ b/src/icons/lined/XCircle.tsx
@@ -1,6 +1,13 @@
 import { XCircle as FeatherXCircle, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const XCircle: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherXCircle data-icon="xcircle" {...rootProps} />
 );

--- a/src/icons/lined/XSquare.tsx
+++ b/src/icons/lined/XSquare.tsx
@@ -1,6 +1,13 @@
 import { XSquare as FeatherXSquare, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const XSquare: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherXSquare data-icon="xsquare" {...rootProps} />
 );

--- a/src/icons/lined/Youtube.tsx
+++ b/src/icons/lined/Youtube.tsx
@@ -1,6 +1,13 @@
 import { Youtube as FeatherYoutube, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Youtube: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherYoutube data-icon="youtube" {...rootProps} />
 );

--- a/src/icons/lined/Zap.tsx
+++ b/src/icons/lined/Zap.tsx
@@ -1,6 +1,13 @@
 import { Zap as FeatherZap, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const Zap: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherZap data-icon="zap" {...rootProps} />
 );

--- a/src/icons/lined/ZapOff.tsx
+++ b/src/icons/lined/ZapOff.tsx
@@ -1,6 +1,13 @@
 import { ZapOff as FeatherZapOff, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const ZapOff: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherZapOff data-icon="zapoff" {...rootProps} />
 );

--- a/src/icons/lined/ZoomIn.tsx
+++ b/src/icons/lined/ZoomIn.tsx
@@ -1,6 +1,13 @@
 import { ZoomIn as FeatherZoomIn, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const ZoomIn: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherZoomIn data-icon="zoomin" {...rootProps} />
 );

--- a/src/icons/lined/ZoomOut.tsx
+++ b/src/icons/lined/ZoomOut.tsx
@@ -1,6 +1,13 @@
 import { ZoomOut as FeatherZoomOut, Props } from 'react-feather';
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
+
 export const ZoomOut: React.FC<Props> = ({ ...rootProps }) => (
   <FeatherZoomOut data-icon="zoomout" {...rootProps} />
 );

--- a/src/icons/linedCustom/AccessPolicy.tsx
+++ b/src/icons/linedCustom/AccessPolicy.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const AccessPolicy = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/ActivityFolder.tsx
+++ b/src/icons/linedCustom/ActivityFolder.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const ActivityFolder = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/ActivityMonitor.tsx
+++ b/src/icons/linedCustom/ActivityMonitor.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const ActivityMonitor = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/Batteries.tsx
+++ b/src/icons/linedCustom/Batteries.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const Batteries = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/CapsulePills.tsx
+++ b/src/icons/linedCustom/CapsulePills.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const CapsulePills = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/CheckFile.tsx
+++ b/src/icons/linedCustom/CheckFile.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const CheckFile = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/Checklist.tsx
+++ b/src/icons/linedCustom/Checklist.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const Checklist = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/ClearList.tsx
+++ b/src/icons/linedCustom/ClearList.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const ClearList = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/Clipboard.tsx
+++ b/src/icons/linedCustom/Clipboard.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const Clipboard = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/ClockRewind.tsx
+++ b/src/icons/linedCustom/ClockRewind.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const ClockRewind = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/CodeReview.tsx
+++ b/src/icons/linedCustom/CodeReview.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const CodeReview = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/Container.tsx
+++ b/src/icons/linedCustom/Container.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const Container = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/ControlPolicy.tsx
+++ b/src/icons/linedCustom/ControlPolicy.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const ControlPolicy = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/CornerUpRightSquare.tsx
+++ b/src/icons/linedCustom/CornerUpRightSquare.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const CornerUpRightSquare = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/CryptoKey.tsx
+++ b/src/icons/linedCustom/CryptoKey.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const CryptoKey = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/Disguise.tsx
+++ b/src/icons/linedCustom/Disguise.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const Disguise = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/Domain.tsx
+++ b/src/icons/linedCustom/Domain.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const Domain = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/DomainRecord.tsx
+++ b/src/icons/linedCustom/DomainRecord.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const DomainRecord = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/Filter.tsx
+++ b/src/icons/linedCustom/Filter.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const Filter = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/Fork.tsx
+++ b/src/icons/linedCustom/Fork.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const Fork = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/Function.tsx
+++ b/src/icons/linedCustom/Function.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const Function = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/Heart.tsx
+++ b/src/icons/linedCustom/Heart.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const Heart = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/HeartCircle.tsx
+++ b/src/icons/linedCustom/HeartCircle.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const HeartCircle = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/HeartFolder.tsx
+++ b/src/icons/linedCustom/HeartFolder.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const HeartFolder = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/HeartList.tsx
+++ b/src/icons/linedCustom/HeartList.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const HeartList = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/HeartMonitor.tsx
+++ b/src/icons/linedCustom/HeartMonitor.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const HeartMonitor = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/Heatmap.tsx
+++ b/src/icons/linedCustom/Heatmap.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const Heatmap = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/Helix.tsx
+++ b/src/icons/linedCustom/Helix.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const Helix = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/HelixAlt.tsx
+++ b/src/icons/linedCustom/HelixAlt.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const HelixAlt = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/Hook.tsx
+++ b/src/icons/linedCustom/Hook.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const Hook = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/Host.tsx
+++ b/src/icons/linedCustom/Host.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const Host = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/HostAgent.tsx
+++ b/src/icons/linedCustom/HostAgent.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const HostAgent = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/Jira.tsx
+++ b/src/icons/linedCustom/Jira.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const Jira = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/Key.tsx
+++ b/src/icons/linedCustom/Key.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const Key = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/KeyLock.tsx
+++ b/src/icons/linedCustom/KeyLock.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const KeyLock = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/Library.tsx
+++ b/src/icons/linedCustom/Library.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const Library = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/Lifeology.tsx
+++ b/src/icons/linedCustom/Lifeology.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const Lifeology = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/LightBulb.tsx
+++ b/src/icons/linedCustom/LightBulb.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const LightBulb = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/LinkBroken.tsx
+++ b/src/icons/linedCustom/LinkBroken.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const LinkBroken = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/MaxDate.tsx
+++ b/src/icons/linedCustom/MaxDate.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const MaxDate = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/MortarBoard.tsx
+++ b/src/icons/linedCustom/MortarBoard.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const MortarBoard = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/NodeMesh.tsx
+++ b/src/icons/linedCustom/NodeMesh.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const NodeMesh = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/NodeTree.tsx
+++ b/src/icons/linedCustom/NodeTree.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const NodeTree = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/OfficeBuilding.tsx
+++ b/src/icons/linedCustom/OfficeBuilding.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const OfficeBuilding = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/Oncoprint.tsx
+++ b/src/icons/linedCustom/Oncoprint.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const Oncoprint = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/PasswordPolicy.tsx
+++ b/src/icons/linedCustom/PasswordPolicy.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const PasswordPolicy = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/Planet.tsx
+++ b/src/icons/linedCustom/Planet.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const Planet = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/PlotCurve.tsx
+++ b/src/icons/linedCustom/PlotCurve.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const PlotCurve = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/PlotNeedle.tsx
+++ b/src/icons/linedCustom/PlotNeedle.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const PlotNeedle = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/PlotScatter.tsx
+++ b/src/icons/linedCustom/PlotScatter.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const PlotScatter = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/Procedure.tsx
+++ b/src/icons/linedCustom/Procedure.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const Procedure = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/Radar.tsx
+++ b/src/icons/linedCustom/Radar.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const Radar = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/Repository.tsx
+++ b/src/icons/linedCustom/Repository.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const Repository = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/ResetDate.tsx
+++ b/src/icons/linedCustom/ResetDate.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const ResetDate = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/Root.tsx
+++ b/src/icons/linedCustom/Root.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const Root = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/Run.tsx
+++ b/src/icons/linedCustom/Run.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const Run = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/Spaceship.tsx
+++ b/src/icons/linedCustom/Spaceship.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const Spaceship = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/StackedBar.tsx
+++ b/src/icons/linedCustom/StackedBar.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const StackedBar = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/Unavailable.tsx
+++ b/src/icons/linedCustom/Unavailable.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const Unavailable = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/UserKey.tsx
+++ b/src/icons/linedCustom/UserKey.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const UserKey = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/UserShield.tsx
+++ b/src/icons/linedCustom/UserShield.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const UserShield = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/UsersShield.tsx
+++ b/src/icons/linedCustom/UsersShield.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const UsersShield = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/Versions.tsx
+++ b/src/icons/linedCustom/Versions.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const Versions = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/icons/linedCustom/Webhook.tsx
+++ b/src/icons/linedCustom/Webhook.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+/**
+ * @deprecated It is recommended you use the Chromicons package directly (https://github.com/lifeomic/chromicons)
+ * instead of the icons provided by Chroma.
+ *
+ * This icon will be removed in a future version of Chroma.
+ */
 export const Webhook = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg


### PR DESCRIPTION
### Changes

- Deprecate the lined + linedCustom icons coming from Chroma in favor of using Chromicons directly.  In a future version, Chroma will also switch to using Chromicons directly internally.

**NOTE:** This should not block you from still using the icons from Chroma, it's more nudging you to use Chromicons directly instead.  We will let this bake a while before ripping these icons out and release with a proper breaking change (minor since we are still pre-1.0).

Here is what the deprecation notice will look like if you use VS Code:

<img width="833" alt="dep-notice" src="https://user-images.githubusercontent.com/8069555/121740779-990efc00-cacb-11eb-892d-43c028515e02.png">
