### PR TITLE
fix: Add fixed width to day picker

### DIFF
--- a/src/components/DayPicker/DayPicker.tsx
+++ b/src/components/DayPicker/DayPicker.tsx
@@ -37,6 +37,7 @@ const useStyles = makeStyles((theme) => ({
     borderRadius: theme.spacing(1.25),
     backgroundColor: theme.palette.common.white,
     boxShadow: theme.boxShadows.popover,
+    width: theme.pxToRem(277),
     '& .DayPicker-wrapper': {
       paddingBottom: 0,
     },


### PR DESCRIPTION
Add fixed width to day picker container so we don't get ovals for day hover/focus/selected states when a day picker isn't `fullWidth`

BEFORE | AFTER
-- | --
<img width="309" alt="day-before" src="https://user-images.githubusercontent.com/485903/174665306-3e394145-f374-4c1b-b568-ad6ac3f11893.png"> | <img width="309" alt="day-after" src="https://user-images.githubusercontent.com/485903/174665304-032da5aa-92cf-4842-9970-b387d9c3dcdb.png">
