### PR TITLE
fix: Add prop to `<DayPicker` for custom selected text color

### DIFF
--- a/src/components/DayPicker/DayPicker.tsx
+++ b/src/components/DayPicker/DayPicker.tsx
@@ -122,11 +122,18 @@ export type DayPickerProps = Omit<TextFieldProps, 'value' | 'onChange'> & {
   value?: Date;
 
   /**
-   * A background color to use for the currently selected month.
+   * A background color to use for the currently selected day.
    *
    * Default is the main primary color of the theme.
    */
   selectedBackgroundColor?: string;
+
+  /**
+   * A text color to use for the currently selected day.
+   *
+   * Default is white.
+   */
+  selectedTextColor?: string;
 
   /**
    * Where to anchor the calender pop-up. Default is 'bottom-left'.
@@ -228,6 +235,7 @@ export const DayPicker = React.forwardRef<HTMLInputElement, DayPickerProps>(
     {
       value,
       selectedBackgroundColor,
+      selectedTextColor,
       anchorPosition = 'bottom-left',
       minDate,
       maxDate,
@@ -423,6 +431,7 @@ export const DayPicker = React.forwardRef<HTMLInputElement, DayPickerProps>(
               selected: {
                 backgroundColor:
                   selectedBackgroundColor || theme.palette.primary.main,
+                color: selectedTextColor || theme.palette.common.white,
               },
               outside: {
                 backgroundColor: 'transparent',

--- a/stories/components/DayPicker/default.md
+++ b/stories/components/DayPicker/default.md
@@ -147,6 +147,9 @@ const [errorMessage, setErrorMessage] = React.useState(false);
   // A color string to use for the background of the "selected" day
   // in the calendar.
   selectedBackgroundColor={...}
+  // A color string to use for the text color of the "selected" day
+  // in the calendar.
+  selectedTextColor={...}
   // A function for formatting the month + year title.
   // Useful to override for localization.
   formatMonthTitle={...}


### PR DESCRIPTION
There's a case in Lifeology where I want to keep the `<DayPicker`'s default background color for selected day because it matches all primary buttons. However, in Lifeology there is not enough contrast between `<DayPicker`'s default background color and the text color (white) of selected day to pass a11y checks. This PR adds a prop `selectedTextColor` to customize  selected day's text color in order pass a11y checks. 

BEFORE | AFTER
-- | --
<img width="276" alt="Screen Shot 2022-06-21 at 8 06 39 PM" src="https://user-images.githubusercontent.com/485903/174916366-eced9558-0e8a-46df-9dc9-25bf5ca3cad3.png"><br />Fails a11y check | <img width="276" alt="Screen Shot 2022-06-21 at 8 07 19 PM" src="https://user-images.githubusercontent.com/485903/174916368-270ec0f1-f8d5-43d9-8511-fd5ce460f197.png"><br />Passes a11y check

<img width="755" alt="Screen Shot 2022-06-21 at 8 25 47 PM" src="https://user-images.githubusercontent.com/485903/174917848-f12d89ad-3478-41eb-bc0d-4b034a926f9a.png">