### PR TITLE
Add explicit children prop to prep for react-18

### DIFF
--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -41,6 +41,7 @@ export const useStyles = makeStyles(
 export type AlertClasses = GetClasses<typeof useStyles>;
 
 export interface AlertProps {
+  children?: React.ReactNode;
   className?: string;
   statusType?: NotificationStatusType;
   fullWidth?: boolean;

--- a/src/components/Alert/AlertActionsRow.tsx
+++ b/src/components/Alert/AlertActionsRow.tsx
@@ -24,6 +24,7 @@ export const useStyles = makeStyles(
 export type AlertActionsRowClasses = GetClasses<typeof useStyles>;
 
 export interface AlertActionsRowProps {
+  children?: React.ReactNode;
   className?: string;
 }
 

--- a/src/components/Alert/AlertBody.tsx
+++ b/src/components/Alert/AlertBody.tsx
@@ -55,6 +55,7 @@ export const useStyles = makeStyles(
 export type AlertBodyClasses = GetClasses<typeof useStyles>;
 
 export interface AlertBodyProps {
+  children?: React.ReactNode;
   className?: string;
   spaceBetween?: boolean;
 }

--- a/src/components/Alert/AlertIcon.tsx
+++ b/src/components/Alert/AlertIcon.tsx
@@ -23,6 +23,7 @@ export const useStyles = makeStyles(
 export type AlertIconClasses = GetClasses<typeof useStyles>;
 
 export interface AlertIconProps {
+  children?: React.ReactNode;
   className?: string;
   icon?: React.ComponentType<React.SVGProps<SVGSVGElement>>;
 }

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -67,6 +67,7 @@ export const useStyles = makeStyles(
 export type AvatarClasses = GetClasses<typeof useStyles>;
 
 export interface AvatarProps extends React.ComponentPropsWithoutRef<'div'> {
+  children?: React.ReactNode;
   name: string;
   size?: 0 | 1 | 2;
   src?: string;

--- a/src/components/Box/Box.tsx
+++ b/src/components/Box/Box.tsx
@@ -15,6 +15,7 @@ export interface BoxProps
     HTMLDivElement
   > {
   ref?: React.Ref<HTMLDivElement>;
+  children?: React.ReactNode;
   className?: string;
   flexChildren?: boolean;
   flexWrap?: boolean;

--- a/src/components/Breadcrumbs/Breadcrumb.tsx
+++ b/src/components/Breadcrumbs/Breadcrumb.tsx
@@ -60,6 +60,7 @@ export interface BreadcrumbProps
     React.HTMLAttributes<HTMLLIElement>,
     HTMLLIElement
   > {
+  children?: React.ReactNode;
   color?: 'inverse' | 'default';
   isCurrentPage?: boolean;
   text: string;

--- a/src/components/Breadcrumbs/BreadcrumbNav.tsx
+++ b/src/components/Breadcrumbs/BreadcrumbNav.tsx
@@ -23,7 +23,9 @@ export interface BreadcrumbNavProps
   extends React.DetailedHTMLProps<
     React.HTMLAttributes<HTMLElement>,
     HTMLElement
-  > {}
+  > {
+  children?: React.ReactNode;
+}
 
 export const BreadcrumbNav: React.FC<BreadcrumbNavProps> = ({
   className,

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -163,6 +163,7 @@ export const useStyles = makeStyles(
 export type ButtonClasses = GetClasses<typeof useStyles>;
 
 export interface ButtonProps extends React.ComponentPropsWithoutRef<'button'> {
+  children?: React.ReactNode;
   color?: 'default' | 'inverse';
   disabled?: boolean;
   fullWidth?: boolean;

--- a/src/components/ButtonFloat/ButtonFloat.tsx
+++ b/src/components/ButtonFloat/ButtonFloat.tsx
@@ -120,6 +120,7 @@ export type ButtonFloatClasses = GetClasses<typeof useStyles>;
 export interface ButtonFloatProps
   extends React.ComponentPropsWithoutRef<'button'> {
   align?: 'top' | 'center' | 'bottom';
+  children?: React.ReactNode;
   icon?: React.ComponentType<React.SVGProps<SVGSVGElement>>;
   fullWidth?: boolean;
   justify?: 'left' | 'center' | 'right';

--- a/src/components/ButtonLink/ButtonLink.tsx
+++ b/src/components/ButtonLink/ButtonLink.tsx
@@ -158,6 +158,7 @@ export const useStyles = makeStyles(
 export type ButtonLinkClasses = GetClasses<typeof useStyles>;
 
 export interface ButtonLinkProps extends LinkProps {
+  children?: React.ReactNode;
   color?: ButtonProps['color'];
   disabled?: ButtonProps['disabled'];
   fullWidth?: ButtonProps['fullWidth'];

--- a/src/components/ButtonUnstyled/ButtonUnstyled.tsx
+++ b/src/components/ButtonUnstyled/ButtonUnstyled.tsx
@@ -36,6 +36,7 @@ export type ButtonUnstyledClasses = GetClasses<typeof useStyles>;
 
 export interface ButtonUnstyledProps
   extends React.ComponentPropsWithoutRef<'button'> {
+  children?: React.ReactNode;
   disabled?: boolean;
   fullWidth?: boolean;
 }

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -76,6 +76,7 @@ export interface ChipOwnProps
     React.HTMLAttributes<HTMLDivElement>,
     HTMLDivElement
   > {
+  children?: React.ReactNode;
   label?: string;
   onDelete?(): void;
   disableDelete?: boolean;

--- a/src/components/ExpansionPanel/ExpansionPanel.tsx
+++ b/src/components/ExpansionPanel/ExpansionPanel.tsx
@@ -87,6 +87,7 @@ export interface ExpansionPanelProps
     HTMLDivElement
   > {
   ariaOwnsId?: string;
+  children?: React.ReactNode;
   contentClassName?: string;
   innerContentClassName?: string;
   title: string;

--- a/src/components/IconTile/IconTile.tsx
+++ b/src/components/IconTile/IconTile.tsx
@@ -39,7 +39,9 @@ export interface IconTileOwnProps
   extends React.DetailedHTMLProps<
     React.HTMLAttributes<HTMLDivElement>,
     HTMLDivElement
-  > {}
+  > {
+  children?: React.ReactNode;
+}
 
 export type IconTileClasses = GetClasses<typeof useStyles>;
 

--- a/src/components/IconTile/IconTileBadge.tsx
+++ b/src/components/IconTile/IconTileBadge.tsx
@@ -33,6 +33,7 @@ export interface IconTileBadgeOwnProps
     React.HTMLAttributes<HTMLDivElement>,
     HTMLDivElement
   > {
+  children?: React.ReactNode;
   icon?: React.ComponentType<React.SVGProps<SVGSVGElement>>;
 }
 

--- a/src/components/IconTile/IconTileContent.tsx
+++ b/src/components/IconTile/IconTileContent.tsx
@@ -36,8 +36,9 @@ export interface IconTileContentOwnProps
     React.HTMLAttributes<HTMLDivElement>,
     HTMLDivElement
   > {
-  text?: string;
   caption?: string;
+  children?: React.ReactNode;
+  text?: string;
 }
 
 export type IconTileContentClasses = GetClasses<typeof useStyles>;

--- a/src/components/IconTile/IconTileHero.tsx
+++ b/src/components/IconTile/IconTileHero.tsx
@@ -35,6 +35,7 @@ export type IconTileHeroClasses = GetClasses<typeof useStyles>;
 export interface IconTileHeroOwnProps {
   backgroundColor?: string;
   backgroundUrl?: string;
+  children?: React.ReactNode;
 }
 
 export interface IconTileHeroProps

--- a/src/components/LayoutManager/LayoutManager.tsx
+++ b/src/components/LayoutManager/LayoutManager.tsx
@@ -66,6 +66,7 @@ export interface LayoutManagerProps
     React.HTMLAttributes<HTMLDivElement>,
     HTMLDivElement
   > {
+  children?: React.ReactNode;
   header?: React.ReactNode;
   initialIsSidebarCollapsed?: boolean;
   isSidebarCollapseDisabled?: boolean;

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -39,9 +39,10 @@ export interface LinkProps
       HTMLAnchorElement
     >
   > {
+  children?: React.ReactNode;
+  color?: 'default' | 'inverse';
   ['data-testid']?: string;
   newTab?: boolean;
-  color?: 'default' | 'inverse';
 }
 
 export const Link: React.FC<LinkProps> = ({

--- a/src/components/Menu/MenuButton.tsx
+++ b/src/components/Menu/MenuButton.tsx
@@ -22,6 +22,7 @@ export const useStyles = makeStyles(
 export type MenuButtonClasses = GetClasses<typeof useStyles>;
 
 export interface MenuButtonProps extends ButtonProps {
+  children?: React.ReactNode;
   trailingIcon?: React.ComponentType<React.SVGProps<SVGSVGElement>>;
 }
 

--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -40,6 +40,7 @@ export type MenuItemClasses = GetClasses<typeof useStyles>;
 
 export interface MenuItemProps
   extends React.ComponentPropsWithoutRef<'button'> {
+  children?: React.ReactNode;
   icon?: React.ComponentType<React.SVGProps<SVGSVGElement>>;
   text?: string;
 }

--- a/src/components/Modal/ModalActions.tsx
+++ b/src/components/Modal/ModalActions.tsx
@@ -33,6 +33,7 @@ export type ModalActionsClasses = GetClasses<typeof useStyles>;
 
 export interface ModalActionsProps
   extends React.ComponentPropsWithoutRef<'div'> {
+  children?: React.ReactNode;
   justify?: 'space-between' | 'flex-end';
 }
 

--- a/src/components/PageLayout/PageLayout.tsx
+++ b/src/components/PageLayout/PageLayout.tsx
@@ -70,6 +70,7 @@ export type PageLayoutClasses = GetClasses<typeof useStyles>;
 export interface PageLayoutProps
   extends StandardProps<HTMLDivElement, PageLayoutClasses> {
   backgroundImage?: string;
+  children?: React.ReactNode;
   disclaimer?: React.ReactNode;
   headerActions?: PageHeaderProps['actions'];
   headerAlign?: PageHeaderProps['align'];

--- a/src/components/Pill/Pill.tsx
+++ b/src/components/Pill/Pill.tsx
@@ -51,8 +51,9 @@ export interface PillOwnProps
       'onAnimationStart' | 'onDrag' | 'onDragEnd' | 'onDragStart' | 'style'
     >,
     MotionProps {
-  label?: string;
   color?: 'primary' | 'default';
+  children?: React.ReactNode;
+  label?: string;
   variant?: 'default' | 'highlight';
 }
 

--- a/src/components/Popover/PopoverActions.tsx
+++ b/src/components/Popover/PopoverActions.tsx
@@ -33,6 +33,7 @@ export interface PopoverActionsOwnProps
     React.HTMLAttributes<HTMLDivElement>,
     HTMLDivElement
   > {
+  children?: React.ReactNode;
   className?: string;
   justify?: 'flex-start' | 'center' | 'flex-end';
 }

--- a/src/components/Popover/PopoverContent.tsx
+++ b/src/components/Popover/PopoverContent.tsx
@@ -19,7 +19,9 @@ export interface PopoverContentProps
   extends React.DetailedHTMLProps<
     React.HTMLAttributes<HTMLDivElement>,
     HTMLDivElement
-  > {}
+  > {
+  children?: React.ReactNode;
+}
 
 export const PopoverContent = React.forwardRef<
   HTMLDivElement,

--- a/src/components/Popover/PopoverItem.tsx
+++ b/src/components/Popover/PopoverItem.tsx
@@ -62,6 +62,7 @@ export type PopoverItemClasses = GetClasses<typeof useStyles>;
 
 export interface PopoverItemOwnProps
   extends StandardProps<HTMLLIElement, PopoverItemClasses> {
+  children?: React.ReactNode;
   clipText?: boolean;
   icon?: React.ComponentType<React.SVGProps<SVGSVGElement>>;
   text?: string;

--- a/src/components/Popover/PopoverList.tsx
+++ b/src/components/Popover/PopoverList.tsx
@@ -28,7 +28,9 @@ export interface PopoverListProps
   extends React.DetailedHTMLProps<
     React.HTMLAttributes<HTMLUListElement>,
     HTMLUListElement
-  > {}
+  > {
+  children?: React.ReactNode;
+}
 
 export const PopoverList = React.forwardRef<HTMLUListElement, PopoverListProps>(
   ({ children, ...rootProps }, ref) => {

--- a/src/components/PrimaryNavigation/PrimaryNavigation.tsx
+++ b/src/components/PrimaryNavigation/PrimaryNavigation.tsx
@@ -155,6 +155,7 @@ export interface PrimaryNavigationProps
     React.HTMLAttributes<HTMLElement>,
     HTMLElement
   > {
+  children?: React.ReactNode;
   header?: React.ReactNode;
   headerMin?: React.ReactNode;
   footer?: React.ReactNode;

--- a/src/components/PrimaryNavigation/PrimaryNavigationExpansionItem.tsx
+++ b/src/components/PrimaryNavigation/PrimaryNavigationExpansionItem.tsx
@@ -148,6 +148,7 @@ export interface PrimaryNavigationExpansionItemProps
     >,
     Pick<NavLinkProps, 'exact' | 'to'>,
     MotionProps {
+  children?: React.ReactNode;
   rootParentPath?: string;
   label?: string;
   beta?: boolean;

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -127,6 +127,7 @@ export const useStyles = makeStyles(
 export type RadioClasses = GetClasses<typeof useStyles>;
 
 export interface RadioProps extends BaseFormElement {
+  children?: React.ReactNode;
   icon?: React.ComponentType<React.SVGProps<SVGSVGElement>>;
 }
 

--- a/src/components/Radio/RadioGroup.tsx
+++ b/src/components/Radio/RadioGroup.tsx
@@ -73,8 +73,9 @@ export interface RadioGroupProps
     RadioProps,
     'aria-label' | 'color' | 'name' | 'onChange' | 'value'
   > {
-  className?: string;
   align?: 'center' | 'flex-start';
+  children?: React.ReactNode;
+  className?: string;
   direction?: 'row' | 'column';
   justify?: 'center' | 'flex-start' | 'space-between' | 'space-evenly';
   title?: string;

--- a/src/components/Radio/RadioGroupMinimal.tsx
+++ b/src/components/Radio/RadioGroupMinimal.tsx
@@ -153,6 +153,7 @@ export interface RadioGroupMinimalProps
     'aria-label' | 'color' | 'name' | 'onChange' | 'value'
   > {
   background?: boolean;
+  children?: React.ReactNode;
   className?: string;
   direction?: 'row' | 'column';
   fullWidth?: boolean;

--- a/src/components/SecondaryNavigation/SecondaryNavigation.tsx
+++ b/src/components/SecondaryNavigation/SecondaryNavigation.tsx
@@ -53,6 +53,7 @@ export type SecondaryNavigationClasses = GetClasses<typeof useStyles>;
 
 export interface SecondaryNavigationProps
   extends StandardProps<HTMLElement, SecondaryNavigationClasses> {
+  children?: React.ReactNode;
   variant?: 'vertical' | 'horizontal';
 }
 

--- a/src/components/Select/GroupHeading.tsx
+++ b/src/components/Select/GroupHeading.tsx
@@ -28,6 +28,7 @@ export type GroupHeadingClasses = GetClasses<typeof useStyles>;
 
 export interface GroupHeadingProps {
   className?: string;
+  children?: React.ReactNode;
   ['data-select-role']: 'heading';
 }
 

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -317,6 +317,7 @@ export interface SelectProps
       'className' | 'id' | 'value'
     > {
   ['aria-label']?: string;
+  children?: React.ReactNode;
   secondaryLabel?: string;
   fullWidth?: boolean;
   icon?: React.ComponentType<React.SVGProps<SVGSVGElement>>;

--- a/src/components/Select/SelectOption.tsx
+++ b/src/components/Select/SelectOption.tsx
@@ -56,6 +56,7 @@ export type SelectOptionClasses = GetClasses<typeof useStyles>;
 
 export interface SelectOptionProps {
   className?: string;
+  children?: React.ReactNode;
   disabled?: boolean;
   isChecked?: boolean;
   meta?: any;

--- a/src/components/SlideOver/Body.tsx
+++ b/src/components/SlideOver/Body.tsx
@@ -22,6 +22,7 @@ export type BodyClasses = GetClasses<typeof useStyles>;
 export interface BodyProps {
   as?: React.ElementType<any>;
   className?: string;
+  children?: React.ReactNode;
   [key: string]: any;
 }
 export const Body: React.FC<BodyProps> = ({

--- a/src/components/SlideOver/Header.tsx
+++ b/src/components/SlideOver/Header.tsx
@@ -26,6 +26,7 @@ export type HeaderClasses = GetClasses<typeof useStyles>;
 
 export interface HeaderProps {
   className?: string;
+  children?: React.ReactNode;
   onClose: () => any;
   title?: string;
   classes?: {

--- a/src/components/SlideOver/SlideOver.tsx
+++ b/src/components/SlideOver/SlideOver.tsx
@@ -97,6 +97,7 @@ export interface SlideOverProps {
     inner?: string;
     content?: string;
   };
+  children?: React.ReactNode;
   isOpen?: boolean;
 }
 

--- a/src/components/SmallTile/SmallTile.tsx
+++ b/src/components/SmallTile/SmallTile.tsx
@@ -35,7 +35,9 @@ export interface SmallTileOwnProps
   extends React.DetailedHTMLProps<
     React.HTMLAttributes<HTMLDivElement>,
     HTMLDivElement
-  > {}
+  > {
+  children?: React.ReactNode;
+}
 
 export type SmallTileClasses = GetClasses<typeof useStyles>;
 

--- a/src/components/SmallTile/SmallTileContent.tsx
+++ b/src/components/SmallTile/SmallTileContent.tsx
@@ -36,6 +36,7 @@ export interface SmallTileContentOwnProps
     React.HTMLAttributes<HTMLDivElement>,
     HTMLDivElement
   > {
+  children?: React.ReactNode;
   text?: string;
   fullHeight?: boolean;
 }

--- a/src/components/SmallTile/SmallTileFooter.tsx
+++ b/src/components/SmallTile/SmallTileFooter.tsx
@@ -39,6 +39,7 @@ export interface SmallTileFooterOwnProps
     React.HTMLAttributes<HTMLDivElement>,
     HTMLDivElement
   > {
+  children?: React.ReactNode;
   text?: string;
   justify?: 'flex-start' | 'center' | 'flex-end' | 'space-between';
 }

--- a/src/components/Snackbar/Snackbar.tsx
+++ b/src/components/Snackbar/Snackbar.tsx
@@ -66,6 +66,7 @@ export type SnackbarClasses = GetClasses<typeof useStyles>;
 
 export interface SnackbarProps {
   duration?: number;
+  children?: React.ReactNode;
   className?: string;
   icon?: React.ComponentType<React.SVGProps<SVGSVGElement>>;
   isOpen?: boolean;

--- a/src/components/TableModule/TableModuleActions.tsx
+++ b/src/components/TableModule/TableModuleActions.tsx
@@ -36,7 +36,9 @@ export interface TableModuleActionsProps
   extends React.DetailedHTMLProps<
     React.HTMLAttributes<HTMLDivElement>,
     HTMLDivElement
-  > {}
+  > {
+  children?: React.ReactNode;
+}
 
 export const TableModuleActions: React.FC<TableModuleActionsProps> = ({
   children,

--- a/src/components/Tabs/Tab.tsx
+++ b/src/components/Tabs/Tab.tsx
@@ -110,6 +110,7 @@ export const useStyles = makeStyles(
 export type TabClasses = GetClasses<typeof useStyles>;
 
 export interface TabProps extends TabStop {
+  children?: React.ReactNode;
   className?: string;
   disabled?: boolean;
   onClick?: React.MouseEventHandler<HTMLButtonElement>;

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -85,6 +85,7 @@ export const useStyles = makeStyles(
 
 export interface TextOwnProps extends React.HTMLAttributes<HTMLElement> {
   align?: 'center' | 'justify' | 'left' | 'right';
+  children?: React.ReactNode;
   size?:
     | 'headline'
     | 'body'

--- a/src/components/_private/UniqueId.ts
+++ b/src/components/_private/UniqueId.ts
@@ -2,6 +2,7 @@ function gen4Part() {
   return Math.random().toString(16).slice(-4);
 }
 
+// TODO: Replace with `useId` when React18 is adopted
 export function generateUniqueId(prefix: string) {
   return (prefix || '').concat(
     [

--- a/src/components/_private/forms/FormElementUtils.ts
+++ b/src/components/_private/forms/FormElementUtils.ts
@@ -24,6 +24,7 @@ export interface BaseFormElement extends BaseFormElementWithNodeLabel {
  * or error messages.
  */
 export interface BaseFormMessage {
+  children?: React.ReactNode;
   className?: string;
   color?: 'default' | 'inverse';
   /**


### PR DESCRIPTION
### Changes

- Add explicit `children` prop to prep for `react-18` type changes
  - https://twitter.com/dan_abramov/status/1512833611401150474?s=21&t=ZE1lLF3izIsZA43_TgTeKw
  - This should make our upgrade (when ready) a lot smoother