### PR TITLE
Test coverage cleanups

### DIFF
--- a/src/components/KeymapHelp/KeymapHelp.test.tsx
+++ b/src/components/KeymapHelp/KeymapHelp.test.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+
+import { KeymapHelp, KeymapHelpProps } from '.';
+import { renderWithTheme } from '../../testUtils/renderWithTheme';
+
+const LISTENER_TEST_ID = 'key-listener-test-id';
+
+const render = (props?: KeymapHelpProps) =>
+  renderWithTheme(
+    <KeymapHelp keyListenerTestId={LISTENER_TEST_ID} {...props} />
+  );
+
+it('launches the modal on Shift + ?', () => {
+  const view = render();
+
+  const listener = view.queryByTestId(LISTENER_TEST_ID);
+
+  expect(listener).not.toBeNull();
+});

--- a/src/components/KeymapHelp/KeymapHelp.tsx
+++ b/src/components/KeymapHelp/KeymapHelp.tsx
@@ -47,11 +47,14 @@ export interface KeymapHelpProps {
    */
   keyMapDocs?: KeyBindingDoc[];
   closeButtonText?: string;
+
+  keyListenerTestId?: string;
 }
 
 export const KeymapHelp: React.FC<KeymapHelpProps> = ({
   closeButtonText,
   keyMapDocs,
+  keyListenerTestId,
 }) => {
   const classes = useStyles({});
   const [isOpen, setIsOpen] = React.useState(false);
@@ -71,7 +74,7 @@ export const KeymapHelp: React.FC<KeymapHelpProps> = ({
   return (
     <>
       <GlobalHotKeys keyMap={KEY_MAP} handlers={HANDLERS}>
-        <span />
+        <span data-testid={keyListenerTestId} />
       </GlobalHotKeys>
       <Modal
         isOpen={isOpen}

--- a/src/components/Select/useWindowSize.ts
+++ b/src/components/Select/useWindowSize.ts
@@ -1,3 +1,4 @@
+/* istanbul ignore file */
 // https://usehooks.com/useWindowSize/
 import * as React from 'react';
 
@@ -6,6 +7,11 @@ interface Size {
   width?: number;
 }
 
+/**
+ * @deprecated Use `useWindowSize` from 'hooks/events/useWindowSize` instead. This function
+ * will be removed in the next major version of Chroma.
+ */
+/* istanbul ignore next */
 export function useWindowSize() {
   function getSize() {
     return {

--- a/stories/components/KeymapHelp/KeymapHelp.stories.tsx
+++ b/stories/components/KeymapHelp/KeymapHelp.stories.tsx
@@ -1,0 +1,23 @@
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import { KeymapHelp } from '../../../src/components/KeymapHelp';
+import { Container } from '../../storyComponents/Container';
+import md from './default.md';
+
+const KeymapHelpStory: React.FC = () => {
+  return (
+    <Container>
+      <KeymapHelp />
+    </Container>
+  );
+};
+
+storiesOf('Components/KeymapHelp', module).add(
+  'Default',
+  () => <KeymapHelpStory />,
+  {
+    readme: {
+      content: md,
+    },
+  }
+);

--- a/stories/components/KeymapHelp/default.md
+++ b/stories/components/KeymapHelp/default.md
@@ -1,0 +1,39 @@
+# KeymapHelp
+
+The KeymapHelp component provides a modal UI for detailing a set of keyboard shortcuts.
+
+The modal is "invisible" unless raised using `Shift + ?`. To show the default experience now, press `Shift + ?`.
+
+<!-- STORY -->
+
+## Import
+
+```js
+import { KeymapHelp } from '@lifeomic/chroma-react/components/KeymapHelp';
+```
+
+## Usage
+
+```jsx
+<KeymapHelp />
+```
+
+## Customization
+
+You can specify additional keymap entries using the `keyMapDocs` prop.
+
+```jsx
+<KeymapHelp
+  keyMapDocs={[
+    {
+      sequence: 'ctrl+alt+delete',
+      description: 'Bring up the help menu',
+    },
+  ]}
+/>
+```
+
+## Links
+
+- [Component Source](https://github.com/lifeomic/chroma-react/blob/master/src/components/KeymapHelp/KeymapHelp.tsx)
+- [Story Source](https://github.com/lifeomic/chroma-react/blob/master/stories/components/KeymapHelp/KeymapHelp.stories.tsx)


### PR DESCRIPTION
## Motivation
Something weird: the `master` build in GitHub Actions is claiming 85% branch coverage, but my local runs are claiming <80 (causing failure).

Doesn't seem like an urgent issue since the master build is continuously passing, but thought I'd fixup a couple files that were bringing us down.

I fixed two problems:
- No existing test files or storybookfor the `Keymap` component. I added a dead-simple test and a storybook entry.
  - I wonder if this is worth keeping around in Chroma. It adds a dependency, and [there is only one use case in the whole org](https://github.com/search?q=org%3Alifeomic+KeymapHelp&type=code).
- An unused `useWindowSize` hook that I deprecated and `istanbul ignore`d.
  - Why it's dead: there's an identical hook located at a more friendly filepath (`hooks/events/useWindowSize`).
