### PR TITLE
OLOGY-1328 feat: add prop for aria-label on menu items

### DIFF
--- a/src/components/Menu/Menu.test.tsx
+++ b/src/components/Menu/Menu.test.tsx
@@ -159,6 +159,7 @@ test('it spreads menu item props properly', async () => {
           key={0}
           text="option1"
           data-testid="option"
+          ariaLabel="arya stark"
         />,
       ]}
     />
@@ -171,6 +172,7 @@ test('it spreads menu item props properly', async () => {
   const option = await findByTestId('option');
   expect(option).toBeDisabled();
   expect(option).toHaveClass('menu-item-1');
+  expect(option).toHaveAttribute('aria-label', 'arya stark');
 });
 
 test('it applies the provided className', async () => {

--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -67,6 +67,7 @@ export interface MenuItemProps
   icon?: React.ComponentType<React.SVGProps<SVGSVGElement>>;
   text?: string;
   secondaryText?: string;
+  ariaLabel?: string;
 }
 
 export const MenuItem = React.forwardRef<HTMLButtonElement, MenuItemProps>(
@@ -79,6 +80,7 @@ export const MenuItem = React.forwardRef<HTMLButtonElement, MenuItemProps>(
       onClick,
       text,
       secondaryText,
+      ariaLabel,
       ...rootProps
     },
     ref
@@ -103,6 +105,7 @@ export const MenuItem = React.forwardRef<HTMLButtonElement, MenuItemProps>(
           className
         )}
         onClick={handleStopPropagation}
+        aria-label={ariaLabel}
         {...rootProps}
       >
         {!!Icon && (

--- a/stories/components/Menu/Menu.stories.tsx
+++ b/stories/components/Menu/Menu.stories.tsx
@@ -34,12 +34,14 @@ const MenuStory: React.FC = () => {
               icon={HelpCircle}
               onClick={() => console.log('Request Download Link')}
               key={0}
+              ariaLabel="Download"
             />,
             <MenuItem
               text="Edit"
               icon={Edit}
               onClick={() => console.log('Edit')}
               key={1}
+              ariaLabel="Edit"
             />,
             <MenuItem
               color="negative"
@@ -47,6 +49,7 @@ const MenuStory: React.FC = () => {
               icon={Trash}
               onClick={() => console.log('Delete')}
               key={2}
+              ariaLabel="Delete"
             />,
             <MenuItem
               text="Disabled Option"
@@ -55,6 +58,7 @@ const MenuStory: React.FC = () => {
               onClick={() => console.log('Request Download Link')}
               disabled
               key={0}
+              ariaLabel="Download"
             />,
           ]}
         />

--- a/stories/components/Menu/default.md
+++ b/stories/components/Menu/default.md
@@ -190,6 +190,7 @@ Your own content can be rendered inside of a Menu Item as well.
 ## Accessibility
 
 - The anchor element has `aria-expanded` and `aria-haspopup` set appropriately.
+- Menu Item has an optional `aria-label` property.
 - The Menu and Menu Item components have the `role="menu"` and
   `role="menuitem"`.
 - Pressing `Enter` on the focused anchor element expands the menu.


### PR DESCRIPTION
we moved some Lifeology Viewer buttons into a Menu and lost the ability to add aria labels, wanting to add them back