### PR TITLE
fix: radio group minimal accessibility

### DIFF
--- a/src/components/Radio/RadioGroupMinimal.tsx
+++ b/src/components/Radio/RadioGroupMinimal.tsx
@@ -45,7 +45,7 @@ export const useStyles = makeStyles(
       overflow: 'hidden',
       padding: theme.spacing(0.25),
       '& input': {
-        display: 'none',
+        ...screenreaderOnlyStyles,
         '& + div': {
           display: 'flex',
           justifyContent: 'center',
@@ -97,6 +97,11 @@ export const useStyles = makeStyles(
             cursor: 'not-allowed',
           },
         },
+        '&:focus + div': {
+          '&::before': {
+            boxShadow: '0 0 0 2px rgba(0, 150, 225, .3)',
+          },
+        },
       },
       '& label': {
         marginTop: 0,
@@ -119,6 +124,11 @@ export const useStyles = makeStyles(
         },
         '& label > p, & svg': {
           color: 'unset',
+        },
+      },
+      '& input:focus + div': {
+        '&::before': {
+          boxShadow: '0 0 0 2px rgba(255, 255, 255, .3)',
         },
       },
     },


### PR DESCRIPTION
**Issue**
- User is not able to tab to focus checked radio 
- User is not able to use arrows to toggle between options

**Changes**
- Updated radio input to include screen reader styles instead of not being displayed at all

**BEFORE**

https://user-images.githubusercontent.com/32574227/176694680-67d34846-0bb6-4589-9141-302a2383b86e.mov


**AFTER**

https://user-images.githubusercontent.com/32574227/176694636-45e97059-49ae-4c4d-997b-a7cd91e1493d.mov


