### PR TITLE
fix: Added type=button to the tab component

### DIFF
--- a/src/components/Tabs/Tab.tsx
+++ b/src/components/Tabs/Tab.tsx
@@ -135,6 +135,7 @@ export const Tab: React.FC<TabProps> = ({
       disabled={disabled}
       onClick={onClick}
       id={stopId}
+      type="button"
       {...rootProps}
     >
       {variant === 'pill' ? <span>{children}</span> : children}


### PR DESCRIPTION
It turns out that the default button type in the [spec](https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type) is a submit button. This is very janky for a tab button because if it is inside of a form then changing tabs causes the form to submit.