### PR TITLE
feat: Add support for trailing icon on `<ButtonLink`

### DIFF
--- a/src/components/ButtonLink/ButtonLink.test.tsx
+++ b/src/components/ButtonLink/ButtonLink.test.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { IconComponent } from '../../testUtils/IconComponent';
+import {
+  IconComponent,
+  testId as iconComponentTestId,
+} from '../../testUtils/IconComponent';
 import { renderWithTheme } from '../../testUtils/renderWithTheme';
 import { ButtonLink, ButtonLinkProps } from './index';
 
@@ -234,4 +237,16 @@ test('it renders a disabled inverse link when disabled', async () => {
   expect(root.getAttribute('aria-disabled')).toBe('true');
   expect(root.getAttribute('role')).toBe('button');
   expect(root).toHaveClass('ChromaButtonLink-containedInverse');
+});
+
+test('it renders a trailing icon', async () => {
+  const props = getBaseProps();
+  const { findByTestId } = renderWithTheme(
+    <ButtonLink {...props} data-testid={testId} trailingIcon={IconComponent}>
+      Button
+    </ButtonLink>
+  );
+  const trailingIcon = await findByTestId(iconComponentTestId);
+  expect(trailingIcon).toBeInTheDocument();
+  expect(trailingIcon).toHaveClass('ChromaButtonLink-trailingIcon');
 });

--- a/src/components/ButtonLink/ButtonLink.tsx
+++ b/src/components/ButtonLink/ButtonLink.tsx
@@ -126,7 +126,10 @@ export const useStyles = makeStyles(
       height: theme.spacing(2),
       marginRight: theme.spacing(1),
     },
-
+    trailingIcon: {
+      marginRight: 0,
+      marginLeft: theme.spacing(1),
+    },
     disabled: {
       pointerEvents: 'none',
       color: theme.palette.grey[900],
@@ -158,6 +161,7 @@ export interface ButtonLinkProps extends LinkProps {
   disabled?: ButtonProps['disabled'];
   fullWidth?: ButtonProps['fullWidth'];
   icon?: ButtonProps['icon'];
+  trailingIcon?: React.ComponentType<React.SVGProps<SVGSVGElement>>;
   variant?: ButtonProps['variant'];
 }
 
@@ -173,6 +177,7 @@ export const ButtonLink = React.forwardRef<HTMLAnchorElement, ButtonLinkProps>(
       rel,
       target,
       to,
+      trailingIcon: TrailingIcon,
       variant,
       ...rootProps
     },
@@ -220,6 +225,13 @@ export const ButtonLink = React.forwardRef<HTMLAnchorElement, ButtonLinkProps>(
       >
         {!!Icon && <Icon role="img" aria-hidden className={classes.icon} />}
         {children}
+        {!!TrailingIcon && (
+          <TrailingIcon
+            role="img"
+            aria-hidden
+            className={clsx(classes.icon, classes.trailingIcon)}
+          />
+        )}
       </LinkOrExternalLink>
     );
   }

--- a/stories/components/ButtonLink/default.md
+++ b/stories/components/ButtonLink/default.md
@@ -62,6 +62,7 @@ The following props are available to Button Link:
 - disabled
 - fullWidth
 - icon
+- trailing Icon
 - variant
 
 ## Accessibility


### PR DESCRIPTION
<img width="198" alt="Screen Shot 2021-10-06 at 3 08 45 PM" src="https://user-images.githubusercontent.com/485903/136268906-90931e4f-3021-4ef0-9cad-055262992523.png">
