### PR TITLE
docs: Add `aria-hidden` to adornment icons

### DIFF
--- a/stories/components/TextField/TextField.stories.tsx
+++ b/stories/components/TextField/TextField.stories.tsx
@@ -71,7 +71,7 @@ const AllTextFieldsStory: React.FC = () => {
               aria-label="Name"
             />
             <TextField
-              startAdornment={<User />}
+              startAdornment={<User aria-hidden />}
               value={text}
               onChange={(e) => {
                 setText(e.target.value);
@@ -80,7 +80,7 @@ const AllTextFieldsStory: React.FC = () => {
               aria-label="Name"
             />
             <TextField
-              endAdornment={<User />}
+              endAdornment={<User aria-hidden />}
               value={text}
               onChange={(e) => {
                 setText(e.target.value);
@@ -145,7 +145,7 @@ const AllTextFieldsStory: React.FC = () => {
               aria-label="Name"
             />
             <TextField
-              startAdornment={<User />}
+              startAdornment={<User aria-hidden />}
               value={text}
               onChange={(e) => {
                 setText(e.target.value);
@@ -154,7 +154,7 @@ const AllTextFieldsStory: React.FC = () => {
               aria-label="Name"
             />
             <TextField
-              endAdornment={<User />}
+              endAdornment={<User aria-hidden />}
               value={text}
               onChange={(e) => {
                 setText(e.target.value);

--- a/stories/components/TextField/default.md
+++ b/stories/components/TextField/default.md
@@ -60,8 +60,10 @@ An element that can be placed inside at the start or end of the input.
 Element should only be an Icon, IconButton, or IconButtonLink.
 
 ```jsx
-<TextField startAdornment={<DollarSign />} />
+<TextField startAdornment={<DollarSign aria-hidden />} />
 ```
+
+**NOTE:** When using an icon only, it's important to add `aria-hidden` so they are removed from the Accessibility Tree.
 
 ```jsx
 <TextField endAdornment={<IconButton icon={Check} />} />


### PR DESCRIPTION
### Changes

- Add `aria-hidden` to adornment icons for a11y.  Sorry, I should've caught this first time around.
  - https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-hidden_attribute
  - https://stackoverflow.com/questions/61048356/why-do-we-use-aria-hidden-with-icons
  - https://www.w3.org/WAI/GL/wiki/Using_aria-hidden%3Dtrue_on_an_icon_font_that_AT_should_ignore