### PR TITLE
fix: `<RadioGroupMinimal` tooltip display

### DIFF
--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -117,6 +117,7 @@ export const useStyles = makeStyles(
       outline: 'none',
     },
     tooltipContent: {
+      display: 'flex',
       height: theme.pxToRem(16),
     },
   }),

--- a/stories/components/Radio/radioGroupMinimal.md
+++ b/stories/components/Radio/radioGroupMinimal.md
@@ -98,8 +98,10 @@ An icon can be provided. If a label is not provided, but an aria-label is, that 
 will be used as the tooltip message.
 
 ```jsx
-<RadioGroupMinimal aria-label="Option 1" icon={User} label="" />
-<RadioGroupMinimal icon={User} label="Option 1" />
+<RadioGroupMinimal>
+  <Radio aria-label="Option 1" icon={User} label="" />
+  <Radio icon={User} label="Option 1" />
+</RadioGroupMinimal>
 ```
 
 ### Background


### PR DESCRIPTION
This display bug doesn't appear in Storybook but surfaced when I consumed the latest Chroma changes from another repo.

BEFORE | AFTER | &nbsp;
-- | -- | -- 
<img width="196" alt="01" src="https://user-images.githubusercontent.com/485903/151606653-a70213ea-bf44-44f2-933c-86b6291b222f.png"> | <img width="196" alt="02" src="https://user-images.githubusercontent.com/485903/151606657-5e9ecad1-432e-468e-ad4d-2d7d0431dca4.png"> | No visual changes in Storybook
<img width="153" alt="03" src="https://user-images.githubusercontent.com/485903/151606660-9cd787a0-a3bd-4b16-8d5a-f1fb1afd6931.png"> | <img width="153" alt="04" src="https://user-images.githubusercontent.com/485903/151606662-37a4756a-6752-4cb2-b037-82da1ca61acf.png">
