### PR TITLE
fix: Text alignment for text buttons in table module actions

### DIFF
--- a/src/components/TableModule/TableModule.tsx
+++ b/src/components/TableModule/TableModule.tsx
@@ -166,6 +166,8 @@ export const useStyles = makeStyles(
       paddingBottom: '0.2rem',
       position: 'relative',
       '& > button': {
+        alignItems: 'center',
+        justifyContent: 'center',
         minHeight: 0,
         // Add negative horizontal margins when there is
         // only one button so container appears as circle


### PR DESCRIPTION
BEFORE | AFTER
-- | --
<img width="216" alt="Screen Shot 2022-05-13 at 12 54 54 PM" src="https://user-images.githubusercontent.com/485903/168331848-51ab0370-c611-4188-86b6-278382ad84c8.png"> | <img width="216" alt="Screen Shot 2022-05-13 at 12 53 05 PM" src="https://user-images.githubusercontent.com/485903/168331842-6ec47853-3202-4ab5-9b80-57cbf425d194.png">


