### PR TITLE
fix: Add "align" to Text component

### DIFF
--- a/src/components/Text/Text.test.tsx
+++ b/src/components/Text/Text.test.tsx
@@ -178,3 +178,43 @@ test('it applies the marginBottom class when "marginBottom"', async () => {
   const root = await findByTestId(testId);
   expect(root).toHaveClass('ChromaText-marginBottom');
 });
+
+test('it renders align="center"', async () => {
+  const { findByTestId } = renderWithTheme(
+    <Text data-testid={testId} align="center">
+      test
+    </Text>
+  );
+  const root = await findByTestId(testId);
+  expect(root).toHaveClass('ChromaText-alignCenter');
+});
+
+test('it renders align="justify"', async () => {
+  const { findByTestId } = renderWithTheme(
+    <Text data-testid={testId} align="justify">
+      test
+    </Text>
+  );
+  const root = await findByTestId(testId);
+  expect(root).toHaveClass('ChromaText-alignJustify');
+});
+
+test('it renders align="left"', async () => {
+  const { findByTestId } = renderWithTheme(
+    <Text data-testid={testId} align="left">
+      test
+    </Text>
+  );
+  const root = await findByTestId(testId);
+  expect(root).toHaveClass('ChromaText-alignLeft');
+});
+
+test('it renders align="right"', async () => {
+  const { findByTestId } = renderWithTheme(
+    <Text data-testid={testId} align="right">
+      test
+    </Text>
+  );
+  const root = await findByTestId(testId);
+  expect(root).toHaveClass('ChromaText-alignRight');
+});

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -67,11 +67,24 @@ export const useStyles = makeStyles(
     marginBottom: {
       marginBottom: theme.spacing(1),
     },
+    alignCenter: {
+      textAlign: 'center',
+    },
+    alignJustify: {
+      textAlign: 'justify',
+    },
+    alignLeft: {
+      textAlign: 'left',
+    },
+    alignRight: {
+      textAlign: 'right',
+    },
   }),
   { name: TextStylesKey }
 );
 
 export interface TextOwnProps extends React.HTMLAttributes<HTMLElement> {
+  align?: 'center' | 'justify' | 'left' | 'right';
   size?:
     | 'headline'
     | 'body'
@@ -95,6 +108,7 @@ export interface TextProps extends TextOwnProps {}
 export const Text = React.forwardRef<HTMLParagraphElement, TextProps>(
   (
     {
+      align,
       children,
       className,
       color = 'default',
@@ -137,6 +151,12 @@ export const Text = React.forwardRef<HTMLParagraphElement, TextProps>(
             [classes.inverseColor]: color === 'inverse',
           },
           marginBottom && classes.marginBottom,
+          {
+            [classes.alignCenter]: align === 'center',
+            [classes.alignJustify]: align === 'justify',
+            [classes.alignLeft]: align === 'left',
+            [classes.alignRight]: align === 'right',
+          },
           className
         )}
         ref={ref}

--- a/stories/components/Text/Text.stories.tsx
+++ b/stories/components/Text/Text.stories.tsx
@@ -48,6 +48,12 @@ const TextStory: React.FunctionComponent = () => {
       <Text size="code" marginBottom>
         code text
       </Text>
+
+      <Text size="headline">Alignment</Text>
+      <Text align="center">align center</Text>
+      <Text align="left">align left</Text>
+      <Text align="right">align right</Text>
+      <Text align="justify">align justify</Text>
     </Container>
   );
 };

--- a/stories/components/Text/default.md
+++ b/stories/components/Text/default.md
@@ -40,6 +40,14 @@ The sizing options are listed above in the story.
 <Text color="inverse">body text</Text>
 ```
 
+### Align
+
+`Text` supports an `align` prop for the `text-align` CSS property.
+
+```jsx
+<Text align="center">aligned center</Text>
+```
+
 ### Set component to `<h1>`
 
 There may be cases where the text needs to be an `h1` tag. The `useH1` prop can


### PR DESCRIPTION
### Changes

- Add `align` prop to `<Text`
  - Currently only supporting the three I'm most aware of, `center`, `left`, `right`, and `justify`.  Can add more if folks use other options more frequently. https://developer.mozilla.org/en-US/docs/Web/CSS/text-align

I made this a `fix` conventional commit to do the `PATCH` version.