### PR TITLE
Add a default type on makeStyles

### DIFF
--- a/src/styles/makeStyles.ts
+++ b/src/styles/makeStyles.ts
@@ -3,7 +3,10 @@ import muiMakeStyles from '@material-ui/styles/makeStyles';
 import { Styles, WithStylesOptions } from '@material-ui/styles/withStyles';
 import { Theme } from './createTheme';
 
-export const makeStyles = <Props extends {}, ClassKey extends string = string>(
+export const makeStyles = <
+  Props extends {} = {},
+  ClassKey extends string = string
+>(
   styles: Styles<Theme, Props, ClassKey>,
   options?: WithStylesOptions<Theme>
 ) => {


### PR DESCRIPTION
Motivation: Typescript 4 makes the type inference on `props` more strict, and where the type of props cannot be strictly inferred, consumers must add a a type parameter to satisfy makeStyles. Some do `makeStyles<{}>(...)` `makeStyles<Record<string, string>>(...)` or `makeStyles<uknown>()` for simplicity. Adding a default type ([matching the types in mui](https://github.com/mui-org/material-ui/blob/v4.12.1/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts#L12)) makes this unnecessary for consumers upgrading to TS 4.x 