### PR TITLE
ColorPicker fullWidth popover

### DIFF
--- a/src/components/ColorPicker/ColorPicker.tsx
+++ b/src/components/ColorPicker/ColorPicker.tsx
@@ -186,17 +186,14 @@ export const useStyles = makeStyles(
       },
     },
     swatchButton: {
-      height: 20,
-      width: 20,
+      height: theme.pxToRem(20),
+      width: theme.pxToRem(20),
       position: 'absolute',
       right: theme.spacing(1),
       top: theme.spacing(1),
     },
     popover: {
       minWidth: 'unset',
-    },
-    popover: {
-      width: '14rem',
     },
     popoverList: {
       display: 'grid',
@@ -433,7 +430,6 @@ export const ColorPicker = React.forwardRef<HTMLInputElement, ColorPickerProps>(
           />
 
           <Popover
-            className={classes.popover}
             anchorElement={
               <ButtonUnstyled
                 className={classes.swatchButton}

--- a/src/components/ColorPicker/ColorPicker.tsx
+++ b/src/components/ColorPicker/ColorPicker.tsx
@@ -175,6 +175,9 @@ export const useStyles = makeStyles(
       height: theme.pxToRem(50),
       justifyContent: 'center',
     },
+    popover: {
+      width: '14rem',
+    },
     popoverList: {
       display: 'flex',
       flexWrap: 'wrap',
@@ -212,7 +215,7 @@ export const useStyles = makeStyles(
   { name: ColorPickerStylesKey }
 );
 
-const isValidHexColor = (color: string) => {
+export const isValidHexColor = (color: string) => {
   const hexRegex = new RegExp(/^#[0-9A-F]{6}$/i);
   const shortHandHexRegex = new RegExp(/^#([0-9A-F]{3}){1,2}$/i);
   return hexRegex.test(color) || shortHandHexRegex.test(color);
@@ -409,6 +412,7 @@ export const ColorPicker = React.forwardRef<HTMLInputElement, ColorPickerProps>(
               </ButtonUnstyled>
             }
             aria-label="Color Picker"
+            className={classes.popover}
           >
             {({ popover }: PopoverRenderProps) => (
               <>

--- a/src/components/ColorPicker/index.ts
+++ b/src/components/ColorPicker/index.ts
@@ -3,4 +3,5 @@ export {
   ColorPickerClasses,
   ColorPickerProps,
   ColorPickerStylesKey,
+  isValidHexColor,
 } from './ColorPicker';


### PR DESCRIPTION
**Changes**
- Set width on popover to prevent fullWidth ColorPickers popover from stretching
- Exported `isValidHexColor` helper function to use in PHC for form validation

**BEFORE**
![Screen Shot 2021-06-22 at 1 00 45 PM](https://user-images.githubusercontent.com/32574227/122969289-78ac3080-d35a-11eb-81f2-2e92e9b9d5f7.png)

**AFTER**
![Screen Shot 2021-06-22 at 1 03 12 PM](https://user-images.githubusercontent.com/32574227/122969282-76e26d00-d35a-11eb-8a56-736c66bdedb4.png)
