### PR TITLE
Add an onError handler to avatar img

### DIFF
--- a/src/components/Avatar/Avatar.test.tsx
+++ b/src/components/Avatar/Avatar.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { act } from 'react-dom/test-utils';
 import { renderWithTheme } from '../../testUtils/renderWithTheme';
 import { Avatar, AvatarBadge, AvatarProps } from './index';
 
@@ -52,6 +53,36 @@ test('it renders the "src"', async () => {
   const imgTag = await findByAltText(props.name);
   expect(imgTag).toBeInTheDocument();
   expect(imgTag.getAttribute('src')).toEqual('cool-tony.jpg');
+});
+
+test('it renders with initials when src fails', async () => {
+  const props = getBaseProps();
+  const onError = jest.fn();
+  const { findByAltText, queryByAltText, findByText } = renderWithTheme(
+    <Avatar
+      {...props}
+      data-testid={testId}
+      src="uncool-tony.jpg"
+      onError={onError}
+    />
+  );
+  const imgTag = await findByAltText(props.name);
+  expect(imgTag).toBeInTheDocument();
+  expect(imgTag.getAttribute('src')).toEqual('uncool-tony.jpg');
+  const error = new Event('error');
+
+  act(() => {
+    imgTag.dispatchEvent(error);
+  });
+
+  const imgTagAfterUpdate = queryByAltText(props.name);
+  expect(imgTagAfterUpdate).toBeNull();
+  // can't assert it was called with the right error due to synthetic events
+  // not being trusted
+  expect(onError).toHaveBeenCalledTimes(1);
+
+  const initials = await findByText('T'); // initial
+  expect(initials).toBeInTheDocument();
 });
 
 //#region useDefaultSrc checks

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -71,6 +71,7 @@ export interface AvatarProps extends React.ComponentPropsWithoutRef<'div'> {
   size?: 0 | 1 | 2;
   src?: string;
   useDefaultSrc?: boolean;
+  onError?: React.ReactEventHandler<HTMLImageElement>;
 }
 
 const getInitials = (name: string) => {
@@ -93,11 +94,23 @@ export const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>(
       size = 1,
       src,
       useDefaultSrc = false,
+      onError: bubbleError,
       ...rootProps
     },
     ref
   ) => {
     const classes = useStyles({});
+
+    const [error, setError] = React.useState(false);
+
+    const onError: React.ReactEventHandler<HTMLImageElement> = (error) => {
+      setError(true);
+      bubbleError && bubbleError(error);
+    };
+
+    React.useEffect(() => {
+      setError(false);
+    }, [src]);
 
     // We need to be *super* careful to not display any self identifying information
     // (name or image src) if "useDefaultSrc" is provided.  This will ensure
@@ -123,9 +136,9 @@ export const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>(
         tabIndex={onClick ? 0 : undefined}
         {...rootProps}
       >
-        {!src && !useDefaultSrc ? getInitials(name) : null}
-        {src && !useDefaultSrc && (
-          <img className={classes.img} src={src} alt={name} />
+        {(error || !src) && !useDefaultSrc ? getInitials(name) : null}
+        {src && !error && !useDefaultSrc && (
+          <img onError={onError} className={classes.img} src={src} alt={name} />
         )}
         {useDefaultSrc && (
           <svg

--- a/stories/components/Avatar/Avatar.stories.tsx
+++ b/stories/components/Avatar/Avatar.stories.tsx
@@ -53,6 +53,9 @@ const AvatarImageStory: React.FC = () => (
       onClick={console.log}
       useDefaultSrc
     />
+    <Avatar size={0} src={'/some-error-path.jpg'} name="Lego Man" />
+    <Avatar size={1} src={'/some-error-path.jpg'} name="Lego Man" />
+    <Avatar size={2} src={'/some-error-path.jpg'} name="Lego Man" />
   </Container>
 );
 

--- a/stories/components/Avatar/default.md
+++ b/stories/components/Avatar/default.md
@@ -32,6 +32,19 @@ import tonypicture from './tonypic.jpg';
 <Avatar src={tonypicture} name="Tony" />;
 ```
 
+#### onError
+
+An onError handler can be added to capture errors loading the `src` image. By
+default, when a `src` fails to load, the avatar will fallback to initials.
+
+```jsx
+<Avatar
+  src={someImageThatMightFail}
+  name="Tony"
+  onError={handleAvatarImageError}
+/>
+```
+
 ### Use Default Source (Masking Information)
 
 This prop is leveraged when the information about the user needs to be "masked".


### PR DESCRIPTION
### Motivation:

Sometimes, avatar images fail to load, and causes layout issues.

Example: 
![image](https://user-images.githubusercontent.com/833911/140943409-f26d56cd-5fd4-4f39-9f68-fc348814d4d7.png)

This `img` src fails to load because it's set to my google profile image, but my cookie for google auth has expired. It causes overflow and horizontal scroll on the whole page. 

### Solution:

Just emit an error to consumer (if they want it) and fallback to initials, hiding the failed `img` tag. 

![image](https://user-images.githubusercontent.com/833911/140943766-63b29cfb-aa16-4f6c-ad43-07e403a366c4.png)


![image](https://user-images.githubusercontent.com/833911/140943805-d67e126a-b3f5-4d2a-9da4-a165cea1ae08.png)


