### PR TITLE
feat: add `composeEventHandlers` helper

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -12,11 +12,12 @@ import {
 import { Portal } from 'reakit/Portal';
 import { RemoveScroll } from 'react-remove-scroll';
 import { Text } from '../Text';
-import { useForkedRef, wrapEvent } from './helpers';
+import { useForkedRef } from './helpers';
 import { X } from '@lifeomic/chromicons';
 import clsx from 'clsx';
 import FocusLock from 'react-focus-lock';
 import * as React from 'react';
+import { composeEventHandlers } from '../../utils';
 
 const ariaDescribedBy = 'modal-content';
 const ariaLabelledBy = 'modal-header';
@@ -218,21 +219,32 @@ const ModalInner = React.forwardRef<HTMLDivElement, ModalProps>(
           <motion.div
             data-testid={OVERLAY_TEST_ID}
             className={clsx(classes.overlay, overlayClassName)}
-            onClick={wrapEvent(onClick, (event: React.SyntheticEvent) => {
-              if (mouseDownTarget.current === event.target) {
-                event.stopPropagation();
-                onDismiss && !disableDismissOnClickOutside && onDismiss(event);
-              }
-            })}
-            onMouseDown={wrapEvent(onMouseDown, (event: React.MouseEvent) => {
-              mouseDownTarget.current = event.target;
-            })}
-            onKeyDown={wrapEvent(onKeyDown, (event: React.KeyboardEvent) => {
-              if (event.key === 'Escape') {
-                event.stopPropagation();
-                onDismiss && onDismiss(event);
-              }
-            })}
+            onClick={composeEventHandlers([
+              onClick,
+              (event) => {
+                if (mouseDownTarget.current === event.target) {
+                  event.stopPropagation();
+                  onDismiss &&
+                    !disableDismissOnClickOutside &&
+                    onDismiss(event);
+                }
+              },
+            ])}
+            onMouseDown={composeEventHandlers([
+              onMouseDown,
+              (event) => {
+                mouseDownTarget.current = event.target;
+              },
+            ])}
+            onKeyDown={composeEventHandlers([
+              onKeyDown,
+              (event) => {
+                if (event.key === 'Escape') {
+                  event.stopPropagation();
+                  onDismiss && onDismiss(event);
+                }
+              },
+            ])}
             ref={thisRef}
             positionTransition
             initial={{ opacity: 0 }}
@@ -312,9 +324,12 @@ const Content = React.forwardRef<HTMLDivElement, ModalProps>(
         aria-describedby={ariaDescribedBy}
         aria-labelledby={ariaLabelledBy}
         tabIndex={-1}
-        onClick={wrapEvent(onClick, (event: any) => {
-          event.stopPropagation();
-        })}
+        onClick={composeEventHandlers([
+          onClick,
+          (event) => {
+            event.stopPropagation();
+          },
+        ])}
         ref={ref}
         variants={poseVariants}
         initial={shouldReduceMotion ? {} : 'init'}
@@ -404,9 +419,12 @@ const FullScreenContent = React.forwardRef<HTMLDivElement, ModalProps>(
         aria-describedby={ariaDescribedBy}
         aria-labelledby={ariaLabelledBy}
         tabIndex={-1}
-        onClick={wrapEvent(onClick, (event: any) => {
-          event.stopPropagation();
-        })}
+        onClick={composeEventHandlers([
+          onClick,
+          (event) => {
+            event.stopPropagation();
+          },
+        ])}
         ref={ref}
         initial={{ opacity: 0 }}
         animate={{

--- a/src/components/Modal/helpers.ts
+++ b/src/components/Modal/helpers.ts
@@ -1,5 +1,9 @@
 import * as React from 'react';
 
+/**
+ * @deprecated Use `composeEventHandlers(...)` instead.
+ */
+/* istanbul ignore next */
 export function wrapEvent(theirHandler: any, ourHandler: any) {
   return (event: any) => {
     theirHandler && theirHandler(event);

--- a/src/utils/event-handlers.ts
+++ b/src/utils/event-handlers.ts
@@ -1,0 +1,26 @@
+/**
+ * Composes a series of `handlers` into a single handler. Subsequent handlers
+ * will not be invoked after a handler calls `e.preventDefault()`.
+ *
+ * Useful for allowing external overriding of internal event handlers in
+ * a component.
+ *
+ * @example
+ * <div
+ *   onClick={
+ *     composeEventHandlers([
+ *       props.onClick,
+ *       (e) => { ... }
+ *     ])
+ *   }
+ * />
+ */
+export const composeEventHandlers = <Event extends React.SyntheticEvent>(
+  handlers: (((e: Event) => void) | undefined)[]
+) => (e: Event) => {
+  for (const handler of handlers) {
+    if (handler && !e.defaultPrevented) {
+      handler(e);
+    }
+  }
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,2 @@
 export { warning } from './warning';
+export * from './event-handlers';


### PR DESCRIPTION
**Note**: This PR depends on #216.

## Motivation
Consolidating the event handlers "forwarding" behavior shared by `DayPicker` and `Modal` into a single `composeEventHandlers` helper.

I put this in a more conspicuous import path, since I thought it might be useful to external consumers.

Also, deprecated (and `istanbul ignored`) the internal `wrapEvent` helper from `Modal`.