### PR TITLE
docs: use chromicons over internal icons

### DIFF
--- a/stories/components/Alert/Alert.stories.tsx
+++ b/stories/components/Alert/Alert.stories.tsx
@@ -18,7 +18,7 @@ import {
   Info,
   XCircle,
   X,
-} from '../../../src/icons/lined';
+} from '@lifeomic/chromicons';
 import defaultMd from './default.md';
 
 const AlertStory: React.FC = () => (

--- a/stories/components/Button/Button.stories.tsx
+++ b/stories/components/Button/Button.stories.tsx
@@ -2,7 +2,7 @@ import { boolean } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 import * as React from 'react';
 import { Button, ButtonProps } from '../../../src/components/Button';
-import { Grid } from '../../../src/icons/lined';
+import { Grid } from '@lifeomic/chromicons';
 import { Container } from '../../storyComponents/Container';
 import defaultMd from './default.md';
 

--- a/stories/components/ButtonFloat/ButtonFloat.stories.tsx
+++ b/stories/components/ButtonFloat/ButtonFloat.stories.tsx
@@ -2,7 +2,7 @@ import { boolean } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 import * as React from 'react';
 import { ButtonFloat } from '../../../src/components/ButtonFloat';
-import { Edit, Plus, ChevronDown } from '../../../src/icons/lined';
+import { Edit, Plus, ChevronDown } from '@lifeomic/chromicons';
 import { Container } from '../../storyComponents/Container';
 import defaultMd from './default.md';
 

--- a/stories/components/ButtonLink/ButtonLink.stories.tsx
+++ b/stories/components/ButtonLink/ButtonLink.stories.tsx
@@ -2,7 +2,7 @@ import { storiesOf } from '@storybook/react';
 import * as React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import { ButtonLink } from '../../../src/components/ButtonLink';
-import { Grid } from '../../../src/icons/lined';
+import { Grid } from '@lifeomic/chromicons';
 import { Container } from '../../storyComponents/Container';
 import defaultMd from './default.md';
 

--- a/stories/components/ButtonUnstyled/ButtonUnstyled.stories.tsx
+++ b/stories/components/ButtonUnstyled/ButtonUnstyled.stories.tsx
@@ -3,7 +3,7 @@ import md from './default.md';
 import { Alert, AlertBody, AlertIcon } from '../../../src/components/Alert';
 import { ButtonUnstyled } from '../../../src/components/ButtonUnstyled';
 import { Container } from '../../storyComponents/Container';
-import { Info } from '../../../src/icons/lined';
+import { Info } from '@lifeomic/chromicons';
 import { storiesOf } from '@storybook/react';
 import { Text } from '../../../src/components/Text';
 

--- a/stories/components/Divider/Divider.stories.tsx
+++ b/stories/components/Divider/Divider.stories.tsx
@@ -16,7 +16,7 @@ import {
   Link,
   Image,
   Smile,
-} from '../../../src/icons/lined';
+} from '@lifeomic/chromicons';
 
 const DividerStory: React.FC = () => (
   <>

--- a/stories/components/IconButton/IconButton.stories.tsx
+++ b/stories/components/IconButton/IconButton.stories.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react';
 import * as React from 'react';
 import { IconButton } from '../../../src/components/IconButton';
 import { Text } from '../../../src/components/Text';
-import { Edit, X } from '../../../src/icons/lined';
+import { Edit, X } from '@lifeomic/chromicons';
 import { Container } from '../../storyComponents/Container';
 import { spacing } from '../../storyStyles';
 import defaultMd from './default.md';

--- a/stories/components/IconButtonFloat/IconButtonFloat.stories.tsx
+++ b/stories/components/IconButtonFloat/IconButtonFloat.stories.tsx
@@ -2,7 +2,7 @@ import { boolean } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 import * as React from 'react';
 import { IconButtonFloat } from '../../../src/components/IconButtonFloat';
-import { Edit, Plus, X } from '../../../src/icons/lined';
+import { Edit, Plus, X } from '@lifeomic/chromicons';
 import { Container } from '../../storyComponents/Container';
 import defaultMd from './default.md';
 

--- a/stories/components/IconButtonLink/IconButtonLink.stories.tsx
+++ b/stories/components/IconButtonLink/IconButtonLink.stories.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import { IconButtonLink } from '../../../src/components/IconButtonLink';
 import { Text } from '../../../src/components/Text';
-import { Edit, X } from '../../../src/icons/lined';
+import { Edit, X } from '@lifeomic/chromicons';
 import { Container } from '../../storyComponents/Container';
 import { spacing } from '../../storyStyles';
 import defaultMd from './default.md';

--- a/stories/components/IconTile/IconTile.stories.tsx
+++ b/stories/components/IconTile/IconTile.stories.tsx
@@ -6,7 +6,7 @@ import {
   IconTileContent,
   IconTileHero,
 } from '../../../src/components/IconTile';
-import { Airplay, Droplet, Heart } from '../../../src/icons/lined';
+import { Airplay, Droplet, Heart } from '@lifeomic/chromicons';
 import { Container } from '../../storyComponents/Container';
 import { Noop } from '../../storyComponents/Noop';
 import defaultMd from './default.md';

--- a/stories/components/Icons/Icons.stories.tsx
+++ b/stories/components/Icons/Icons.stories.tsx
@@ -764,6 +764,7 @@ const AdaptiveIconsStory: React.FC = () => (
   </Container>
 );
 
+/** @deprecated */
 const LinedIconsStory: React.FC = () => (
   <Container
     containerStyles={{
@@ -778,6 +779,7 @@ const LinedIconsStory: React.FC = () => (
   </Container>
 );
 
+/** @deprecated */
 const LinedCustomIconsStory: React.FC = () => (
   <Container
     containerStyles={{

--- a/stories/components/LayoutManager/LayoutManager.stories.tsx
+++ b/stories/components/LayoutManager/LayoutManager.stories.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import { Button } from '../../../src/components/Button';
 import { IconButton } from '../../../src/components/IconButton';
-import { MoreHorizontal } from '../../../src/icons/lined';
+import { MoreHorizontal } from '@lifeomic/chromicons';
 import { Header } from '../../../src/components/Header';
 import {
   LayoutManager,

--- a/stories/components/Menu/Menu.stories.tsx
+++ b/stories/components/Menu/Menu.stories.tsx
@@ -8,7 +8,7 @@ import {
   HelpCircle,
   MoreHorizontal,
   Trash,
-} from '../../../src/icons/lined';
+} from '@lifeomic/chromicons';
 import { Container } from '../../storyComponents/Container';
 import defaultMd from './default.md';
 import menuButtonMd from './menuButton.md';

--- a/stories/components/Select/Select.stories.tsx
+++ b/stories/components/Select/Select.stories.tsx
@@ -6,7 +6,7 @@ import {
   Select,
   SelectOption,
 } from '../../../src/components/Select';
-import { HelpCircle } from '../../../src/icons/lined';
+import { HelpCircle } from '@lifeomic/chromicons';
 import { Container } from '../../storyComponents/Container';
 import { Noop } from '../../storyComponents/Noop';
 import defaultMd from './default.md';

--- a/stories/components/TableModule/TableModule.stories.tsx
+++ b/stories/components/TableModule/TableModule.stories.tsx
@@ -14,7 +14,7 @@ import {
   TableModuleActions,
   TableSortClickProps,
 } from '../../../src/components/TableModule';
-import { Share, Trash } from '../../../src/icons/lined';
+import { Share, Trash } from '@lifeomic/chromicons';
 import { Container } from '../../storyComponents/Container';
 import { Noop } from '../../storyComponents/Noop';
 import alignmentMd from './alignment.md';

--- a/stories/components/TextArea/TextArea.stories.tsx
+++ b/stories/components/TextArea/TextArea.stories.tsx
@@ -2,7 +2,7 @@ import { storiesOf } from '@storybook/react';
 import * as React from 'react';
 import { FormBox } from '../../../src/components/FormBox';
 import { TextArea } from '../../../src/components/TextArea';
-import { HelpCircle } from '../../../src/icons/lined';
+import { HelpCircle } from '@lifeomic/chromicons';
 import { Container } from '../../storyComponents/Container';
 import defaultMd from './default.md';
 

--- a/stories/components/TextField/TextField.stories.tsx
+++ b/stories/components/TextField/TextField.stories.tsx
@@ -2,7 +2,7 @@ import { storiesOf } from '@storybook/react';
 import * as React from 'react';
 import { FormBox } from '../../../src/components/FormBox';
 import { TextField } from '../../../src/components/TextField';
-import { HelpCircle } from '../../../src/icons/lined';
+import { HelpCircle } from '@lifeomic/chromicons';
 import { Container } from '../../storyComponents/Container';
 import defaultMd from './default.md';
 


### PR DESCRIPTION
### Changes

- Gearing up to strip out the icons from this library, I migrated the storybook stories from the internal icons to Chromicons