### PR TITLE
Adjust margins so single line of chips does not affect ComboBox height

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -205,7 +205,7 @@ export const useStyles = makeStyles(
     chipList: {
       display: 'flex',
       flexFlow: 'wrap',
-      margin: theme.spacing(0, -0.5),
+      margin: theme.spacing(-0.5, -0.5, 0),
     },
     chip: {
       alignItems: 'center',
@@ -215,7 +215,7 @@ export const useStyles = makeStyles(
       display: 'inline-block',
       height: theme.pxToRem(22),
       fontSize: theme.pxToRem(12),
-      margin: theme.spacing(0.25),
+      margin: theme.spacing(0.5, 0.25, 0),
       overflow: 'hidden',
       paddingLeft: theme.spacing(1),
       paddingRight: theme.spacing(1),


### PR DESCRIPTION
When ComboBox had a single line of chips, the height of the parent wrapper would increase by 1px once a chip(s) would appear.

**BEFORE WITHOUT CHIPS** | **BEFORE WITH CHIPS** | **AFTER WITHOUT CHIPS** | **AFTER WITH CHIPS**
-- | -- | -- | --
<img width="208" alt="Screen Shot 2021-06-25 at 11 43 55 AM" src="https://user-images.githubusercontent.com/485903/123450522-d46cf880-d5aa-11eb-8793-61980cb1ac53.png"> | <img width="208" alt="Screen Shot 2021-06-25 at 11 46 23 AM" src="https://user-images.githubusercontent.com/485903/123450706-00887980-d5ab-11eb-8c7b-757bc4284210.png"> | <img width="208" alt="Screen Shot 2021-06-25 at 11 51 12 AM" src="https://user-images.githubusercontent.com/485903/123451678-bc49a900-d5ab-11eb-9b95-d9b854c1e39e.png"> | <img width="208" alt="Screen Shot 2021-06-25 at 11 51 27 AM" src="https://user-images.githubusercontent.com/485903/123451682-bc49a900-d5ab-11eb-9363-6d9f5a716666.png">
`height: 35px` (computed) | `height: 36px` (computed) | `height: 35px` (computed) | `height: 35px` (computed)

One side effect of this change is that chips are no longer perfectly centered vertically. In other words there is one pixel more of padding at the bottom of the chip list than at the top of the chip list (as seen below). So the trade off here is the height of the `<Select` will no longer shift in height once a chip appears but the chips are no longer vertically centered. 😢 

<img width="493" alt="Screen Shot 2021-06-25 at 11 54 57 AM" src="https://user-images.githubusercontent.com/485903/123453180-36c6f880-d5ad-11eb-9120-7f1e4f925e0b.png">



