### PR TITLE
FIX: add backgroundImage prop to PageLayout

### DIFF
--- a/src/components/PageLayout/PageLayout.test.tsx
+++ b/src/components/PageLayout/PageLayout.test.tsx
@@ -112,3 +112,23 @@ test('it renders a background when `applyBackgroundCover={true}`', async () => {
     'ChromaPageLayout-backgroundCover'
   );
 });
+
+test('it sets background-image with provided "backgroundImage"', async () => {
+  const props = getBaseProps();
+  const testId = 'backgroundImage';
+  const backgroundImage = 'myBackgroundImage';
+
+  const { findByTestId } = renderWithTheme(
+    <PageLayout
+      {...props}
+      data-testid={testId}
+      applyBackgroundCover={true}
+      backgroundImage={backgroundImage}
+    />
+  );
+
+  const root = await findByTestId(testId);
+  expect(root?.firstElementChild).toHaveStyle(
+    `background-image: url(${backgroundImage})`
+  );
+});

--- a/src/components/PageLayout/PageLayout.tsx
+++ b/src/components/PageLayout/PageLayout.tsx
@@ -69,6 +69,7 @@ export type PageLayoutClasses = GetClasses<typeof useStyles>;
 
 export interface PageLayoutProps
   extends StandardProps<HTMLDivElement, PageLayoutClasses> {
+  backgroundImage?: string;
   disclaimer?: React.ReactNode;
   headerActions?: PageHeaderProps['actions'];
   headerAlign?: PageHeaderProps['align'];
@@ -99,6 +100,7 @@ const ConditionalWrapper: React.FC<ConditionalWrapperProps> = ({
 export const PageLayout = React.forwardRef<HTMLDivElement, PageLayoutProps>(
   (
     {
+      backgroundImage,
       headerAlign = 'center',
       headerCenter,
       headerCenterClassName,
@@ -134,7 +136,18 @@ export const PageLayout = React.forwardRef<HTMLDivElement, PageLayoutProps>(
         <ConditionalWrapper
           condition={applyBackgroundCover}
           wrapper={(children: React.ReactNode) => (
-            <div className={classes.backgroundCover}>{children}</div>
+            <div
+              className={classes.backgroundCover}
+              style={
+                backgroundImage
+                  ? {
+                      backgroundImage: `url(${backgroundImage})`,
+                    }
+                  : undefined
+              }
+            >
+              {children}
+            </div>
           )}
         >
           <PageHeader

--- a/stories/components/PageLayout/applyBackground.md
+++ b/stories/components/PageLayout/applyBackground.md
@@ -21,7 +21,7 @@ import { PageLayout } from '@lifeomic/chroma-react/components/PageLayout';
 
 ### Overriding The Image
 
-To override the image, leverage the styles key:
+To override the image at the theme level, leverage the styles key:
 
 ```js
 ChromaPageLayout: {
@@ -30,6 +30,18 @@ ChromaPageLayout: {
     // any additional props to apply
   }
 }
+```
+
+To override the image for a single use, pass in backgroundImage:
+
+```jsx
+<PageLayout
+  title="Account 1"
+  applyBackgroundCover
+  backgroundImage={overrideImage}
+>
+  {/* Your content */}
+</PageLayout>
 ```
 
 ## Links


### PR DESCRIPTION
**Changes**
- Added `backgroundImage` prop to PageLayout
  - It can be overridden at a theme level but we should also allow one time overrides 