### PR TITLE
feat: Add `DayPicker` selected day background color from palette options

### DIFF
--- a/src/components/DayPicker/DayPicker.tsx
+++ b/src/components/DayPicker/DayPicker.tsx
@@ -126,7 +126,7 @@ export type DayPickerProps = Omit<TextFieldProps, 'value' | 'onChange'> & {
    *
    * Default is the main primary color of the theme.
    */
-  selectedBackgroundColor?: 'primary' | 'secondary';
+  color?: 'primary' | 'secondary';
 
   /**
    * Where to anchor the calender pop-up. Default is 'bottom-left'.
@@ -227,7 +227,7 @@ export const DayPicker = React.forwardRef<HTMLInputElement, DayPickerProps>(
   (
     {
       value,
-      selectedBackgroundColor,
+      color,
       anchorPosition = 'bottom-left',
       minDate,
       maxDate,
@@ -422,11 +422,11 @@ export const DayPicker = React.forwardRef<HTMLInputElement, DayPickerProps>(
             modifiersStyles={{
               selected: {
                 backgroundColor:
-                  selectedBackgroundColor === 'secondary'
+                  color === 'secondary'
                     ? theme.palette.secondary.main
                     : theme.palette.primary.main,
                 color:
-                  selectedBackgroundColor === 'secondary'
+                  color === 'secondary'
                     ? theme.palette.getContrastText(
                         theme.palette.secondary.main
                       )

--- a/src/components/DayPicker/DayPicker.tsx
+++ b/src/components/DayPicker/DayPicker.tsx
@@ -124,7 +124,7 @@ export type DayPickerProps = Omit<TextFieldProps, 'value' | 'onChange'> & {
   /**
    * A background color to use for the currently selected month.
    *
-   * Default is the main primary color of the theme.
+   * Default is 'primary'.
    */
   pickerColor?: 'primary' | 'secondary';
 

--- a/src/components/DayPicker/DayPicker.tsx
+++ b/src/components/DayPicker/DayPicker.tsx
@@ -126,7 +126,7 @@ export type DayPickerProps = Omit<TextFieldProps, 'value' | 'onChange'> & {
    *
    * Default is the main primary color of the theme.
    */
-  selectedBackgroundColor?: string;
+  selectedBackgroundColor?: 'primary' | 'secondary';
 
   /**
    * Where to anchor the calender pop-up. Default is 'bottom-left'.
@@ -422,7 +422,15 @@ export const DayPicker = React.forwardRef<HTMLInputElement, DayPickerProps>(
             modifiersStyles={{
               selected: {
                 backgroundColor:
-                  selectedBackgroundColor || theme.palette.primary.main,
+                  selectedBackgroundColor === 'secondary'
+                    ? theme.palette.secondary.main
+                    : theme.palette.primary.main,
+                color:
+                  selectedBackgroundColor === 'secondary'
+                    ? theme.palette.getContrastText(
+                        theme.palette.secondary.main
+                      )
+                    : theme.palette.getContrastText(theme.palette.primary.main),
               },
               outside: {
                 backgroundColor: 'transparent',

--- a/src/components/DayPicker/DayPicker.tsx
+++ b/src/components/DayPicker/DayPicker.tsx
@@ -227,7 +227,7 @@ export const DayPicker = React.forwardRef<HTMLInputElement, DayPickerProps>(
   (
     {
       value,
-      pickerColor,
+      pickerColor = 'primary',
       anchorPosition = 'bottom-left',
       minDate,
       maxDate,

--- a/src/components/DayPicker/DayPicker.tsx
+++ b/src/components/DayPicker/DayPicker.tsx
@@ -126,7 +126,7 @@ export type DayPickerProps = Omit<TextFieldProps, 'value' | 'onChange'> & {
    *
    * Default is the main primary color of the theme.
    */
-  color?: 'primary' | 'secondary';
+  pickerColor?: 'primary' | 'secondary';
 
   /**
    * Where to anchor the calender pop-up. Default is 'bottom-left'.
@@ -227,7 +227,7 @@ export const DayPicker = React.forwardRef<HTMLInputElement, DayPickerProps>(
   (
     {
       value,
-      color,
+      pickerColor,
       anchorPosition = 'bottom-left',
       minDate,
       maxDate,
@@ -422,11 +422,11 @@ export const DayPicker = React.forwardRef<HTMLInputElement, DayPickerProps>(
             modifiersStyles={{
               selected: {
                 backgroundColor:
-                  color === 'secondary'
+                  pickerColor === 'secondary'
                     ? theme.palette.secondary.main
                     : theme.palette.primary.main,
                 color:
-                  color === 'secondary'
+                  pickerColor === 'secondary'
                     ? theme.palette.getContrastText(
                         theme.palette.secondary.main
                       )

--- a/stories/components/DayPicker/DayPicker.stories.tsx
+++ b/stories/components/DayPicker/DayPicker.stories.tsx
@@ -71,7 +71,6 @@ const DayPickerStory: React.FC = () => {
               fullWidth
               label={'Default'}
               initialValue={new Date()}
-              color="secondary"
             />
             <PickerWithInternalState
               fullWidth

--- a/stories/components/DayPicker/DayPicker.stories.tsx
+++ b/stories/components/DayPicker/DayPicker.stories.tsx
@@ -71,6 +71,7 @@ const DayPickerStory: React.FC = () => {
               fullWidth
               label={'Default'}
               initialValue={new Date()}
+              color="secondary"
             />
             <PickerWithInternalState
               fullWidth

--- a/stories/components/DayPicker/default.md
+++ b/stories/components/DayPicker/default.md
@@ -146,7 +146,7 @@ const [errorMessage, setErrorMessage] = React.useState(false);
   setDate={setDate}
   // The secondary color can be used for the background
   // color of the "selected" day in the calendar.
-  selectedBackgroundColor="secondary"
+  color="secondary"
   // A function for formatting the month + year title.
   // Useful to override for localization.
   formatMonthTitle={...}

--- a/stories/components/DayPicker/default.md
+++ b/stories/components/DayPicker/default.md
@@ -146,7 +146,7 @@ const [errorMessage, setErrorMessage] = React.useState(false);
   setDate={setDate}
   // The secondary color can be used for the background
   // color of the "selected" day in the calendar.
-  color="secondary"
+  pickerColor="secondary"
   // A function for formatting the month + year title.
   // Useful to override for localization.
   formatMonthTitle={...}

--- a/stories/components/DayPicker/default.md
+++ b/stories/components/DayPicker/default.md
@@ -144,9 +144,9 @@ const [errorMessage, setErrorMessage] = React.useState(false);
   label="Date"
   value={date}
   setDate={setDate}
-  // A color string to use for the background of the "selected" day
-  // in the calendar.
-  selectedBackgroundColor={...}
+  // The secondary color can be used for the background
+  // color of the "selected" day in the calendar.
+  selectedBackgroundColor="secondary"
   // A function for formatting the month + year title.
   // Useful to override for localization.
   formatMonthTitle={...}

--- a/stories/components/DayPicker/default.md
+++ b/stories/components/DayPicker/default.md
@@ -144,8 +144,7 @@ const [errorMessage, setErrorMessage] = React.useState(false);
   label="Date"
   value={date}
   setDate={setDate}
-  // The main theme color used for the background
-  // color of the "selected" day in the calendar.
+  // The main theme color used for styling the calendar.
   pickerColor="secondary"
   // A function for formatting the month + year title.
   // Useful to override for localization.


### PR DESCRIPTION
This PR locks down `<DayPicker`'s `pickerColor` to two palette options: `primary` (default) and `secondary`. Text color of `pickerColor` for each option will now pull from `getContrastText`.

`pickerColor` is replacing `selectedBackgroundColor`.

AFTER (PRIMARY) | AFTER (SECONDARY)
-- | --
<img width="310" alt="Screen Shot 2022-06-22 at 11 54 42 AM" src="https://user-images.githubusercontent.com/485903/175077321-9e5d2f13-1b06-415c-b71b-3a46ad6b6a19.png"> | <img width="310" alt="Screen Shot 2022-06-22 at 11 55 07 AM" src="https://user-images.githubusercontent.com/485903/175077326-9fbac0ed-fc3e-460b-917a-56695af53340.png">

<img width="697" alt="Screen Shot 2022-06-22 at 11 55 28 AM" src="https://user-images.githubusercontent.com/485903/175077368-7a64b77f-2d55-4e80-80e3-21d1e25c1d27.png">

