### PR TITLE
fix: Import CSS for PhoneNumberFormatField + docs

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -31,6 +31,7 @@ module.exports = {
   },
   moduleNameMapper: {
     '\\.(jpg|jpeg|png|gif|svg)$': '<rootDir>/test/imageMock.js',
+    '\\.(css)$': '<rootDir>/test/emptyMock.js',
   },
   globals: {
     'ts-jest': {

--- a/src/components/NumberFormat/PhoneNumberFormatField.tsx
+++ b/src/components/NumberFormat/PhoneNumberFormatField.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import 'react-phone-number-input/style.css';
+import * as React from 'react';
 import { TextFieldProps, TextField } from '../TextField';
 // @ts-ignore The flags module is not typed
 import flags from 'react-phone-number-input/flags';

--- a/stories/components/NumberFormat/PhoneNumberFormatField.stories.tsx
+++ b/stories/components/NumberFormat/PhoneNumberFormatField.stories.tsx
@@ -1,0 +1,25 @@
+import { Container } from '../../storyComponents/Container';
+import { PhoneNumberFormatField } from '../../../src/components/NumberFormat';
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import defaultMd from './phoneNumberFormat.md';
+
+const PhoneNumberFormatFieldStory: React.FC = () => {
+  const [text, setText] = React.useState('');
+
+  return (
+    <Container>
+      <PhoneNumberFormatField
+        label="Phone"
+        value={text}
+        onChange={(value) => setText(value)}
+      />
+    </Container>
+  );
+};
+
+storiesOf('Form Components/Phone Input', module).add(
+  'Default',
+  () => <PhoneNumberFormatFieldStory />,
+  { readme: { content: defaultMd } }
+);

--- a/stories/components/NumberFormat/phoneNumberFormat.md
+++ b/stories/components/NumberFormat/phoneNumberFormat.md
@@ -1,0 +1,85 @@
+# Phone Number Format Field
+
+An input component for entering a phone number, it extends the Chroma TextField component. Uses [react-phone-number-input](https://gitlab.com/catamphetamine/react-phone-number-input#readme).
+
+<!-- STORY -->
+
+## Import
+
+```js
+import { PhoneNumberFormatField } from '@lifeomic/chroma-react/components/NumberFormat';
+```
+
+## Usage
+
+```jsx
+<PhoneNumberFormatField
+  value=""
+  onChange={(value) => {
+    console.log(value);
+  }}
+  label="Phone"
+/>
+```
+
+### Label
+
+The label to display for the element.
+
+```jsx
+<PhoneNumberFormatField label="Name" />
+```
+
+### Placeholder
+
+The placeholder text to display.
+
+```jsx
+<PhoneNumberFormatField placeholder="Enter your phone number" />
+```
+
+### Has Error
+
+Sets an error style on the element.
+
+```jsx
+<PhoneNumberFormatField label="Phone" hasError />
+```
+
+### Error Message
+
+Caption, error text to display underneath the element when an error occurs. For
+the message to be displayed `hasError` must be set as well.
+
+```jsx
+<PhoneNumberFormatField label="Phone" hasError errorMessage="This is required!" />
+```
+
+### Disabled
+
+Applies the disabled state to the element.
+
+```jsx
+<PhoneNumberFormatField label="Phone" disabled />
+```
+
+**REMINDER:** If you use `disabled`, screenreaders will not announce the text
+inside of the TextField to the user, and will completely skip over this element.
+
+### Read Only
+
+Applies the read only state to the element.
+
+```jsx
+<PhoneNumberFormatField label="Phone" readOnly />
+```
+
+### Accessibility
+
+- Similar to `<TextField />`, as it extends that component
+- Uses a native `<select>` element for the flag input
+
+## Links
+
+- [Component Source](https://github.com/lifeomic/chroma-react/blob/master/src/components/NumberFormat/PhoneNumberFormatField.tsx)
+- [Story Source](https://github.com/lifeomic/chroma-react/blob/master/stories/components/NumberFormat/PhoneNumberFormatFieldStory.stories.tsx)

--- a/test/emptyMock.js
+++ b/test/emptyMock.js
@@ -1,0 +1,1 @@
+module.exports = {};


### PR DESCRIPTION
### Changes

- Add `import 'react-phone-number-input/style.css';` to resolve the styling issues with `<PhoneNumberFormatField />`
  - After adding this, I had to add a `moduleNameMapper` for CSS files for jest.  I created an `emptyMock`, in case we need to reuse that pattern for something else in the future.
- Wrote (brief) docs for component