### PR TITLE
feat: Add trailing icon support for button

### DIFF
--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react';
-import { IconComponent } from '../../testUtils/IconComponent';
+import {
+  IconComponent,
+  testId as iconComponentTestId,
+} from '../../testUtils/IconComponent';
 import { renderWithTheme } from '../../testUtils/renderWithTheme';
 import { Button, ButtonProps } from './index';
 
@@ -117,5 +120,17 @@ test('it renders with `variant="text" color="inverse"`', async () => {
   );
   const button = await findByTestId(testId);
   expect(button).toHaveClass('ChromaButton-textInverse');
+});
+
+test('it renders a trailing icon', async () => {
+  const props = getBaseProps();
+  const { findByTestId } = renderWithTheme(
+    <Button {...props} data-testid={testId} trailingIcon={IconComponent}>
+      Button
+    </Button>
+  );
+  const trailingIcon = await findByTestId(iconComponentTestId);
+  expect(trailingIcon).toBeInTheDocument();
+  expect(trailingIcon).toHaveClass('ChromaButton-trailingIcon');
 });
 // #endregion

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -149,6 +149,10 @@ export const useStyles = makeStyles(
       height: theme.spacing(2),
       marginRight: theme.spacing(1),
     },
+    trailingIcon: {
+      marginRight: 0,
+      marginLeft: theme.spacing(1),
+    },
   }),
   { name: ButtonStylesKey }
 );
@@ -161,6 +165,7 @@ export interface ButtonProps extends React.ComponentPropsWithoutRef<'button'> {
   fullWidth?: boolean;
   icon?: React.ComponentType<React.SVGProps<SVGSVGElement>>;
   variant?: 'contained' | 'outlined' | 'text';
+  trailingIcon?: React.ComponentType<React.SVGProps<SVGSVGElement>>;
 }
 
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
@@ -172,6 +177,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       disabled,
       fullWidth,
       icon: Icon,
+      trailingIcon: TrailingIcon,
       variant = 'contained',
       ...rootProps
     },
@@ -204,6 +210,13 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       >
         {!!Icon && <Icon role="img" aria-hidden className={classes.icon} />}
         {children}
+        {!!TrailingIcon && (
+          <TrailingIcon
+            role="img"
+            aria-hidden
+            className={clsx(classes.icon, classes.trailingIcon)}
+          />
+        )}
       </button>
     );
   }

--- a/stories/components/Button/default.md
+++ b/stories/components/Button/default.md
@@ -40,6 +40,15 @@ icon set.
 <Button icon={Edit}>Button</Button>
 ```
 
+### Trailing Icon
+
+The Button component takes a `trailingIcon` prop. This icon will be
+rendered after the text. It's recommended to use the Chromicons icon set.
+
+```jsx
+<Button trailingIcon={ChevronDown}>Button</Button>
+```
+
 ### Color
 
 When a button needs to be rendered, but on a dark-colored background, the


### PR DESCRIPTION
Adds support for icons to be placed on the right side of buttons

<img width="198" alt="Screen Shot 2021-10-06 at 10 21 15 AM" src="https://user-images.githubusercontent.com/485903/136222053-d15d2235-4a0b-45f5-bd67-446f8e7c996b.png">
<img width="771" alt="Screen Shot 2021-10-06 at 10 20 08 AM" src="https://user-images.githubusercontent.com/485903/136222049-1cec09c4-ed77-49c2-a8eb-55caefc9d513.png">


