### PR TITLE
fix: Center align text in `<ButtonLink`

### DIFF
--- a/src/components/ButtonLink/ButtonLink.tsx
+++ b/src/components/ButtonLink/ButtonLink.tsx
@@ -34,6 +34,7 @@ export const useStyles = makeStyles(
       paddingRight: theme.pxToRem(11),
       paddingTop: theme.pxToRem(7),
       position: 'relative',
+      textAlign: 'center',
       textDecoration: 'none',
       textOverflow: 'ellipsis',
       transition:


### PR DESCRIPTION
BEFORE | AFTER
-- | --
<img width="342" alt="Screen Shot 2021-12-16 at 9 44 41 AM" src="https://user-images.githubusercontent.com/485903/146393094-6552b1e5-9b4c-42ed-81b2-18373689afa5.png"> | <img width="342" alt="Screen Shot 2021-12-16 at 9 42 14 AM" src="https://user-images.githubusercontent.com/485903/146393111-3eea3f99-a65e-43e7-ba82-474a2a43e558.png">

Closes #234 