### PR TITLE
feat: Add flexChildren prop

### DIFF
--- a/src/components/Box/Box.test.tsx
+++ b/src/components/Box/Box.test.tsx
@@ -146,6 +146,14 @@ test('it renders a Box with flexWrap', async () => {
   expect(root).toHaveClass('ChromaBox-flexWrap');
 });
 
+test('it renders a Box with flexChildren', async () => {
+  const { findByTestId } = renderWithTheme(
+    <Box flexChildren data-testid={testId} />
+  );
+  const root = await findByTestId(testId);
+  expect(root).toHaveClass('ChromaBox-flexChildren');
+});
+
 test('it renders a Box with combined props', async () => {
   const { findByTestId } = renderWithTheme(
     <Box
@@ -190,6 +198,7 @@ test('it renders a Box with combined CSS props', async () => {
       bgColor="primary.main"
       data-testid={testId}
       flexWrap
+      flexChildren
     />
   );
   const root = await findByTestId(testId);
@@ -214,4 +223,5 @@ test('it renders a Box with combined CSS props', async () => {
   expect(root).toHaveClass('ChromaBox-color');
   expect(root).toHaveClass('ChromaBox-bgColor');
   expect(root).toHaveClass('ChromaBox-flexWrap');
+  expect(root).toHaveClass('ChromaBox-flexChildren');
 });

--- a/src/components/Box/Box.tsx
+++ b/src/components/Box/Box.tsx
@@ -16,6 +16,7 @@ export interface BoxProps
   > {
   ref?: React.Ref<HTMLDivElement>;
   className?: string;
+  flexChildren?: boolean;
   flexWrap?: boolean;
   align?:
     | 'stretch'
@@ -89,6 +90,11 @@ export const useStyles = makeStyles<BoxProps>(
       alignBaseline: { alignItems: 'baseline' },
       alignCenter: { alignItems: 'center' },
       alignStart: { alignItems: 'start' },
+      flexChildren: {
+        '& > *': {
+          flex: 1,
+        },
+      },
       flexWrap: { flexWrap: 'wrap' },
       alignFlexStart: { alignItems: 'flex-start' },
       alignEnd: { alignItems: 'end' },
@@ -165,6 +171,7 @@ export const Box = React.forwardRef<HTMLDivElement, BoxProps>((props, ref) => {
     children,
     align,
     direction,
+    flexChildren,
     flexWrap,
     gap,
     justify,
@@ -200,6 +207,9 @@ export const Box = React.forwardRef<HTMLDivElement, BoxProps>((props, ref) => {
       ref={ref}
       className={clsx(
         classes.root,
+        {
+          [classes.flexChildren]: flexChildren,
+        },
         {
           [classes.flexWrap]: flexWrap,
         },

--- a/stories/components/Box/Box.stories.tsx
+++ b/stories/components/Box/Box.stories.tsx
@@ -14,6 +14,8 @@ const containerGroup = 'Container Box';
 const BoxStory: React.FC = () => {
   const [itemBoxes, setItemBoxes] = React.useState([null, null, null]);
 
+  const flexChildren = boolean('flexChildren', false, containerGroup);
+
   const direction = select(
     'direction',
     { undefined: undefined, 'row (default)': 'row', column: 'column' },
@@ -83,6 +85,7 @@ const BoxStory: React.FC = () => {
           direction={direction}
           align={align}
           justify={justify}
+          flexChildren={flexChildren}
           height={height}
           width={width}
           fullHeight={fullHeight}

--- a/stories/components/Box/default.md
+++ b/stories/components/Box/default.md
@@ -122,6 +122,22 @@ CSS.
 
 ---
 
+### Flex Children
+
+All direct children of `<Box` will flex to fill the height and width of parent.
+This provides a quick way to fill parent container with child content without
+the need to manipulate any child props.
+
+```jsx
+<Box fullHeight fullWidth flexChildren>
+  <p>Flex to fill height and width of parent</p>
+  <p>Flex to fill height and width of parent</p>
+  <p>Flex to fill height and width of parent</p>
+</Box>
+```
+
+---
+
 ### Color
 
 Color props take a string dot notation to the theme palette properties, or are


### PR DESCRIPTION
I find myself declaring `'& > *': { flex: 1 }` a lot with `<Box` to make children fill parent container so I thought of adding this prop as a quick way to accomplish this.

### AFTER

https://user-images.githubusercontent.com/485903/151193473-518ddc0b-46f1-4c5c-94f5-22832ce1350a.mov

<img width="655" alt="flex-children-docs" src="https://user-images.githubusercontent.com/485903/151193711-d7c16620-7ed1-4ec5-a506-95624adc6f96.png">

Closes #242 