### PR TITLE
chore: add CONTRIBUTING.md to call out semantic-release requirement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Contributing
+
+Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
+
+## How can I contribute?
+
+If you're interested in contributing to Chroma, we encourage you to submit a pull request!
+
+Make sure at least one commit in your pull request matches [the conventional commits spec](https://www.conventionalcommits.org/en/v1.0.0/), so that your change
+can be versioned correctly.
+
+## Releases
+
+This project releases using [`semantic-release`](https://github.com/semantic-release/semantic-release). Merged PRs are released immediately based on commit messages matching [the conventional commits spec](https://www.conventionalcommits.org/en/v1.0.0/).


### PR DESCRIPTION
## Motivation
Addressing this feedback: https://github.com/lifeomic/chroma-react/pull/149#pullrequestreview-697569743.

How I created this file:

- Copied [the `CONTRIBUTING.md` from `phc-sdk-py`](https://github.com/lifeomic/phc-sdk-py/blob/master/CONTRIBUTING.md), another of our open-source repos.
- Slimmed it down significantly, since I wasn't sure if most of the details there applied to this repo.
- Added details about `semantic-release`.