### PR TITLE
feat: add start and end adornments to TextField

### DIFF
--- a/src/components/TextField/TextField.test.tsx
+++ b/src/components/TextField/TextField.test.tsx
@@ -2,6 +2,7 @@ import { IconComponent } from '../../testUtils/IconComponent';
 import { renderWithTheme } from '../../testUtils/renderWithTheme';
 import { TextField, TextFieldProps } from './index';
 import * as React from 'react';
+import { Text } from '../Text/Text';
 
 const testId = 'TextField';
 
@@ -31,7 +32,9 @@ test('it applies the provided className', async () => {
   );
 
   const textfield = await findByTestId(testId);
-  expect(textfield?.parentElement).toHaveClass('custom-class-name');
+  expect(textfield?.parentElement?.parentElement).toHaveClass(
+    'custom-class-name'
+  );
 });
 
 test('it renders a TextField with a secondaryLabel', async () => {
@@ -181,7 +184,7 @@ test('it renders an inverse color TextField', async () => {
   const error = await findByText(/TextArea error message/);
   expect(error).toHaveClass('ChromaFormErrorMessage-inverse');
 
-  expect(textfield?.previousSibling).toHaveClass(
+  expect(textfield?.parentElement?.previousSibling).toHaveClass(
     'ChromaTextField-labelInverse'
   );
 });
@@ -248,4 +251,46 @@ test('it renders an aria-label when not provided with label', async () => {
 
   const ariaLabel = await findByLabelText(/aria-label-text/);
   expect(ariaLabel).toBeInTheDocument();
+});
+
+test('it renders startAdornment', async () => {
+  const { findByTestId } = renderWithTheme(
+    <TextField
+      label=""
+      aria-label="aria-label-text"
+      startAdornment={<Text data-testid="start-adornment">~</Text>}
+    />
+  );
+
+  const startAdornment = await findByTestId('start-adornment');
+  expect(startAdornment).toBeInTheDocument();
+});
+
+test('it renders endAdornment', async () => {
+  const { findByTestId } = renderWithTheme(
+    <TextField
+      label=""
+      aria-label="aria-label-text"
+      endAdornment={<Text data-testid="end-adornment">lb</Text>}
+    />
+  );
+
+  const endAdornment = await findByTestId('end-adornment');
+  expect(endAdornment).toBeInTheDocument();
+});
+
+test('it renders startAdornment and endAdornment', async () => {
+  const { findByTestId } = renderWithTheme(
+    <TextField
+      label=""
+      aria-label="aria-label-text"
+      startAdornment={<Text data-testid="start-adornment">~</Text>}
+      endAdornment={<Text data-testid="end-adornment">lb</Text>}
+    />
+  );
+
+  const startAdornment = await findByTestId('start-adornment');
+  expect(startAdornment).toBeInTheDocument();
+  const endAdornment = await findByTestId('end-adornment');
+  expect(endAdornment).toBeInTheDocument();
 });

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -140,6 +140,10 @@ export const useStyles = makeStyles(
         userSelect: 'none',
       },
 
+      '& a': {
+        padding: 0,
+      },
+
       '& svg': {
         color: theme.palette.black[500],
         height: theme.pxToRem(20),
@@ -152,15 +156,7 @@ export const useStyles = makeStyles(
       },
     },
     adornmentInverse: {
-      '& p': {
-        color: theme.palette.common.white,
-      },
-
-      '& svg': {
-        color: theme.palette.common.white,
-      },
-
-      '& button': {
+      '& p, & svg, & button': {
         color: theme.palette.common.white,
       },
     },
@@ -230,6 +226,8 @@ export interface TextFieldProps
   label?: BaseFormElement['label'];
   secondaryLabel?: string;
   tooltipMessage?: string;
+  // Adornment Recommended components:
+  // Icon, IconButton, IconButtonLink, or Text
   startAdornment?: React.ReactNode;
   endAdornment?: React.ReactNode;
 }

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -48,6 +48,10 @@ export const useStyles = makeStyles(
         opacity: 0.9,
       },
     },
+    inputContainer: {
+      position: 'relative',
+      width: 'fit-content',
+    },
     input: {
       backgroundColor: 'rgba(132, 137, 166, 0.15)',
       border: `1px solid transparent`,
@@ -77,7 +81,7 @@ export const useStyles = makeStyles(
         '&:focus': {
           backgroundColor: 'rgba(132, 137, 166, 0.15)',
           border: `1px solid transparent`,
-        }
+        },
       },
       '&::-webkit-input-placeholder': {
         color: theme.palette.black[400],
@@ -103,7 +107,7 @@ export const useStyles = makeStyles(
         opacity: 1,
         '&:focus': {
           backgroundColor: 'rgba(230, 231, 237, 0.1)',
-        }
+        },
       },
       '&::-webkit-input-placeholder': {
         color: 'rgba(255, 255, 255, 0.8)',
@@ -117,6 +121,58 @@ export const useStyles = makeStyles(
       '&:-moz-placeholder': {
         color: 'rgba(255, 255, 255, 0.8)',
       },
+    },
+    inputStartAdornment: {
+      paddingLeft: theme.spacing(4),
+    },
+    inputEndAdornment: {
+      paddingRight: theme.spacing(4),
+    },
+    adornment: {
+      position: 'absolute',
+
+      '& p': {
+        color: theme.palette.text.primary,
+        fontSize: theme.pxToRem(14),
+        lineHeight: 'unset',
+        margin: 0,
+        maxWidth: theme.pxToRem(20),
+        userSelect: 'none',
+      },
+
+      '& svg': {
+        color: theme.palette.black[500],
+        height: theme.pxToRem(20),
+        width: theme.pxToRem(20),
+      },
+
+      '& button': {
+        color: theme.palette.black[500],
+        padding: 0,
+      },
+    },
+    adornmentInverse: {
+      '& p': {
+        color: theme.palette.common.white,
+      },
+
+      '& svg': {
+        color: theme.palette.common.white,
+      },
+
+      '& button': {
+        color: theme.palette.common.white,
+      },
+    },
+    startAdornment: {
+      bottom: 8,
+      left: 8,
+      top: 8,
+    },
+    endAdornment: {
+      bottom: 8,
+      right: 8,
+      top: 8,
     },
     hasTrailer: {
       marginBottom: theme.spacing(0.5),
@@ -174,6 +230,8 @@ export interface TextFieldProps
   label?: BaseFormElement['label'];
   secondaryLabel?: string;
   tooltipMessage?: string;
+  startAdornment?: React.ReactNode;
+  endAdornment?: React.ReactNode;
 }
 
 export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
@@ -192,6 +250,8 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
       name,
       secondaryLabel,
       tooltipMessage,
+      startAdornment,
+      endAdornment,
       ...rootProps
     },
     ref
@@ -247,28 +307,55 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
             )}
           </label>
         )}
-        <input
-          aria-describedby={buildDescribedBy({
-            hasError,
-            hasHelpMessage: !!helpMessage,
-            uniqueId,
-          })}
-          aria-label={ariaLabel}
-          ref={ref}
-          className={clsx(
-            classes.input,
-            fullWidth && classes.inputFullWidth,
-            hasError && classes.inputError,
-            hasError && color === 'inverse' && classes.inputErrorInverse,
-            {
-              [classes.inputInverse]: color === 'inverse',
-            }
+
+        <div className={classes.inputContainer}>
+          {startAdornment && (
+            <span
+              className={clsx(
+                classes.adornment,
+                color === 'inverse' && classes.adornmentInverse,
+                classes.startAdornment
+              )}
+            >
+              {startAdornment}
+            </span>
           )}
-          type="text"
-          id={uniqueId}
-          name={name}
-          {...rootProps}
-        />
+          <input
+            aria-describedby={buildDescribedBy({
+              hasError,
+              hasHelpMessage: !!helpMessage,
+              uniqueId,
+            })}
+            aria-label={ariaLabel}
+            ref={ref}
+            className={clsx(
+              classes.input,
+              startAdornment && classes.inputStartAdornment,
+              endAdornment && classes.inputEndAdornment,
+              fullWidth && classes.inputFullWidth,
+              hasError && classes.inputError,
+              hasError && color === 'inverse' && classes.inputErrorInverse,
+              {
+                [classes.inputInverse]: color === 'inverse',
+              }
+            )}
+            type="text"
+            id={uniqueId}
+            name={name}
+            {...rootProps}
+          />
+          {endAdornment && (
+            <span
+              className={clsx(
+                classes.adornment,
+                color === 'inverse' && classes.adornmentInverse,
+                classes.endAdornment
+              )}
+            >
+              {endAdornment}
+            </span>
+          )}
+        </div>
         {helpMessage && (
           <FormHelpMessage
             color={color}

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -50,7 +50,14 @@ export const useStyles = makeStyles(
     },
     inputContainer: {
       position: 'relative',
+      minWidth: theme.pxToRem(180),
       width: 'fit-content',
+    },
+    inputContainerFullWidth: {
+      width: '100%',
+      '& $inputHasAdornment': {
+        maxWidth: 'unset',
+      },
     },
     input: {
       backgroundColor: 'rgba(132, 137, 166, 0.15)',
@@ -59,7 +66,7 @@ export const useStyles = makeStyles(
       color: theme.palette.text.primary,
       fontFamily: theme.typography.fontFamily,
       fontSize: theme.pxToRem(14),
-      minWidth: theme.pxToRem(175),
+      minWidth: theme.pxToRem(180),
       lineHeight: 1.25,
       paddingBottom: theme.spacing(1),
       paddingLeft: theme.spacing(1.25),
@@ -96,6 +103,9 @@ export const useStyles = makeStyles(
         color: theme.palette.black[400],
       },
     },
+    inputHasAdornment: {
+      maxWidth: theme.pxToRem(152),
+    },
     inputInverse: {
       backgroundColor: 'rgba(230, 231, 237, 0.1)',
       color: theme.palette.common.white,
@@ -123,10 +133,10 @@ export const useStyles = makeStyles(
       },
     },
     inputStartAdornment: {
-      paddingLeft: theme.spacing(4),
+      paddingLeft: theme.spacing(4.25),
     },
     inputEndAdornment: {
-      paddingRight: theme.spacing(4),
+      paddingRight: theme.spacing(4.25),
     },
     adornment: {
       position: 'absolute',
@@ -153,12 +163,12 @@ export const useStyles = makeStyles(
     },
     startAdornment: {
       bottom: 8,
-      left: 8,
+      left: 10,
       top: 8,
     },
     endAdornment: {
       bottom: 8,
-      right: 8,
+      right: 10,
       top: 8,
     },
     hasTrailer: {
@@ -297,7 +307,12 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
           </label>
         )}
 
-        <div className={classes.inputContainer}>
+        <div
+          className={clsx(
+            classes.inputContainer,
+            fullWidth && classes.inputContainerFullWidth
+          )}
+        >
           {startAdornment && (
             <span
               className={clsx(
@@ -319,6 +334,9 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
             ref={ref}
             className={clsx(
               classes.input,
+              startAdornment || endAdornment
+                ? classes.inputHasAdornment
+                : undefined,
               startAdornment && classes.inputStartAdornment,
               endAdornment && classes.inputEndAdornment,
               fullWidth && classes.inputFullWidth,

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -131,15 +131,6 @@ export const useStyles = makeStyles(
     adornment: {
       position: 'absolute',
 
-      '& p': {
-        color: theme.palette.text.primary,
-        fontSize: theme.pxToRem(14),
-        lineHeight: 'unset',
-        margin: 0,
-        maxWidth: theme.pxToRem(20),
-        userSelect: 'none',
-      },
-
       '& a': {
         padding: 0,
       },
@@ -156,7 +147,7 @@ export const useStyles = makeStyles(
       },
     },
     adornmentInverse: {
-      '& p, & svg, & button': {
+      '& svg, & button': {
         color: theme.palette.common.white,
       },
     },
@@ -227,7 +218,7 @@ export interface TextFieldProps
   secondaryLabel?: string;
   tooltipMessage?: string;
   // Adornment Recommended components:
-  // Icon, IconButton, IconButtonLink, or Text
+  // Icon, IconButton, or IconButtonLink
   startAdornment?: React.ReactNode;
   endAdornment?: React.ReactNode;
 }

--- a/stories/components/TextField/TextField.stories.tsx
+++ b/stories/components/TextField/TextField.stories.tsx
@@ -2,9 +2,11 @@ import { storiesOf } from '@storybook/react';
 import * as React from 'react';
 import { FormBox } from '../../../src/components/FormBox';
 import { TextField } from '../../../src/components/TextField';
-import { HelpCircle } from '@lifeomic/chromicons';
+import { HelpCircle, Lock, Mail, User } from '@lifeomic/chromicons';
 import { Container } from '../../storyComponents/Container';
 import defaultMd from './default.md';
+import { IconButton } from '../../../src/components/IconButton';
+import { Text } from '../../../src/components/Text';
 
 const AllTextFieldsStory: React.FC = () => {
   const [text, setText] = React.useState('');
@@ -67,6 +69,24 @@ const AllTextFieldsStory: React.FC = () => {
               label=""
               aria-label="Name"
             />
+            <TextField
+              startAdornment={<Text>$</Text>}
+              value={text}
+              onChange={(e) => {
+                setText(e.target.value);
+              }}
+              label=""
+              aria-label="Name"
+            />
+            <TextField
+              endAdornment={<Text>K</Text>}
+              value={text}
+              onChange={(e) => {
+                setText(e.target.value);
+              }}
+              label=""
+              aria-label="Name"
+            />
           </FormBox>
         </Container>
 
@@ -116,6 +136,24 @@ const AllTextFieldsStory: React.FC = () => {
               errorMessage="This is required!"
             />
             <TextField
+              value={text}
+              onChange={(e) => {
+                setText(e.target.value);
+              }}
+              label=""
+              aria-label="Name"
+            />
+            <TextField
+              startAdornment={<User />}
+              value={text}
+              onChange={(e) => {
+                setText(e.target.value);
+              }}
+              label=""
+              aria-label="Name"
+            />
+            <TextField
+              endAdornment={<User />}
               value={text}
               onChange={(e) => {
                 setText(e.target.value);
@@ -190,6 +228,26 @@ const AllTextFieldsStory: React.FC = () => {
               aria-label="Name"
               color="inverse"
             />
+            <TextField
+              startAdornment={<IconButton aria-label="Mail" icon={Mail} />}
+              value={text}
+              onChange={(e) => {
+                setText(e.target.value);
+              }}
+              label=""
+              aria-label="Name"
+              color="inverse"
+            />
+            <TextField
+              endAdornment={<IconButton aria-label="Mail" icon={Mail} />}
+              value={text}
+              onChange={(e) => {
+                setText(e.target.value);
+              }}
+              label=""
+              aria-label="Name"
+              color="inverse"
+            />
           </FormBox>
         </Container>
 
@@ -249,6 +307,26 @@ const AllTextFieldsStory: React.FC = () => {
               color="inverse"
             />
             <TextField
+              value={text}
+              onChange={(e) => {
+                setText(e.target.value);
+              }}
+              label=""
+              aria-label="Name"
+              color="inverse"
+            />
+            <TextField
+              startAdornment={<IconButton aria-label="Check" icon={Lock} />}
+              value={text}
+              onChange={(e) => {
+                setText(e.target.value);
+              }}
+              label=""
+              aria-label="Name"
+              color="inverse"
+            />
+            <TextField
+              endAdornment={<IconButton aria-label="Check" icon={Lock} />}
               value={text}
               onChange={(e) => {
                 setText(e.target.value);

--- a/stories/components/TextField/TextField.stories.tsx
+++ b/stories/components/TextField/TextField.stories.tsx
@@ -6,7 +6,9 @@ import { HelpCircle, Lock, Mail, User } from '@lifeomic/chromicons';
 import { Container } from '../../storyComponents/Container';
 import defaultMd from './default.md';
 import { IconButton } from '../../../src/components/IconButton';
+import { IconButtonLink } from '../../../src/components/IconButtonLink';
 import { Text } from '../../../src/components/Text';
+import { BrowserRouter } from 'react-router-dom';
 
 const AllTextFieldsStory: React.FC = () => {
   const [text, setText] = React.useState('');
@@ -315,26 +317,32 @@ const AllTextFieldsStory: React.FC = () => {
               aria-label="Name"
               color="inverse"
             />
-            <TextField
-              startAdornment={<IconButton aria-label="Check" icon={Lock} />}
-              value={text}
-              onChange={(e) => {
-                setText(e.target.value);
-              }}
-              label=""
-              aria-label="Name"
-              color="inverse"
-            />
-            <TextField
-              endAdornment={<IconButton aria-label="Check" icon={Lock} />}
-              value={text}
-              onChange={(e) => {
-                setText(e.target.value);
-              }}
-              label=""
-              aria-label="Name"
-              color="inverse"
-            />
+            <BrowserRouter>
+              <TextField
+                startAdornment={
+                  <IconButtonLink aria-label="Check" icon={Lock} to="" />
+                }
+                value={text}
+                onChange={(e) => {
+                  setText(e.target.value);
+                }}
+                label=""
+                aria-label="Name"
+                color="inverse"
+              />
+              <TextField
+                endAdornment={
+                  <IconButtonLink aria-label="Check" icon={Lock} to="" />
+                }
+                value={text}
+                onChange={(e) => {
+                  setText(e.target.value);
+                }}
+                label=""
+                aria-label="Name"
+                color="inverse"
+              />
+            </BrowserRouter>
           </FormBox>
         </Container>
       </Container>

--- a/stories/components/TextField/TextField.stories.tsx
+++ b/stories/components/TextField/TextField.stories.tsx
@@ -7,7 +7,6 @@ import { Container } from '../../storyComponents/Container';
 import defaultMd from './default.md';
 import { IconButton } from '../../../src/components/IconButton';
 import { IconButtonLink } from '../../../src/components/IconButtonLink';
-import { Text } from '../../../src/components/Text';
 import { BrowserRouter } from 'react-router-dom';
 
 const AllTextFieldsStory: React.FC = () => {
@@ -72,7 +71,7 @@ const AllTextFieldsStory: React.FC = () => {
               aria-label="Name"
             />
             <TextField
-              startAdornment={<Text>$</Text>}
+              startAdornment={<User />}
               value={text}
               onChange={(e) => {
                 setText(e.target.value);
@@ -81,7 +80,7 @@ const AllTextFieldsStory: React.FC = () => {
               aria-label="Name"
             />
             <TextField
-              endAdornment={<Text>K</Text>}
+              endAdornment={<User />}
               value={text}
               onChange={(e) => {
                 setText(e.target.value);

--- a/stories/components/TextField/default.md
+++ b/stories/components/TextField/default.md
@@ -54,6 +54,39 @@ The placeholder text to display.
 <TextField placeholder="Enter your name" />
 ```
 
+### Adornment
+
+An element that can be placed inside at the start or end of the input.
+Element should only be an Icon, IconButton, or Text.
+
+```jsx
+<TextField startAdornment={<DollarSign />} />
+```
+
+```jsx
+<TextField endAdornment={<Text>K</Text>} />
+```
+
+```jsx
+<TextField endAdornment={<IconButton icon={Check} />} />
+```
+
+If you are using the TextField adornments in a form, you will need to prevent default
+
+```jsx
+<TextField
+  endAdornment={
+    <IconButton
+      icon={Check}
+      onClick={(e) => {
+        e.preventDefault();
+        // Your other click logic here
+      }}
+    />
+  }
+/>
+```
+
 ### Full Width
 
 Makes the element take 100% of the width

--- a/stories/components/TextField/default.md
+++ b/stories/components/TextField/default.md
@@ -57,18 +57,22 @@ The placeholder text to display.
 ### Adornment
 
 An element that can be placed inside at the start or end of the input.
-Element should only be an Icon, IconButton, or Text.
+Element should only be an Icon, IconButton, IconButtonLink, or Text.
 
 ```jsx
 <TextField startAdornment={<DollarSign />} />
 ```
 
 ```jsx
-<TextField endAdornment={<Text>K</Text>} />
+<TextField startAdornment={<Text>K</Text>} />
 ```
 
 ```jsx
 <TextField endAdornment={<IconButton icon={Check} />} />
+```
+
+```jsx
+<TextField endAdornment={<IconButtonLink icon={Check} />} />
 ```
 
 If you are using the TextField adornments in a form, you will need to prevent default

--- a/stories/components/TextField/default.md
+++ b/stories/components/TextField/default.md
@@ -57,14 +57,10 @@ The placeholder text to display.
 ### Adornment
 
 An element that can be placed inside at the start or end of the input.
-Element should only be an Icon, IconButton, IconButtonLink, or Text.
+Element should only be an Icon, IconButton, or IconButtonLink.
 
 ```jsx
 <TextField startAdornment={<DollarSign />} />
-```
-
-```jsx
-<TextField startAdornment={<Text>K</Text>} />
 ```
 
 ```jsx


### PR DESCRIPTION
**Changes**
- Added `startAdornment` and `endAdornment` as new props

![Screen Shot 2021-08-06 at 7 49 26 PM](https://user-images.githubusercontent.com/32574227/128580765-5b653dc5-9196-4b4b-8849-a7f0d131f1b1.png)

![Screen Shot 2021-08-08 at 7 42 13 PM](https://user-images.githubusercontent.com/32574227/128649090-75925eda-5723-461c-a962-f560d3612872.png)

