### PR TITLE
fix: Use palette for `<DayPicker` background hover color

### DIFF
--- a/src/components/DayPicker/DayPicker.tsx
+++ b/src/components/DayPicker/DayPicker.tsx
@@ -63,7 +63,7 @@ const useStyles = makeStyles((theme) => ({
       backgroundColor: theme.palette.grey[300],
     },
     '&.DayPicker:not(.DayPicker--interactionDisabled) .DayPicker-Day:not(.DayPicker-Day--disabled):not(.DayPicker-Day--selected):not(.DayPicker-Day--outside):hover': {
-      backgroundColor: fade(theme.palette.primary[50], 0.65),
+      backgroundColor: fade(theme.palette.primary[50], 0.5),
     },
   },
   dayPickerBottomLeft: {

--- a/src/components/DayPicker/DayPicker.tsx
+++ b/src/components/DayPicker/DayPicker.tsx
@@ -325,28 +325,28 @@ export const DayPicker = React.forwardRef<HTMLInputElement, DayPickerProps>(
       onTextChange && onTextChange(formatDate(day));
     };
 
-    // const onBlur = (e: React.FocusEvent<unknown>) => {
-    //   /**
-    //    * This logic primarily serves to provide good keyboard navigation.
-    //    */
-    //   if (!isInternalNode(e.relatedTarget)) {
-    //     setIsCalendarOpen(false);
-    //   }
+    const onBlur = (e: React.FocusEvent<unknown>) => {
+      /**
+       * This logic primarily serves to provide good keyboard navigation.
+       */
+      if (!isInternalNode(e.relatedTarget)) {
+        setIsCalendarOpen(false);
+      }
 
-    //   /**
-    //    * Clear any intermediate input. This minimizes confusion -- if
-    //    * the text field is not focused, then it contains the most recent
-    //    * value.
-    //    *
-    //    * Otherwise, consumers may see a value that hasn't been reported
-    //    * via `onDayChange`.
-    //    */
-    //   setIntermediateInput(undefined);
-    // };
+      /**
+       * Clear any intermediate input. This minimizes confusion -- if
+       * the text field is not focused, then it contains the most recent
+       * value.
+       *
+       * Otherwise, consumers may see a value that hasn't been reported
+       * via `onDayChange`.
+       */
+      setIntermediateInput(undefined);
+    };
 
-    // const isInternalNode = (target: EventTarget | null) => {
-    //   return target instanceof Node && wrapperRef.current?.contains(target);
-    // };
+    const isInternalNode = (target: EventTarget | null) => {
+      return target instanceof Node && wrapperRef.current?.contains(target);
+    };
 
     const DAY_PICKER_STYLES: Record<DayPickerAnchorPosition, string> = {
       'bottom-left': classes.dayPickerBottomLeft,
@@ -401,7 +401,7 @@ export const DayPicker = React.forwardRef<HTMLInputElement, DayPickerProps>(
             textFieldProps.onFocus,
             () => setIsCalendarOpen(true),
           ])}
-          // onBlur={composeEventHandlers([textFieldProps.onBlur, onBlur])}
+          onBlur={composeEventHandlers([textFieldProps.onBlur, onBlur])}
         />
         {isCalendarOpen && (
           <ReactDayPicker
@@ -465,7 +465,7 @@ export const DayPicker = React.forwardRef<HTMLInputElement, DayPickerProps>(
               formatMonthTitle,
               formatWeekdayShort,
             }}
-            // onBlur={onBlur}
+            onBlur={onBlur}
             {...calendarProps}
           />
         )}

--- a/src/components/DayPicker/DayPicker.tsx
+++ b/src/components/DayPicker/DayPicker.tsx
@@ -63,7 +63,7 @@ const useStyles = makeStyles((theme) => ({
       backgroundColor: theme.palette.grey[300],
     },
     '&.DayPicker:not(.DayPicker--interactionDisabled) .DayPicker-Day:not(.DayPicker-Day--disabled):not(.DayPicker-Day--selected):not(.DayPicker-Day--outside):hover': {
-      backgroundColor: fade(theme.palette.primary[50], 0.35),
+      backgroundColor: fade(theme.palette.primary[50], 0.65),
     },
   },
   dayPickerBottomLeft: {

--- a/src/components/DayPicker/DayPicker.tsx
+++ b/src/components/DayPicker/DayPicker.tsx
@@ -13,6 +13,7 @@ import { TextField, TextFieldProps } from '../TextField';
 import { GetClasses } from '../../typeUtils';
 import { ButtonUnstyled } from '../ButtonUnstyled';
 import { composeEventHandlers } from '../../utils';
+import { fade } from '@material-ui/core/styles/colorManipulator';
 
 export const DayPickerStylesKey = 'ChromaDayPicker';
 export type DayPickerClasses = GetClasses<typeof useStyles>;
@@ -60,6 +61,9 @@ const useStyles = makeStyles((theme) => ({
     '& .DayPicker-Day--today': {
       color: theme.palette.common.black,
       backgroundColor: theme.palette.grey[300],
+    },
+    '&.DayPicker:not(.DayPicker--interactionDisabled) .DayPicker-Day:not(.DayPicker-Day--disabled):not(.DayPicker-Day--selected):not(.DayPicker-Day--outside):hover': {
+      backgroundColor: fade(theme.palette.primary[50], 0.35),
     },
   },
   dayPickerBottomLeft: {
@@ -321,28 +325,28 @@ export const DayPicker = React.forwardRef<HTMLInputElement, DayPickerProps>(
       onTextChange && onTextChange(formatDate(day));
     };
 
-    const onBlur = (e: React.FocusEvent<unknown>) => {
-      /**
-       * This logic primarily serves to provide good keyboard navigation.
-       */
-      if (!isInternalNode(e.relatedTarget)) {
-        setIsCalendarOpen(false);
-      }
+    // const onBlur = (e: React.FocusEvent<unknown>) => {
+    //   /**
+    //    * This logic primarily serves to provide good keyboard navigation.
+    //    */
+    //   if (!isInternalNode(e.relatedTarget)) {
+    //     setIsCalendarOpen(false);
+    //   }
 
-      /**
-       * Clear any intermediate input. This minimizes confusion -- if
-       * the text field is not focused, then it contains the most recent
-       * value.
-       *
-       * Otherwise, consumers may see a value that hasn't been reported
-       * via `onDayChange`.
-       */
-      setIntermediateInput(undefined);
-    };
+    //   /**
+    //    * Clear any intermediate input. This minimizes confusion -- if
+    //    * the text field is not focused, then it contains the most recent
+    //    * value.
+    //    *
+    //    * Otherwise, consumers may see a value that hasn't been reported
+    //    * via `onDayChange`.
+    //    */
+    //   setIntermediateInput(undefined);
+    // };
 
-    const isInternalNode = (target: EventTarget | null) => {
-      return target instanceof Node && wrapperRef.current?.contains(target);
-    };
+    // const isInternalNode = (target: EventTarget | null) => {
+    //   return target instanceof Node && wrapperRef.current?.contains(target);
+    // };
 
     const DAY_PICKER_STYLES: Record<DayPickerAnchorPosition, string> = {
       'bottom-left': classes.dayPickerBottomLeft,
@@ -397,7 +401,7 @@ export const DayPicker = React.forwardRef<HTMLInputElement, DayPickerProps>(
             textFieldProps.onFocus,
             () => setIsCalendarOpen(true),
           ])}
-          onBlur={composeEventHandlers([textFieldProps.onBlur, onBlur])}
+          // onBlur={composeEventHandlers([textFieldProps.onBlur, onBlur])}
         />
         {isCalendarOpen && (
           <ReactDayPicker
@@ -461,7 +465,7 @@ export const DayPicker = React.forwardRef<HTMLInputElement, DayPickerProps>(
               formatMonthTitle,
               formatWeekdayShort,
             }}
-            onBlur={onBlur}
+            // onBlur={onBlur}
             {...calendarProps}
           />
         )}


### PR DESCRIPTION
Use palette for day background hover color vs. default `react-day-picker` color

BEFORE | AFTER
-- | --
<img width="309" alt="Screen Shot 2022-06-21 at 3 26 57 PM" src="https://user-images.githubusercontent.com/485903/174883490-98811284-6093-4bd6-99dc-5598ce359067.png"> | <img width="309" alt="Screen Shot 2022-06-21 at 3 30 01 PM" src="https://user-images.githubusercontent.com/485903/174883495-961f05a3-b701-40a7-bf76-cf5e3fe06e5a.png">

### Keyboard focus

<img width="309" alt="Screen Shot 2022-06-21 at 3 34 01 PM" src="https://user-images.githubusercontent.com/485903/174883499-28f666cb-e841-4095-bb58-c8bd30a7bf2c.png">


