### PR TITLE
Convert PriceFormatField to use penny values

### DIFF
--- a/src/components/NumberFormat/UnitNumberFormatField.test.tsx
+++ b/src/components/NumberFormat/UnitNumberFormatField.test.tsx
@@ -351,11 +351,50 @@ test('rendering a PercentFormatField renders a UnitNumberFormatField with % unit
 
 test('rendering a PriceFormatField renders a UnitNumberFormatField with $ prefixed units', async () => {
   const onChange = jest.fn();
-  const value = 10;
+  const value = 1000;
   const view = renderWithTheme(
     <PriceFormatField value={value} onChange={onChange} />
   );
   const textfield = await view.getByRole('textbox');
   expect(textfield).toBeInTheDocument();
+  expect(textfield).toHaveAttribute('value', '$10.00');
+});
+
+test('rendering a PriceFormatField with noninteger amount of pennies throws', async () => {
+  const onChange = jest.fn();
+  const value = 1000.5;
+  expect(() =>
+    renderWithTheme(<PriceFormatField value={value} onChange={onChange} />)
+  ).toThrow();
+});
+
+test('PriceFormatField passes value as pennies to onChange', async () => {
+  const onChange = jest.fn();
+  const value = 1000;
+  const view = renderWithTheme(
+    <PriceFormatField value={value} onChange={onChange} />
+  );
+
+  const textfield = await view.getByRole('textbox');
+  fireEvent.change(textfield, { target: { value: '2' } });
+
+  expect(onChange).toHaveBeenCalled();
+  expect(onChange).toHaveBeenCalledTimes(1);
+  expect(onChange).toHaveBeenCalledWith(200);
+});
+
+test('PriceFormatField converts its min, max, and value to dollars', async () => {
+  const onChange = jest.fn();
+  const value = 1000;
+  const min = 100;
+  const max = 200;
+  const view = renderWithTheme(
+    <PriceFormatField value={value} onChange={onChange} min={min} max={max} />
+  );
+
+  const textfield = await view.getByRole('textbox');
+
+  expect(textfield).toHaveAttribute('min', '1');
+  expect(textfield).toHaveAttribute('max', '2');
   expect(textfield).toHaveAttribute('value', '$10.00');
 });

--- a/src/components/NumberFormat/UnitNumberFormatField.tsx
+++ b/src/components/NumberFormat/UnitNumberFormatField.tsx
@@ -187,6 +187,9 @@ export const PercentFormatField: React.FC<
   );
 };
 
+/**
+ * @param props All currency values are expected to be an integer amount of pennies
+ */
 export const PriceFormatField: React.FC<
   Omit<TextFieldProps, 'onChange' | 'value'> & {
     min?: number;
@@ -195,9 +198,21 @@ export const PriceFormatField: React.FC<
     onChange: (val: number) => void;
   }
 > = (props) => {
+  const { value, onChange, min, max, ...otherProps } = props;
+  if (
+    !Number.isInteger(value) ||
+    (min && !Number.isInteger(min)) ||
+    (max && !Number.isInteger(max))
+  ) {
+    throw new Error('Non-integer amount of pennies passed to PriceFormatField');
+  }
   return (
     <UnitNumberFormatField
-      {...props}
+      value={value / 100} // Value in pennies converted to dollars
+      onChange={(val) => onChange(val * 100)} // Dollar converted to expected pennies
+      min={min ? min / 100 : undefined} // Min in pennies converted to dollars
+      max={max ? max / 100 : undefined} // Max in pennies converted to dollars
+      {...otherProps}
       prefixUnits={true}
       units={'$'}
       decimalScale={2}


### PR DESCRIPTION
This changes the `PriceFormatField` props of `min`, `max`, `value`, `onChange` to deal with values in terms of integer penny amounts instead of decimal dollar amounts. The underlying `UnitNumberFormatField` still uses decimal numbers because it should be able to handle anything, but this should be hidden away when dealing with money that only ever deals with integer penny amounts.

This is motivated by a desire to standardize dealing with money using pennies, to remove confusion and the need for converting when interfacing with API's that expect penny amounts. This is technically a breaking change, but since I don't believe anyone else is using this yet, hopefully making this change now will prevent confusion in the future.