### PR TITLE
Use grid layout for ColorPicker swatches

### DIFF
--- a/src/components/ColorPicker/ColorPicker.tsx
+++ b/src/components/ColorPicker/ColorPicker.tsx
@@ -19,6 +19,7 @@ import {
   PopoverRenderProps,
 } from '../Popover';
 import { Tooltip } from '../Tooltip';
+import { fade } from '@material-ui/core/styles/colorManipulator';
 
 export const ColorPickerStylesKey = 'ChromaColorPicker';
 
@@ -170,15 +171,31 @@ export const useStyles = makeStyles(
     },
     valueDisplay: {
       alignItems: 'center',
-      borderBottom: `${theme.pxToRem(1)} solid ${theme.palette.divider}`,
       display: 'flex',
       height: theme.pxToRem(50),
       justifyContent: 'center',
+      position: 'relative',
+      '&::after': {
+        background: fade(theme.palette.common.black, 0.25),
+        bottom: 0,
+        content: `''`,
+        height: theme.pxToRem(1),
+        position: 'absolute',
+        width: '100%',
+      },
+    },
+    popover: {
+      minWidth: 'unset',
     },
     popoverList: {
-      display: 'flex',
-      flexWrap: 'wrap',
+      display: 'grid',
+      gridGap: theme.spacing(1.5),
+      gridTemplateColumns: `repeat(6, ${theme.pxToRem(20)})`,
+      margin: theme.spacing(2),
       padding: 0,
+      '& $color': {
+        margin: 0,
+      },
     },
     popoverItem: {
       padding: 0,
@@ -199,14 +216,14 @@ export const useStyles = makeStyles(
     },
     colorPosition: {
       position: 'absolute',
-      right: 10,
+      right: 0,
       top: 0,
     },
     colorCircle: {
       borderRadius: theme.pxToRem(10),
     },
     colorSquare: {
-      borderRadius: theme.pxToRem(5),
+      borderRadius: theme.pxToRem(4),
     },
   }),
   { name: ColorPickerStylesKey }
@@ -400,6 +417,7 @@ export const ColorPicker = React.forwardRef<HTMLInputElement, ColorPickerProps>(
           />
 
           <Popover
+            className={classes.popover}
             anchorElement={
               <ButtonUnstyled
                 aria-label="Pick color"


### PR DESCRIPTION
- Use grid layout for swatches
- Horizontally center swatch group within popover
- Use pseudo element for bottom border
- Right align swatch in input
- Reduce border radius of square swatch
- Remove min width of popover

BEFORE | AFTER
-- | --
<img width="396" alt="Screen Shot 2021-06-22 at 3 25 46 PM" src="https://user-images.githubusercontent.com/485903/122987342-7d7adf80-d36e-11eb-9daa-5c689c0a79d5.png"> | <img width="396" alt="Screen Shot 2021-06-22 at 3 25 19 PM" src="https://user-images.githubusercontent.com/485903/122987338-7ce24900-d36e-11eb-9df3-82f95c9c5e6b.png">
<img width="396" alt="Screen Shot 2021-06-22 at 3 26 37 PM" src="https://user-images.githubusercontent.com/485903/122987344-7e137600-d36e-11eb-8af9-14f6f5f97920.png"> | <img width="396" alt="Screen Shot 2021-06-22 at 3 27 19 PM" src="https://user-images.githubusercontent.com/485903/122987345-7e137600-d36e-11eb-84d9-8c106bffef6b.png">
