### PR TITLE
feat: Add positive and negative `color` values to `<ButtonLink`

### DIFF
--- a/src/components/ButtonLink/ButtonLink.test.tsx
+++ b/src/components/ButtonLink/ButtonLink.test.tsx
@@ -198,6 +198,119 @@ test('it renders with `variant="text" color="inverse"`', async () => {
 });
 // #endregion
 
+// #region negative tests
+test('it renders with `variant="contained" color="negative"`', async () => {
+  const props = getBaseProps();
+  const { findByTestId } = renderWithTheme(
+    <RenderContainer>
+      <ButtonLink
+        {...props}
+        data-testid={testId}
+        variant="contained"
+        color="negative"
+      >
+        ButtonLink
+      </ButtonLink>
+    </RenderContainer>
+  );
+  const root = await findByTestId(testId);
+  expect(root).toHaveClass('ChromaButtonLink-containedNegative');
+});
+
+test('it renders with `variant="outlined" color="negative"`', async () => {
+  const props = getBaseProps();
+  const { findByTestId } = renderWithTheme(
+    <RenderContainer>
+      <ButtonLink
+        {...props}
+        data-testid={testId}
+        variant="outlined"
+        color="negative"
+      >
+        ButtonLink
+      </ButtonLink>
+    </RenderContainer>
+  );
+  const root = await findByTestId(testId);
+  expect(root).toHaveClass('ChromaButtonLink-outlinedNegative');
+});
+
+test('it renders with `variant="text" color="negative"`', async () => {
+  const props = getBaseProps();
+  const { findByTestId } = renderWithTheme(
+    <RenderContainer>
+      <ButtonLink
+        {...props}
+        data-testid={testId}
+        variant="text"
+        color="negative"
+      >
+        ButtonLink
+      </ButtonLink>
+    </RenderContainer>
+  );
+  const root = await findByTestId(testId);
+  expect(root).toHaveClass('ChromaButtonLink-textNegative');
+});
+// #endregion
+
+// #region positive tests
+test('it renders with `variant="contained" color="positive"`', async () => {
+  const props = getBaseProps();
+  const { findByTestId } = renderWithTheme(
+    <RenderContainer>
+      <ButtonLink
+        {...props}
+        data-testid={testId}
+        variant="contained"
+        color="positive"
+      >
+        ButtonLink
+      </ButtonLink>
+    </RenderContainer>
+  );
+  const root = await findByTestId(testId);
+  expect(root).toHaveClass('ChromaButtonLink-containedPositive');
+});
+
+test('it renders with `variant="outlined" color="positive"`', async () => {
+  const props = getBaseProps();
+  const { findByTestId } = renderWithTheme(
+    <RenderContainer>
+      <ButtonLink
+        {...props}
+        data-testid={testId}
+        variant="outlined"
+        color="positive"
+      >
+        ButtonLink
+      </ButtonLink>
+    </RenderContainer>
+  );
+  const root = await findByTestId(testId);
+  expect(root).toHaveClass('ChromaButtonLink-outlinedPositive');
+});
+
+test('it renders with `variant="text" color="positive"`', async () => {
+  const props = getBaseProps();
+  const { findByTestId } = renderWithTheme(
+    <RenderContainer>
+      <ButtonLink
+        {...props}
+        data-testid={testId}
+        variant="text"
+        color="positive"
+      >
+        ButtonLink
+      </ButtonLink>
+    </RenderContainer>
+  );
+  const root = await findByTestId(testId);
+  expect(root).toHaveClass('ChromaButtonLink-textPositive');
+});
+// #endregion
+
+// #region disabled tests
 test('it renders a disabled link when disabled', async () => {
   const props = getBaseProps();
   const { findByTestId } = renderWithTheme(
@@ -238,6 +351,53 @@ test('it renders a disabled inverse link when disabled', async () => {
   expect(root.getAttribute('role')).toBe('button');
   expect(root).toHaveClass('ChromaButtonLink-containedInverse');
 });
+
+test('it renders a disabled negative link when disabled', async () => {
+  const props = getBaseProps();
+  const { findByTestId } = renderWithTheme(
+    <RenderContainer>
+      <ButtonLink
+        {...props}
+        disabled={true}
+        color="negative"
+        data-testid={testId}
+      >
+        ButtonLink
+      </ButtonLink>
+    </RenderContainer>
+  );
+
+  const root = await findByTestId(testId);
+
+  expect(root.getAttribute('href')).toBe(null);
+  expect(root.getAttribute('aria-disabled')).toBe('true');
+  expect(root.getAttribute('role')).toBe('button');
+  expect(root).toHaveClass('ChromaButtonLink-containedNegative');
+});
+
+test('it renders a disabled positive link when disabled', async () => {
+  const props = getBaseProps();
+  const { findByTestId } = renderWithTheme(
+    <RenderContainer>
+      <ButtonLink
+        {...props}
+        disabled={true}
+        color="positive"
+        data-testid={testId}
+      >
+        ButtonLink
+      </ButtonLink>
+    </RenderContainer>
+  );
+
+  const root = await findByTestId(testId);
+
+  expect(root.getAttribute('href')).toBe(null);
+  expect(root.getAttribute('aria-disabled')).toBe('true');
+  expect(root.getAttribute('role')).toBe('button');
+  expect(root).toHaveClass('ChromaButtonLink-containedPositive');
+});
+// #endregion
 
 test('it renders a trailing icon', async () => {
   const props = getBaseProps();

--- a/src/components/ButtonLink/ButtonLink.tsx
+++ b/src/components/ButtonLink/ButtonLink.tsx
@@ -13,7 +13,7 @@ export const useStyles = makeStyles(
   (theme) => ({
     root: {
       background: theme.palette.primary.main,
-      border: `1px solid transparent`,
+      border: `${theme.pxToRem(1)} solid transparent`,
       borderRadius: theme.pxToRem(4),
       color: theme.palette.common.white,
       cursor: 'pointer',
@@ -119,6 +119,70 @@ export const useStyles = makeStyles(
         boxShadow: theme.boxShadows.focusVisibleInverse,
       },
     },
+    containedNegative: {
+      backgroundColor: theme.palette.negative.main,
+      color: theme.palette.common.white,
+      '&:hover': {
+        backgroundColor: theme.palette.negative.dark,
+      },
+      '&:disabled, &[disabled]': {
+        backgroundColor: theme.palette.negative.main,
+        color: theme.palette.common.white,
+      },
+    },
+    containedPositive: {
+      backgroundColor: theme.palette.positive.main,
+      color: theme.palette.common.white,
+      '&:hover': {
+        backgroundColor: theme.palette.positive.dark,
+      },
+      '&:disabled, &[disabled]': {
+        backgroundColor: theme.palette.positive.main,
+        color: theme.palette.common.white,
+      },
+    },
+    outlinedNegative: {
+      borderColor: theme.palette.negative.main,
+      color: theme.palette.negative.main,
+      '&:hover': {
+        borderColor: theme.palette.negative.dark,
+        color: theme.palette.negative.dark,
+      },
+      '&:disabled, &[disabled]': {
+        borderColor: theme.palette.negative.main,
+        color: theme.palette.negative.main,
+      },
+    },
+    outlinedPositive: {
+      borderColor: theme.palette.positive.main,
+      color: theme.palette.positive.main,
+      '&:hover': {
+        borderColor: theme.palette.positive.dark,
+        color: theme.palette.positive.dark,
+      },
+      '&:disabled, &[disabled]': {
+        borderColor: theme.palette.positive.main,
+        color: theme.palette.positive.main,
+      },
+    },
+    textNegative: {
+      color: theme.palette.negative.main,
+      '&:hover': {
+        color: theme.palette.negative.dark,
+      },
+      '&:disabled': {
+        color: theme.palette.negative.main,
+      },
+    },
+    textPositive: {
+      color: theme.palette.positive.main,
+      '&:hover': {
+        color: theme.palette.positive.dark,
+      },
+      '&:disabled': {
+        color: theme.palette.positive.main,
+      },
+    },
     fullWidth: {
       width: '100%',
     },
@@ -207,6 +271,16 @@ export const ButtonLink = React.forwardRef<HTMLAnchorElement, ButtonLinkProps>(
             [classes.outlinedInverse]:
               variant === 'outlined' && color === 'inverse',
             [classes.textInverse]: variant === 'text' && color === 'inverse',
+            [classes.containedNegative]:
+              variant === 'contained' && color === 'negative',
+            [classes.outlinedNegative]:
+              variant === 'outlined' && color === 'negative',
+            [classes.textNegative]: variant === 'text' && color === 'negative',
+            [classes.containedPositive]:
+              variant === 'contained' && color === 'positive',
+            [classes.outlinedPositive]:
+              variant === 'outlined' && color === 'positive',
+            [classes.textPositive]: variant === 'text' && color === 'positive',
           },
           fullWidth && classes.fullWidth,
           disabled &&

--- a/stories/components/ButtonLink/ButtonLink.stories.tsx
+++ b/stories/components/ButtonLink/ButtonLink.stories.tsx
@@ -131,6 +131,46 @@ const InversedButtonLinkStory: React.FunctionComponent = () => (
   </BrowserRouter>
 );
 
+const NegativeButtonLinkStory: React.FunctionComponent = () => (
+  <BrowserRouter>
+    <Container containerStyles={{ display: 'flex' }}>
+      <ButtonLink variant="text" color="negative" to="/foo">
+        Text ButtonLink
+      </ButtonLink>
+    </Container>
+    <Container containerStyles={{ display: 'flex' }}>
+      <ButtonLink variant="outlined" color="negative" to="/foo">
+        Outlined ButtonLink
+      </ButtonLink>
+    </Container>
+    <Container>
+      <ButtonLink variant="contained" color="negative" to="/foo">
+        Contained ButtonLink
+      </ButtonLink>
+    </Container>
+  </BrowserRouter>
+);
+
+const PositiveButtonLinkStory: React.FunctionComponent = () => (
+  <BrowserRouter>
+    <Container containerStyles={{ display: 'flex' }}>
+      <ButtonLink variant="text" color="positive" to="/foo">
+        Text ButtonLink
+      </ButtonLink>
+    </Container>
+    <Container containerStyles={{ display: 'flex' }}>
+      <ButtonLink variant="outlined" color="positive" to="/foo">
+        Outlined ButtonLink
+      </ButtonLink>
+    </Container>
+    <Container>
+      <ButtonLink variant="contained" color="positive" to="/foo">
+        Contained ButtonLink
+      </ButtonLink>
+    </Container>
+  </BrowserRouter>
+);
+
 const DisabledButtonLinkStory: React.FunctionComponent = () => (
   <BrowserRouter>
     <Container containerStyles={{ display: 'flex' }}>
@@ -180,6 +220,60 @@ const DisabledButtonLinkStory: React.FunctionComponent = () => (
           </ButtonLink>
         </Container>
       </Container>
+      <Container containerStyles={{ flex: 1, flexFlow: 'column' }}>
+        <Container>
+          <ButtonLink variant="text" color="negative" to="/foo" disabled={true}>
+            Text ButtonLink
+          </ButtonLink>
+        </Container>
+        <Container>
+          <ButtonLink
+            variant="outlined"
+            color="negative"
+            to="/bar"
+            disabled={true}
+          >
+            Outlined ButtonLink
+          </ButtonLink>
+        </Container>
+        <Container>
+          <ButtonLink
+            variant="contained"
+            color="negative"
+            to="/baz"
+            disabled={true}
+          >
+            Contained ButtonLink
+          </ButtonLink>
+        </Container>
+      </Container>
+      <Container containerStyles={{ flex: 1, flexFlow: 'column' }}>
+        <Container>
+          <ButtonLink variant="text" color="positive" to="/foo" disabled={true}>
+            Text ButtonLink
+          </ButtonLink>
+        </Container>
+        <Container>
+          <ButtonLink
+            variant="outlined"
+            color="positive"
+            to="/bar"
+            disabled={true}
+          >
+            Outlined ButtonLink
+          </ButtonLink>
+        </Container>
+        <Container>
+          <ButtonLink
+            variant="contained"
+            color="positive"
+            to="/baz"
+            disabled={true}
+          >
+            Contained ButtonLink
+          </ButtonLink>
+        </Container>
+      </Container>
     </Container>
   </BrowserRouter>
 );
@@ -198,6 +292,12 @@ storiesOf('Components/ButtonLink', module)
     readme: { content: defaultMd },
   })
   .add('Inverse Color', () => <InversedButtonLinkStory />, {
+    readme: { content: defaultMd },
+  })
+  .add('Negative Color', () => <NegativeButtonLinkStory />, {
+    readme: { content: defaultMd },
+  })
+  .add('Positive Color', () => <PositiveButtonLinkStory />, {
     readme: { content: defaultMd },
   })
   .add('Disabled', () => <DisabledButtonLinkStory />, {


### PR DESCRIPTION
<img width="332" alt="Screen Shot 2022-05-20 at 10 18 16 AM" src="https://user-images.githubusercontent.com/485903/169547993-a9179774-b722-4c0a-80bc-c9f0dd3324e0.png">
<img width="332" alt="Screen Shot 2022-05-20 at 10 18 20 AM" src="https://user-images.githubusercontent.com/485903/169547995-4fc7342b-3c82-47a4-9224-7a001f5278a9.png">

No docs update for this PR since we state: 
_An element that appears as a Button component, but is a link. It has the same properties as Button_.