### PR TITLE
fix: Add `fullWidth` prop to `<RadioGroupMinimal`

### DIFF
--- a/src/components/Radio/RadioGroupMinimal.test.tsx
+++ b/src/components/Radio/RadioGroupMinimal.test.tsx
@@ -74,3 +74,12 @@ test('it renders an aria-label when not provided with title', async () => {
   expect(ariaLabel).toBeInTheDocument();
   expect(ariaLabel?.nodeName).toEqual('LEGEND');
 });
+
+test('it renders with the "fullWidth" prop', async () => {
+  const { findByTestId } = renderWithTheme(
+    <RadioGroupMinimal fullWidth data-testid={testId} />
+  );
+
+  const radioGroupMinimal = await findByTestId(testId);
+  expect(radioGroupMinimal).toHaveClass('ChromaRadioGroupMinimal-fullWidth');
+});

--- a/src/components/Radio/RadioGroupMinimal.tsx
+++ b/src/components/Radio/RadioGroupMinimal.tsx
@@ -12,14 +12,12 @@ export const useStyles = makeStyles(
   (theme) => ({
     root: {
       border: 0,
-      display: 'inline-flex',
       flexDirection: 'column',
       height: '100%',
       margin: 0,
       minWidth: 0,
       padding: 0,
       verticalAlign: 'top',
-      width: '100%',
     },
     legend: {
       color: theme.palette.black[800],
@@ -38,7 +36,7 @@ export const useStyles = makeStyles(
       background: 'rgba(132, 137, 166, 0.15)',
       borderRadius: theme.pxToRem(20),
       border: 'solid 1px transparent',
-      display: 'flex',
+      display: 'inline-flex',
       flexDirection: 'column',
       margin: 0,
       overflow: 'hidden',
@@ -121,7 +119,6 @@ export const useStyles = makeStyles(
     },
     directionRow: {
       flexDirection: 'row',
-      justifyContent: 'space-between',
       '& label': {
         whiteSpace: 'nowrap',
       },

--- a/src/components/Radio/RadioGroupMinimal.tsx
+++ b/src/components/Radio/RadioGroupMinimal.tsx
@@ -19,6 +19,9 @@ export const useStyles = makeStyles(
       padding: 0,
       verticalAlign: 'top',
     },
+    fullWidth: {
+      display: 'inline-flex',
+    },
     legend: {
       color: theme.palette.black[800],
       fontSize: theme.pxToRem(14),
@@ -103,6 +106,11 @@ export const useStyles = makeStyles(
         },
       },
     },
+    radiosFullWidth: {
+      '& > div': {
+        flex: 1,
+      },
+    },
     radiosInverse: {
       backgroundColor: 'rgba(230, 231, 237, 0.1)',
       '& input:checked + div': {
@@ -147,6 +155,7 @@ export interface RadioGroupMinimalProps
   background?: boolean;
   className?: string;
   direction?: 'row' | 'column';
+  fullWidth?: boolean;
   title?: string;
 }
 
@@ -157,6 +166,7 @@ export const RadioGroupMinimal: React.FC<RadioGroupMinimalProps> = ({
   color = 'default',
   children,
   direction = 'row',
+  fullWidth,
   name,
   onChange,
   value,
@@ -189,7 +199,11 @@ export const RadioGroupMinimal: React.FC<RadioGroupMinimalProps> = ({
       }}
     >
       <fieldset
-        className={clsx(classes.root, className)}
+        className={clsx(
+          classes.root,
+          fullWidth && classes.fullWidth,
+          className
+        )}
         role="radiogroup"
         {...rootProps}
       >
@@ -207,6 +221,7 @@ export const RadioGroupMinimal: React.FC<RadioGroupMinimalProps> = ({
         <div
           className={clsx(
             classes.radios,
+            fullWidth && classes.radiosFullWidth,
             {
               [classes.radiosInverse]: color === 'inverse',
             },

--- a/stories/components/Radio/Radio.stories.tsx
+++ b/stories/components/Radio/Radio.stories.tsx
@@ -300,7 +300,6 @@ const RadioMinimalStory: React.FC = () => {
           >
             <Radio value="opt1" label="Option 1" />
             <Radio value="opt2" label="Option 2" />
-            <Radio value="opt3" label="Option 3" />
           </RadioGroupMinimal>
 
           <Divider style={{ marginBottom: '1.5rem' }} />
@@ -313,9 +312,9 @@ const RadioMinimalStory: React.FC = () => {
             onChange={handleChange}
             {...getMinimalPropOptions()}
           >
+            <Radio value="opt3" label="Option 3" />
             <Radio value="opt4" label="Option 4" />
             <Radio value="opt5" label="Option 5" />
-            <Radio value="opt6" label="Option 6" />
           </RadioGroupMinimal>
         </FormBox>
       </Container>
@@ -336,9 +335,8 @@ const RadioMinimalStory: React.FC = () => {
             onChange={handleChange}
             {...getMinimalPropOptions()}
           >
+            <Radio value="opt6" label="Option 6" />
             <Radio value="opt7" label="Option 7" />
-            <Radio value="opt8" label="Option 8" />
-            <Radio value="opt9" label="Option 9" />
           </RadioGroupMinimal>
 
           <Divider style={{ marginBottom: '1.5rem' }} />
@@ -350,9 +348,9 @@ const RadioMinimalStory: React.FC = () => {
             onChange={handleChange}
             {...getMinimalPropOptions()}
           >
+            <Radio value="opt8" label="Option 8" />
+            <Radio value="opt9" label="Option 9" />
             <Radio value="opt10" label="Option 10" />
-            <Radio value="opt11" label="Option 11" />
-            <Radio value="opt12" label="Option 12" />
           </RadioGroupMinimal>
         </FormBox>
       </Container>
@@ -370,13 +368,12 @@ const RadioMinimalStory: React.FC = () => {
             title="Select an option"
             color="inverse"
             name="chroma5"
-            value="opt13"
+            value="opt11"
             onChange={handleChange}
             {...getMinimalPropOptions()}
           >
-            <Radio value="opt13" label="Option 13" />
-            <Radio value="opt14" label="Option 14" />
-            <Radio value="opt15" label="Option 15" />
+            <Radio value="opt11" label="Option 11" />
+            <Radio value="opt12" label="Option 12" />
           </RadioGroupMinimal>
 
           <Divider style={{ marginBottom: '1.5rem' }} />
@@ -386,13 +383,13 @@ const RadioMinimalStory: React.FC = () => {
             title=""
             color="inverse"
             name="chroma6"
-            value="opt16"
+            value="opt13"
             onChange={handleChange}
             {...getMinimalPropOptions()}
           >
-            <Radio value="opt16" label="Option 16" />
-            <Radio value="opt17" label="Option 17" />
-            <Radio value="opt18" label="Option 18" />
+            <Radio value="opt13" label="Option 13" />
+            <Radio value="opt14" label="Option 14" />
+            <Radio value="opt15" label="Option 15" />
           </RadioGroupMinimal>
         </FormBox>
       </Container>
@@ -410,13 +407,12 @@ const RadioMinimalStory: React.FC = () => {
             title="Select an option"
             color="inverse"
             name="chroma7"
-            value="opt19"
+            value="opt16"
             onChange={handleChange}
             {...getMinimalPropOptions()}
           >
-            <Radio value="opt19" label="Option 19" />
-            <Radio value="opt20" label="Option 20" />
-            <Radio value="opt21" label="Option 21" />
+            <Radio value="opt16" label="Option 16" />
+            <Radio value="opt17" label="Option 17" />
           </RadioGroupMinimal>
 
           <Divider style={{ marginBottom: '1.5rem' }} />
@@ -430,9 +426,9 @@ const RadioMinimalStory: React.FC = () => {
             onChange={handleChange}
             {...getMinimalPropOptions()}
           >
-            <Radio value="opt22" label="Option 22" />
-            <Radio value="opt23" label="Option 23" />
-            <Radio value="opt24" label="Option 24" />
+            <Radio value="opt18" label="Option 18" />
+            <Radio value="opt19" label="Option 19" />
+            <Radio value="opt20" label="Option 20" />
           </RadioGroupMinimal>
         </FormBox>
       </Container>

--- a/stories/components/Radio/Radio.stories.tsx
+++ b/stories/components/Radio/Radio.stories.tsx
@@ -57,6 +57,7 @@ const getMinimalPropOptions = (): RadioGroupMinimalProps => {
       },
       'row'
     ),
+    fullWidth: boolean('fullWidth', false),
   };
 };
 

--- a/stories/components/Radio/Radio.stories.tsx
+++ b/stories/components/Radio/Radio.stories.tsx
@@ -138,11 +138,7 @@ const RadioStory: React.FC = () => {
           >
             <Radio value="opt9" label="Option 9" />
             <Radio value="opt10" label="Option 10" />
-            <Radio
-              value="opt11"
-              disabled
-              label="Disabled (not selectable)"
-            />
+            <Radio value="opt11" disabled label="Disabled (not selectable)" />
             <Radio
               value="opt12"
               label="Option 12"
@@ -191,14 +187,8 @@ const RadioStory: React.FC = () => {
           >
             <Radio value="opt17" label="Option 17" />
             <Radio value="opt18" label="Option 18" />
+            <Radio value="opt19" disabled label="Disabled (not selectable)" />
             <Radio
-            
-              value="opt19"
-              disabled
-              label="Disabled (not selectable)"
-            />
-            <Radio
-            
               value="opt20"
               label="Option 20"
               helpMessage="This is some helper text."
@@ -247,12 +237,7 @@ const RadioStory: React.FC = () => {
           >
             <Radio value="opt25" label="Option 25" />
             <Radio value="opt26" label="Option 26" />
-            <Radio
-            
-              value="opt27"
-              disabled
-              label="Disabled (not selectable)"
-            />
+            <Radio value="opt27" disabled label="Disabled (not selectable)" />
             <Radio
               value="opt28"
               label="Option 28"
@@ -332,7 +317,6 @@ const RadioMinimalStory: React.FC = () => {
             <Radio value="opt5" label="Option 5" />
             <Radio value="opt6" label="Option 6" />
           </RadioGroupMinimal>
-
         </FormBox>
       </Container>
 
@@ -351,14 +335,13 @@ const RadioMinimalStory: React.FC = () => {
             value="opt7"
             onChange={handleChange}
             {...getMinimalPropOptions()}
-            >
+          >
             <Radio value="opt7" label="Option 7" />
             <Radio value="opt8" label="Option 8" />
             <Radio value="opt9" label="Option 9" />
           </RadioGroupMinimal>
 
           <Divider style={{ marginBottom: '1.5rem' }} />
-  
           <RadioGroupMinimal
             aria-label="RadioGroup with no title"
             title=""
@@ -366,7 +349,7 @@ const RadioMinimalStory: React.FC = () => {
             value="opt10"
             onChange={handleChange}
             {...getMinimalPropOptions()}
-            >
+          >
             <Radio value="opt10" label="Option 10" />
             <Radio value="opt11" label="Option 11" />
             <Radio value="opt12" label="Option 12" />
@@ -380,7 +363,7 @@ const RadioMinimalStory: React.FC = () => {
           flexFlow: 'column',
           padding: 0,
         }}
-        >
+      >
         <FormBox padding={2}>
           <RadioGroupMinimal
             aria-label="Select an option"
@@ -390,7 +373,7 @@ const RadioMinimalStory: React.FC = () => {
             value="opt13"
             onChange={handleChange}
             {...getMinimalPropOptions()}
-            >
+          >
             <Radio value="opt13" label="Option 13" />
             <Radio value="opt14" label="Option 14" />
             <Radio value="opt15" label="Option 15" />
@@ -406,7 +389,7 @@ const RadioMinimalStory: React.FC = () => {
             value="opt16"
             onChange={handleChange}
             {...getMinimalPropOptions()}
-            >
+          >
             <Radio value="opt16" label="Option 16" />
             <Radio value="opt17" label="Option 17" />
             <Radio value="opt18" label="Option 18" />
@@ -420,7 +403,7 @@ const RadioMinimalStory: React.FC = () => {
           flexFlow: 'column',
           padding: 0,
         }}
-        >
+      >
         <FormBox padding={2}>
           <RadioGroupMinimal
             aria-label="Select an option"

--- a/stories/components/Radio/radioGroupMinimal.md
+++ b/stories/components/Radio/radioGroupMinimal.md
@@ -116,6 +116,14 @@ A direction can be applied. Valid options are `row` (default) or `column`.
 <RadioGroupMinimal direction="column" />
 ```
 
+### Full Width
+
+To set the width to take 100% of the width, use the `fullWidth` prop.
+
+```jsx
+<RadioGroupMinimal fullWidth />
+```
+
 ### Class Name
 
 A class name can be provided.


### PR DESCRIPTION
Adding `fullWidth` prop so that by default `<RadioGroupMinimal` doesn't span 100% width of parent. When there was only a couple of radio options, the design looked a little wonky on account of options being spread to extreme left and right when `direction` was set to `row`.

BEFORE | AFTER (default) | AFTER (fullWidth)
-- | -- | --
<img width="295" alt="01-radio-min-before" src="https://user-images.githubusercontent.com/485903/140089813-2bb781da-6af7-4fe1-8c7c-c4438926bd6b.png"> | <img width="295" alt="02-radio-min-after-default" src="https://user-images.githubusercontent.com/485903/140089816-eff9191f-3e19-4765-a38b-b1b6b7a0d290.png"> | <img width="295" alt="03-radio-min-fullWidth" src="https://user-images.githubusercontent.com/485903/140089818-20976d83-aa36-4a7c-8fa8-286e83dbaa70.png">

**UPDATED DOCS**

<img width="656" alt="Screen Shot 2021-11-03 at 11 23 42 AM" src="https://user-images.githubusercontent.com/485903/140091054-43856237-79c6-4e69-84dd-eceea6bf55ee.png">

**UPDATED KNOBS**

`direction="row"` | `direction="column"`
-- | --
![knob-row](https://user-images.githubusercontent.com/485903/140091224-a02b99d0-0148-4a6b-bead-50afcc421975.gif) | ![knob-column](https://user-images.githubusercontent.com/485903/140091249-3033eb15-32d6-4df8-b30d-a8251ed54e32.gif)

Closes #213


