### PR TITLE
fix: add min/max support to DayPicker

### DIFF
--- a/src/components/DayPicker/DayPicker.tsx
+++ b/src/components/DayPicker/DayPicker.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react';
 import clsx from 'clsx';
 
-import ReactDayPicker, { LocaleUtils } from 'react-day-picker';
+import ReactDayPicker, {
+  DayPickerProps as ReactDayPickerProps,
+  LocaleUtils,
+} from 'react-day-picker';
 import 'react-day-picker/lib/style.css';
 import { Calendar, ChevronLeft, ChevronRight } from '@lifeomic/chromicons';
 
@@ -148,6 +151,15 @@ export type DayPickerProps = Omit<TextFieldProps, 'value' | 'onChange'> & {
   };
 
   /**
+   * Props to spread into the internal day picker.
+   *
+   * IMPORTANT: Props provided via this object take priority over internally
+   * specified props. Defining some values may cause the component to behave
+   * unusually.
+   */
+  calendarProps?: Partial<ReactDayPickerProps>;
+
+  /**
    * Called when a day is selected in the calendar UI or a valid
    * date string is entered manually.
    */
@@ -215,6 +227,7 @@ export const DayPicker = React.forwardRef<HTMLInputElement, DayPickerProps>(
       minDate,
       maxDate,
       ariaLabelOverrides,
+      calendarProps,
       onDayChange,
       onTextChange,
       disableDay,
@@ -444,6 +457,7 @@ export const DayPicker = React.forwardRef<HTMLInputElement, DayPickerProps>(
               formatWeekdayShort,
             }}
             onBlur={onBlur}
+            {...calendarProps}
           />
         )}
       </div>

--- a/stories/components/DayPicker/DayPicker.stories.tsx
+++ b/stories/components/DayPicker/DayPicker.stories.tsx
@@ -85,6 +85,13 @@ const DayPickerStory: React.FC = () => {
               parseDate={parser('M/D/YYYY')}
               disabled
             />
+            <PickerWithInternalState
+              fullWidth
+              label={'With Minimum Date'}
+              initialValue={new Date()}
+              parseDate={parser('M/D/YYYY')}
+              minDate={new Date()}
+            />
           </FormBox>
         </Container>
 
@@ -117,6 +124,14 @@ const DayPickerStory: React.FC = () => {
               fullWidth
               label={'With Error Message'}
               initialValue={new Date()}
+            />
+            <PickerWithErrorHandling
+              color={'inverse'}
+              fullWidth
+              label={'With Max Date'}
+              initialValue={new Date()}
+              parseDate={parser('M/D/YYYY')}
+              maxDate={new Date()}
             />
           </FormBox>
         </Container>

--- a/stories/components/DayPicker/default.md
+++ b/stories/components/DayPicker/default.md
@@ -98,6 +98,28 @@ const [errorMessage, setErrorMessage] = React.useState(false);
 />
 ```
 
+### Min/Max Dates and Disabling
+
+Min/max dates can be set via `minDate` and `maxDate`.
+
+More customized disabling can be done via `disableDay`.
+
+```jsx
+const [errorMessage, setErrorMessage] = React.useState(false);
+
+<DayPicker
+  label="Date"
+  value={date}
+  onDayChange={setDate}
+  // Disables dates before today
+  minDate={new Date()}
+  // Disables dates after today
+  maxDate={new Date()}
+  // Disables every even-numbered day
+  disableDay={(date) => date.getDate() % 2 === 0}
+/>;
+```
+
 ### Positioning
 
 Custom anchor positioning can be done via `anchorPosition`.


### PR DESCRIPTION
## Motivation
Two:
1. Adding a mechanism to specify a min/max date, as well as selectively disabling dates arbitrarily.
2. Allow specifying arbitrary props to the internal day picker, to allow more flexible customization.

## Behavior
![2021-11-11 14 39 27](https://user-images.githubusercontent.com/14932834/141358842-059f7af1-f407-4663-b352-bcf0cde2acaa.gif)
