### PR TITLE
fix: open day picker to currrently selected month by default

### DIFF
--- a/src/components/DayPicker/DayPicker.tsx
+++ b/src/components/DayPicker/DayPicker.tsx
@@ -412,6 +412,7 @@ export const DayPicker = React.forwardRef<HTMLInputElement, DayPickerProps>(
             modifiers={{
               selected: value,
             }}
+            initialMonth={value}
             disabledDays={isDayDisabled}
             modifiersStyles={{
               selected: {


### PR DESCRIPTION
Master build is failing since its a new month and the calendar isn't opening to the selected month by default. I'm guessing this was the expected behavior judging from the tests.