### PR TITLE
docs: Change spacing to correct numbering on doc site

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,4 +115,5 @@ Want to override the default theme of Chroma? No problem!
       const classes = useStyles({});
       return <button className={classes.root}>Custom Button</button>;
     };
+    
     ```

--- a/README.md
+++ b/README.md
@@ -20,39 +20,39 @@ To get started with Chroma, follow these steps:
 
 1. Install dependencies
 
-```bash
-yarn add @lifeomic/chroma-react @material-ui/styles react-router-dom
-```
+    ```bash
+    yarn add @lifeomic/chroma-react @material-ui/styles react-router-dom
+    ```
 
-Chroma leverages `@material-ui/styles` for CSS-in-JS and `react-router-dom` for link-related components.
+   Chroma leverages `@material-ui/styles` for CSS-in-JS and `react-router-dom` for link-related components.
 
 2. Wrap your application with the `ThemeProvider` provided by Chroma.
 
-```jsx
-import { ThemeProvider } from '@lifeomic/chroma-react/styles';
+   ```jsx
+   import { ThemeProvider } from '@lifeomic/chroma-react/styles';
 
-function App({ children }) {
-  return <ThemeProvider>{children}</ThemeProvider>;
-}
-```
+   function App({ children }) {
+    return <ThemeProvider>{children}</ThemeProvider>;
+   }
+   ```
 
 3. Start using components!
 
-```jsx
-import { Button } from '@lifeomic/chroma-react/components/Button';
+   ```jsx
+   import { Button } from '@lifeomic/chroma-react/components/Button';
 
-<Button variant="contained">Button</Button>;
-```
+   <Button variant="contained">Button</Button>;
+   ```
 
 4. Add jest config (optional)
 
-To include the jest configuration setup, add the following:
+    To include the jest configuration setup, add the following:
 
-```js
-setupFilesAfterEnv: ['@lifeomic/chroma-react/jest'];
-```
+   ```js
+   setupFilesAfterEnv: ['@lifeomic/chroma-react/jest'];
+   ```
 
-**Note**: Some components may require support for CSS imports (e.g. `import 'some-module/styles.css`). All major bundlers can support this behavior (example: webpack's [css-loader](https://webpack.js.org/loaders/css-loader/)).
+   **Note**: Some components may require support for CSS imports (e.g. `import 'some-module/styles.css`). All major bundlers can support this behavior (example: webpack's [css-loader](https://webpack.js.org/loaders/css-loader/)).
 
 ## Theming
 
@@ -60,59 +60,59 @@ Want to override the default theme of Chroma? No problem!
 
 1. Create your component-level overrides and palette overrides. Chroma leverages Material-UI's global theme variation [to override specific component styles](https://material-ui.com/customization/components/#5-global-theme-variation).
 
-```js
-// theme.ts
-import {
-  createPalette,
-  createTheme,
-  Theme,
-} from '@lifeomic/chroma-react/styles';
-import { Overrides } from '@lifeomic/chroma-react/styles/overrides';
+    ```js
+    // theme.ts
+    import {
+      createPalette,
+      createTheme,
+      Theme,
+    } from '@lifeomic/chroma-react/styles';
+    import { Overrides } from '@lifeomic/chroma-react/styles/overrides';
 
-// The overrides specified here will be *global* component overrides!
-export const overrides = (theme: Theme): Overrides => ({
-  ChromButton: {
-    root: {
-      background: 'red',
-    },
-    outlined: {
-      border: '1px solid red',
-    },
-  },
-});
+    // The overrides specified here will be *global* component overrides!
+    export const overrides = (theme: Theme): Overrides => ({
+      ChromButton: {
+        root: {
+          background: 'red',
+        },
+        outlined: {
+          border: '1px solid red',
+        },
+      },
+    });
 
-export const palette = createPalette({
-  primary: {
-    main: '#02bff1',
-  },
-});
+    export const palette = createPalette({
+      primary: {
+        main: '#02bff1',
+      },
+    });
 
-export const theme = createTheme({
-  overrides,
-  palette,
-});
-```
+    export const theme = createTheme({
+      overrides,
+      palette,
+    });
+    ```
 
 2. Update your theme provider.
 
-```jsx
-import { ThemeProvider } from '@lifeomic/chroma-react/styles';
-import { theme } from './theme';
+    ```jsx
+    import { ThemeProvider } from '@lifeomic/chroma-react/styles';
+    import { theme } from './theme';
 
-function App({ children }) {
-  return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
-}
-```
+    function App({ children }) {
+      return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
+    }
+    ```
 
 ## Importing Component Styles Only?
 
-Need to build a custom component, but want to use the styles hook of an existing Chroma component?
+    Need to build a custom component, but want to use the styles hook of an existing Chroma component?
 
-```jsx
-import { useStyles } from '@lifeomic/chroma-react/components/Button/Button';
+    ```jsx
+    import { useStyles } from '@lifeomic/chroma-react/components/Button/Button';
 
-const CustomButton = ({}) => {
-  const classes = useStyles({});
-  return <button className={classes.root}>Custom Button</button>;
-};
-```
+    const CustomButton = ({}) => {
+      const classes = useStyles({});
+      return <button className={classes.root}>Custom Button</button>;
+    };
+    ```


### PR DESCRIPTION
This PR only add spaces to the beginning of each line. It does not change any text or formatting. (Repeat of earlier cancelled PR and deleted branch)

The step numbering currently appears correctly on github, but is reset to all 1s when automatically imported into phc-docs at https://docs.dev.lifeomic.com/development/open-source/chroma-react/. I believe this is due to the python-markdown used by phc-docs interpreting the .md file differently than the GitHub-flavored-Markdown of Github. Specifically, python-markdown thinks the consecutive list is restarting at 1 (despite the 2 or 3 in the text) when there is no spacing at the lines between the numbered steps. Adding two tabs at each line seems to fix this.
