### PR TITLE
fix: Remove relative position of both radio groups' root (fieldset)

### DIFF
--- a/src/components/Radio/RadioGroup.tsx
+++ b/src/components/Radio/RadioGroup.tsx
@@ -18,7 +18,6 @@ export const useStyles = makeStyles(
       margin: 0,
       minWidth: 0,
       padding: 0,
-      position: 'relative',
       verticalAlign: 'top',
       width: '100%',
     },

--- a/src/components/Radio/RadioGroupMinimal.tsx
+++ b/src/components/Radio/RadioGroupMinimal.tsx
@@ -18,7 +18,6 @@ export const useStyles = makeStyles(
       margin: 0,
       minWidth: 0,
       padding: 0,
-      position: 'relative',
       verticalAlign: 'top',
       width: '100%',
     },


### PR DESCRIPTION
When adding a `RadioGroupMinimal` to my project I noticed the text label (`<legend>`) was missing. Removing `position: relative` from the root (`<fieldset`) made the text label appear. I took a look at both `<RadioGroup` and `<RadioGroupMinimal` and from what I can tell I don't think `position: relative` is needed. Removing relative positioning didn't seem to have any visual changes in stories across Chrome, Firefox and Safari.

@ynotdraw can you confirm if we need relative positioning or not? These components are leveraging `<fieldset>` and `<legend>` so there might be something I'm missing. 

RELATIVE POSITION / LABEL HIDDEN | POSITION UNSET / LABEL VISIBLE
-- | --
<img width="1792" alt="Screen Shot 2021-09-08 at 10 18 30 AM" src="https://user-images.githubusercontent.com/485903/132526866-32b737b0-ceb9-4b12-9675-69942be3907e.png"> | <img width="1792" alt="Screen Shot 2021-09-08 at 10 18 37 AM" src="https://user-images.githubusercontent.com/485903/132526859-caf37cc6-1970-4dc1-a43c-69b584ef9b7d.png">
