### PR TITLE
feat: Add positive and negative `color` values to `<IconButtonLink`

### DIFF
--- a/src/components/IconButtonLink/IconButtonLink.test.tsx
+++ b/src/components/IconButtonLink/IconButtonLink.test.tsx
@@ -108,6 +108,28 @@ test('it renders with `color="inverse"`', async () => {
   expect(root).toHaveClass('ChromaIconButtonLink-inverse');
 });
 
+test('it renders with `color="negative"`', async () => {
+  const props = getBaseProps();
+  const { findByTestId } = renderWithTheme(
+    <RenderContainer>
+      <IconButtonLink {...props} data-testid={testId} color="negative" />
+    </RenderContainer>
+  );
+  const root = await findByTestId(testId);
+  expect(root).toHaveClass('ChromaIconButtonLink-negative');
+});
+
+test('it renders with `color="positive"`', async () => {
+  const props = getBaseProps();
+  const { findByTestId } = renderWithTheme(
+    <RenderContainer>
+      <IconButtonLink {...props} data-testid={testId} color="positive" />
+    </RenderContainer>
+  );
+  const root = await findByTestId(testId);
+  expect(root).toHaveClass('ChromaIconButtonLink-positive');
+});
+
 test('it allows combining the "padding" props', async () => {
   const props = getBaseProps();
   const { findByTestId } = renderWithTheme(

--- a/src/components/IconButtonLink/IconButtonLink.tsx
+++ b/src/components/IconButtonLink/IconButtonLink.tsx
@@ -54,6 +54,26 @@ export const useStyles = makeStyles(
         },
       },
     },
+    negative: {
+      color: theme.palette.negative.main,
+      '&:hover, &:focus': {
+        color: theme.palette.negative.dark,
+      },
+      '&:disabled': {
+        color: theme.palette.negative.main,
+        opacity: 0.44,
+      },
+    },
+    positive: {
+      color: theme.palette.positive.main,
+      '&:hover, &:focus': {
+        color: theme.palette.positive.dark,
+      },
+      '&:disabled': {
+        color: theme.palette.positive.main,
+        opacity: 0.44,
+      },
+    },
     size0: {
       '& > svg': {
         width: 18,
@@ -166,6 +186,8 @@ export const IconButtonLink = React.forwardRef<
           { [classes.size0]: size === 0 },
           {
             [classes.inverse]: color === 'inverse',
+            [classes.negative]: color === 'negative',
+            [classes.positive]: color === 'positive',
           },
           {
             [classes.paddingTop0]: paddingTop === 0,

--- a/stories/components/IconButtonLink/IconButtonLink.stories.tsx
+++ b/stories/components/IconButtonLink/IconButtonLink.stories.tsx
@@ -53,6 +53,54 @@ const InversedColorStory: React.FunctionComponent = () => (
   </WrappedContainer>
 );
 
+const NegativeColorStory: React.FunctionComponent = () => (
+  <WrappedContainer>
+    <div style={{ marginRight: spacing[4] }}>
+      <IconButtonLink
+        aria-label="Edit"
+        icon={Edit}
+        color="negative"
+        to="/foo"
+      />
+      <Text size="caption">Default</Text>
+    </div>
+    <div>
+      <IconButtonLink
+        aria-label="Edit"
+        icon={Edit}
+        size={0}
+        color="negative"
+        to="/bar"
+      />
+      <Text size="caption">Small</Text>
+    </div>
+  </WrappedContainer>
+);
+
+const PositiveColorStory: React.FunctionComponent = () => (
+  <WrappedContainer>
+    <div style={{ marginRight: spacing[4] }}>
+      <IconButtonLink
+        aria-label="Edit"
+        icon={Edit}
+        color="positive"
+        to="/foo"
+      />
+      <Text size="caption">Default</Text>
+    </div>
+    <div>
+      <IconButtonLink
+        aria-label="Edit"
+        icon={Edit}
+        size={0}
+        color="positive"
+        to="/bar"
+      />
+      <Text size="caption">Small</Text>
+    </div>
+  </WrappedContainer>
+);
+
 const AllIconsButtonStory: React.FunctionComponent = () => (
   <WrappedContainer>
     <div style={{ marginRight: spacing[4] }}>
@@ -71,5 +119,11 @@ storiesOf('Components/IconButtonLink', module)
     readme: { content: defaultMd },
   })
   .add('Inverse Color', () => <InversedColorStory />, {
+    readme: { content: defaultMd },
+  })
+  .add('Negative Color', () => <NegativeColorStory />, {
+    readme: { content: defaultMd },
+  })
+  .add('Positive Color', () => <PositiveColorStory />, {
     readme: { content: defaultMd },
   });


### PR DESCRIPTION
<img width="303" alt="Screen Shot 2022-05-20 at 12 43 46 PM" src="https://user-images.githubusercontent.com/485903/169574221-e8bb78de-366b-4a61-82aa-e3477482ce18.png">
<img width="303" alt="Screen Shot 2022-05-20 at 12 43 50 PM" src="https://user-images.githubusercontent.com/485903/169574224-72736404-b4b2-4837-b21d-01bce1a66054.png">

No docs update for this PR since we state:
_An element that appears as an Icon Button component, but is a link underneath the covers. It has the same properties as Icon Button exposed._