### PR TITLE
FEAT: Add chromicons and use them over internal icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,12 +28,14 @@
     }
   },
   "peerDependencies": {
+    "@lifeomic/chromicons": "^0.2.1",
     "react": "16",
     "react-dom": "16",
     "react-router-dom": ">=5.1.2"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",
+    "@lifeomic/chromicons": "^0.2.1",
     "@material-ui/types": "^5.0.1",
     "@storybook/addon-a11y": "^5.3.18",
     "@storybook/addon-actions": "^5.3.18",

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import * as React from 'react';
-import { X } from '../../icons/lined';
+import { X } from '@lifeomic/chromicons';
 import { makeStyles } from '../../styles';
 import { GetClasses } from '../../typeUtils';
 

--- a/src/components/ExpansionPanel/ExpansionPanel.tsx
+++ b/src/components/ExpansionPanel/ExpansionPanel.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import * as React from 'react';
-import { Plus } from '../../icons/lined';
+import { Plus } from '@lifeomic/chromicons';
 import { makeStyles } from '../../styles';
 import { GetClasses } from '../../typeUtils';
 import { generateUniqueId } from '../_private/UniqueId';

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -13,7 +13,7 @@ import { Portal } from 'reakit/Portal';
 import { RemoveScroll } from 'react-remove-scroll';
 import { Text } from '../Text';
 import { useForkedRef, wrapEvent } from './helpers';
-import { X } from '../../icons/lined';
+import { X } from '@lifeomic/chromicons';
 import clsx from 'clsx';
 import FocusLock from 'react-focus-lock';
 import * as React from 'react';

--- a/src/components/PrimaryNavigation/PrimaryNavigationExpansionItem.tsx
+++ b/src/components/PrimaryNavigation/PrimaryNavigationExpansionItem.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import * as React from 'react';
 import { NavLinkProps, useLocation } from 'react-router-dom';
-import { Plus } from '../../icons/lined';
+import { Plus } from '@lifeomic/chromicons';
 import { makeStyles } from '../../styles/index';
 import { GetClasses, StandardProps } from '../../typeUtils';
 import { sideBarWidthCollapsed, useLayoutManager } from '../LayoutManager';

--- a/src/components/Select/ComboBox.tsx
+++ b/src/components/Select/ComboBox.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown } from '../../icons/lined';
+import { ChevronDown } from '@lifeomic/chromicons';
 import { generateUniqueId } from '../_private/UniqueId';
 import { motion, useReducedMotion } from 'framer-motion';
 import { Portal } from 'reakit/Portal';

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -7,7 +7,7 @@ import {
   usePopoverState,
 } from 'reakit/Popover';
 import { Portal } from 'reakit/Portal';
-import { ChevronDown } from '../../icons/lined';
+import { ChevronDown } from '@lifeomic/chromicons';
 import { makeStyles } from '../../styles';
 import { GetClasses } from '../../typeUtils';
 import {

--- a/src/components/SlideOver/Header.tsx
+++ b/src/components/SlideOver/Header.tsx
@@ -2,7 +2,7 @@ import { GetClasses } from '../../typeUtils';
 import { IconButton } from '../IconButton';
 import { makeStyles } from '../../styles';
 import { Text } from '../Text';
-import { X } from '../../icons/lined';
+import { X } from '@lifeomic/chromicons';
 import * as React from 'react';
 import clsx from 'clsx';
 

--- a/src/components/Snackbar/Snackbar.tsx
+++ b/src/components/Snackbar/Snackbar.tsx
@@ -5,7 +5,7 @@ import { Text } from '../Text';
 import clsx from 'clsx';
 import * as React from 'react';
 import { IconButton } from '../IconButton';
-import { X } from '../../icons/lined';
+import { X } from '@lifeomic/chromicons';
 import { NotificationStatusType } from '../_private/notificationTypes';
 
 export const SnackbarStylesKey = 'ChromaSnackbar';

--- a/src/components/TableModule/TableHeaderCell.tsx
+++ b/src/components/TableModule/TableHeaderCell.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import * as React from 'react';
-import { ChevronDown } from '../../icons/lined';
+import { ChevronDown } from '@lifeomic/chromicons';
 import { makeStyles } from '../../styles/index';
 import { GetClasses } from '../../typeUtils';
 import { TableSortDirection, TableHeader, TableSortClickProps } from './types';

--- a/src/components/TableModule/TableModuleRow.tsx
+++ b/src/components/TableModule/TableModuleRow.tsx
@@ -7,7 +7,7 @@ import { TableModuleProps, testIds } from './TableModule';
 import { TableModuleCell } from './TableModuleCell';
 import { TableModuleActions } from './TableModuleActions';
 import { IconButton } from '../IconButton';
-import { ChevronRight } from '../../icons/lined';
+import { ChevronRight } from '@lifeomic/chromicons';
 import { Tooltip } from '../Tooltip';
 
 export interface TableModuleRowProps

--- a/yarn.lock
+++ b/yarn.lock
@@ -2056,6 +2056,11 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
+"@lifeomic/chromicons@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@lifeomic/chromicons/-/chromicons-0.2.1.tgz#7cfbab7f087ebcd53ad47d7308689d865dc576c1"
+  integrity sha512-+/RJq/ai6SfibQ/8btNlhYYh0CEASmO4xX0G4OyVfAZgVDgX3D7Ccx1+ZqaN203y4PPMpoMIsO6gdIV6UY4k9Q==
+
 "@material-ui/core@^4.9.11":
   version "4.9.11"
   resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-4.9.11.tgz#02f45f4dbea6db191fdc0d993323d64cfae613fd"


### PR DESCRIPTION
### Changes

- Use Chromicons internally instead of the now deprecated, internal icons (https://github.com/lifeomic/chroma-react/pull/143)