### PR TITLE
fix: increase Select maxHeight to 328px

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -184,7 +184,7 @@ export const useStyles = makeStyles(
       display: 'block',
       listStyle: 'none',
       margin: 0,
-      maxHeight: theme.pxToRem(168),
+      maxHeight: theme.pxToRem(328),
       overflowY: 'auto',
       padding: theme.spacing(1, 0),
     },


### PR DESCRIPTION
Some consumers have concerns that the `maxHeight` of the `<Select` popover is too small. There are probably a couple different ways to solve this but this seemed the most simplistic since most mobile devices are taller than 328px.

If anyone has any other ideas I'm open to other options.

The complaint we are getting is that with rating-type questions that require ten or more options, the user might think the ratings stop at four when in fact options go up to ten. 

BEFORE | AFTER
-- | --
<img width="249" alt="Screen Shot 2021-07-07 at 2 52 37 PM" src="https://user-images.githubusercontent.com/485903/124813558-05e2ae00-df33-11eb-98ae-6fa29730396b.png"> | <img width="249" alt="Screen Shot 2021-07-07 at 2 18 03 PM" src="https://user-images.githubusercontent.com/485903/124813557-054a1780-df33-11eb-91a7-f3bcc1156708.png">

