### PR TITLE
Top-Level Component Index

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -4,12 +4,12 @@ import * as BoxComponents from './Box';
 import * as BreadcrumbComponents from './Breadcrumbs';
 import * as ButtonComponents from './Button';
 import * as ButtonFilePickerComponents from './ButtonFilePicker';
-import * as ButtonFloatComponennts from './ButtonFloat';
+import * as ButtonFloatComponents from './ButtonFloat';
 import * as ButtonLinkComponents from './ButtonLink';
 import * as ButtonUnstyledComponents from './ButtonUnstyled';
 import * as CheckboxComponents from './Checkbox';
 import * as ChipComponents from './Chip';
-import * as ColorPicker from './ColorPicker';
+import * as ColorPickerComponents from './ColorPicker';
 import * as DayPickerComponents from './DayPicker';
 import * as DividerComponents from './Divider';
 import * as DotLoaderComponents from './DotLoader';
@@ -59,12 +59,12 @@ export default {
   BreadcrumbComponents,
   ButtonComponents,
   ButtonFilePickerComponents,
-  ButtonFloatComponennts,
+  ButtonFloatComponents,
   ButtonLinkComponents,
   ButtonUnstyledComponents,
   CheckboxComponents,
   ChipComponents,
-  ColorPicker,
+  ColorPickerComponents,
   DayPickerComponents,
   DividerComponents,
   DotLoaderComponents,


### PR DESCRIPTION
Lifeology has a use case where we need to inject chroma into a remote component. Currently we can only do that by injecting every single component individually, like so:
 ```
module.exports = {
    resolve: {
      react: require("react"),
      '@lifeomic/chroma-react/components/Button': require('@lifeomic/chroma-react/components/Button'),
      '@lifeomic/chroma-react/components/TextInput': require('@lifeomic/chroma-react/components/TextInput'),
      '@lifeomic/chroma-react/components/Loader': require('@lifeomic/chroma-react/components/Loader'),
      '@lifeomic/chroma-react/components/OtherComponent': require('@lifeomic/chroma-react/components/OtherComponent'),
      ... for every single chroma component
    }
  };
```


What we really want to do is something like this:


 ```
module.exports = {
    resolve: {
      react: require("react"),
      '@lifeomic/chroma-react/components': require('@lifeomic/chroma-react/components')
    }
  };
```

To fix this, we added a top-level `index` to `/components` that exports all chroma components. This will be used to provide a single dependency reference for remote components. It will not affect any existing apps or uses of chroma-react.