### PR TITLE
Fix stepper accessibility 

### DIFF
--- a/src/components/Stepper/Step.tsx
+++ b/src/components/Stepper/Step.tsx
@@ -25,7 +25,7 @@ export const useStyles = makeStyles(
         outline: 'none',
       },
 
-      '&:hover': {
+      '&:hover, &:focus': {
         '&>div': {
           transform: 'scale(1.1)',
           transition: '0.25s cubic-bezier(0.2, 0.8, 0.2, 1)',
@@ -35,6 +35,15 @@ export const useStyles = makeStyles(
     divRoot: {
       minWidth: theme.pxToRem(110),
       padding: theme.spacing(0, 0.875, 1.5, 0.875),
+
+      '&:focus': {
+        outline: 'none',
+
+        '&>div': {
+          transform: 'scale(1.1)',
+          transition: '0.25s cubic-bezier(0.2, 0.8, 0.2, 1)',
+        },
+      },
     },
     activeRoot: {
       borderBottom: `2px solid ${theme.palette.primary.main}`,
@@ -126,6 +135,7 @@ export interface StepProps {
   disabled?: boolean;
   icon?: React.ComponentType<React.SVGProps<SVGSVGElement>>;
   index?: number;
+  numberOfSteps?: number;
   onClick?: (index: number | undefined) => void;
   subTitle?: string;
   subTitlePillLabel?: string;
@@ -139,7 +149,8 @@ export const Step: React.FC<StepProps> = ({
   completed,
   disabled,
   icon: Icon,
-  index,
+  index = 0,
+  numberOfSteps,
   onClick,
   subTitle,
   subTitlePillLabel,
@@ -214,38 +225,40 @@ export const Step: React.FC<StepProps> = ({
     </>
   );
 
-  if (as === 'button') {
-    return (
-      <button
-        className={clsx(
-          classes.buttonRoot,
-          active && classes.activeRoot,
-          completed && classes.completedRoot,
-          disabled && classes.disabled,
-          className
-        )}
-        disabled={disabled}
-        onClick={handleClick}
-        {...rootProps}
-      >
-        {content}
-      </button>
-    );
-  } else {
-    return (
-      <Box
-        align="center"
-        className={clsx(
-          classes.divRoot,
-          active && classes.activeRoot,
-          completed && classes.completedRoot,
-          className
-        )}
-        direction="column"
-        {...rootProps}
-      >
-        {content}
-      </Box>
-    );
-  }
+  return (
+    <li aria-current={active ? 'step' : undefined}>
+      {as === 'button' ? (
+        <button
+          aria-label={`Step ${index + 1} of ${numberOfSteps}`}
+          className={clsx(
+            classes.buttonRoot,
+            active && classes.activeRoot,
+            completed && classes.completedRoot,
+            disabled && classes.disabled,
+            className
+          )}
+          disabled={disabled}
+          onClick={handleClick}
+          {...rootProps}
+        >
+          {content}
+        </button>
+      ) : (
+        <Box
+          align="center"
+          className={clsx(
+            classes.divRoot,
+            active && classes.activeRoot,
+            completed && classes.completedRoot,
+            className
+          )}
+          direction="column"
+          tabIndex={as === 'div' && active ? 0 : -1}
+          {...rootProps}
+        >
+          {content}
+        </Box>
+      )}
+    </li>
+  );
 };

--- a/src/components/Stepper/Step.tsx
+++ b/src/components/Stepper/Step.tsx
@@ -5,6 +5,7 @@ import { GetClasses } from '../../typeUtils';
 import { Box } from '../Box';
 import { Pill } from '../Pill';
 import { Text } from '../Text';
+import { generateUniqueId } from '../_private/UniqueId';
 
 export const StepStylesKey = 'ChromaStep';
 
@@ -158,9 +159,26 @@ export const Step: React.FC<StepProps> = ({
   ...rootProps
 }) => {
   const classes = useStyles({});
+  const ariaLabel = `Step ${index + 1} of ${numberOfSteps}`;
+
+  const titleId = generateUniqueId('title-');
+  const subTitleId = generateUniqueId('subTitle-');
+  const subTitlePillId = generateUniqueId('subTitlePill-');
 
   const handleClick = () => {
     onClick?.(index);
+  };
+
+  const getDescribedBy = () => {
+    if (title && subTitle) {
+      return `${titleId} ${subTitleId}`;
+    }
+
+    if (title && subTitlePillLabel) {
+      return `${titleId} ${subTitlePillId}`;
+    }
+
+    return titleId;
   };
 
   const content = (
@@ -200,6 +218,7 @@ export const Step: React.FC<StepProps> = ({
       </Box>
       <Text
         className={clsx(classes.title, active && classes.activeTitle)}
+        id={titleId}
         size="subbody"
       >
         {title}
@@ -207,6 +226,7 @@ export const Step: React.FC<StepProps> = ({
       {subTitle && !subTitlePillLabel && (
         <Text
           className={clsx(classes.title, active && classes.activeTitle)}
+          id={subTitleId}
           size="caption"
         >
           {subTitle}
@@ -219,6 +239,7 @@ export const Step: React.FC<StepProps> = ({
             completed && classes.completedPillSubTitle
           )}
           color={active ? 'primary' : 'default'}
+          id={subTitlePillId}
           label={subTitlePillLabel}
         />
       )}
@@ -229,7 +250,8 @@ export const Step: React.FC<StepProps> = ({
     <li aria-current={active ? 'step' : undefined}>
       {as === 'button' ? (
         <button
-          aria-label={`Step ${index + 1} of ${numberOfSteps}`}
+          aria-describedBy={getDescribedBy()}
+          aria-label={ariaLabel}
           className={clsx(
             classes.buttonRoot,
             active && classes.activeRoot,
@@ -246,6 +268,8 @@ export const Step: React.FC<StepProps> = ({
       ) : (
         <Box
           align="center"
+          aria-describedBy={getDescribedBy()}
+          aria-label={ariaLabel}
           className={clsx(
             classes.divRoot,
             active && classes.activeRoot,

--- a/src/components/Stepper/Stepper.test.tsx
+++ b/src/components/Stepper/Stepper.test.tsx
@@ -116,3 +116,45 @@ test('it sets the active child based on "activeStep"', async () => {
   expect(step).toBeInTheDocument();
   expect(step).toHaveClass('ChromaStep-activeRoot');
 });
+
+test('it sets correct aria-label', async () => {
+  const testId = 'step';
+  const { findByTestId } = renderWithTheme(
+    <Stepper activeStep={1}>
+      <Step icon={IconComponent} title="not-active" />
+      <Step data-testid={testId} icon={IconComponent} title="active" />
+    </Stepper>
+  );
+
+  const step = await findByTestId(testId);
+  expect(step).toBeInTheDocument();
+  expect(step).toHaveAttribute('aria-label', 'Step 2 of 2');
+});
+
+test('it sets aria-current attribute on active step', async () => {
+  const testId = 'step';
+  const { findByTestId } = renderWithTheme(
+    <Stepper activeStep={1}>
+      <Step icon={IconComponent} title="not-active" />
+      <Step data-testid={testId} icon={IconComponent} title="active" />
+    </Stepper>
+  );
+
+  const step = await findByTestId(testId);
+  expect(step.parentElement).toBeInTheDocument();
+  expect(step.parentElement).toHaveAttribute('aria-current', 'step');
+});
+
+test('it does not set aria-current attribute on non active steps', async () => {
+  const testId = 'step';
+  const { findByTestId } = renderWithTheme(
+    <Stepper activeStep={1}>
+      <Step data-testid={testId} icon={IconComponent} title="not-active" />
+      <Step icon={IconComponent} title="active" />
+    </Stepper>
+  );
+
+  const step = await findByTestId(testId);
+  expect(step.parentElement).toBeInTheDocument();
+  expect(step.parentElement).not.toHaveAttribute('aria-current', 'step');
+});

--- a/src/components/Stepper/Stepper.tsx
+++ b/src/components/Stepper/Stepper.tsx
@@ -13,7 +13,12 @@ export const useStyles = makeStyles(
       backgroundColor: theme.palette.common.white,
     },
     innerRoot: {
+      alignItems: 'center',
+      display: 'flex',
+      justifyContent: 'space-between',
+      listStyleType: 'none',
       margin: theme.spacing(4, 4, 0, 4),
+      width: '100%',
     },
   }),
   { name: StepperStylesKey }
@@ -70,20 +75,17 @@ export const Stepper: React.FC<StepperProps> = ({
           key: `connector-${index}`,
           ...childrenProps,
         }),
-      React.cloneElement(child, { key: `step-${index}`, ...childrenProps }),
+      React.cloneElement(child, {
+        key: `step-${index}`,
+        numberOfSteps: childrenArray.length,
+        ...childrenProps,
+      }),
     ];
   });
 
   return (
     <Box fullWidth className={clsx(classes.root, className)} {...rootProps}>
-      <Box
-        align="center"
-        className={classes.innerRoot}
-        fullWidth
-        justify="space-between"
-      >
-        {steps}
-      </Box>
+      <ol className={classes.innerRoot}>{steps}</ol>
     </Box>
   );
 };

--- a/src/components/Stepper/Stepper.tsx
+++ b/src/components/Stepper/Stepper.tsx
@@ -18,6 +18,7 @@ export const useStyles = makeStyles(
       justifyContent: 'space-between',
       listStyleType: 'none',
       margin: theme.spacing(4, 4, 0, 4),
+      padding: 0,
       width: '100%',
     },
   }),

--- a/src/components/Stepper/Stepper.tsx
+++ b/src/components/Stepper/Stepper.tsx
@@ -84,7 +84,12 @@ export const Stepper: React.FC<StepperProps> = ({
   });
 
   return (
-    <Box fullWidth className={clsx(classes.root, className)} {...rootProps}>
+    <Box
+      fullWidth
+      className={clsx(classes.root, className)}
+      role="group"
+      {...rootProps}
+    >
       <ol className={classes.innerRoot}>{steps}</ol>
     </Box>
   );


### PR DESCRIPTION
Closes #44 

**Issue**
- Visual impaired users have no way of know which step is the active step
- There are no focus styles when tabbing (we only have hover styles)
- Steps as `div` have no tabIndex so they are missed in the tab order

**Changes**
- Fixed syntax to be more semantic (`ol` & `li`) 
- Added focus styles to steps
- Added `tabIndex` to active `div` steps
  - Button steps already have a `tabIndex` with the button element
- Added `aria-label` to read active step index of out total number of steps
- Added `aria-describedBy` so screen readers can get title, subTitle, and subTitlePill values

**BEFORE**

https://user-images.githubusercontent.com/32574227/176944194-9135f19c-ca4b-464c-a36a-0dc948ea35bc.mov


**AFTER**

https://user-images.githubusercontent.com/32574227/176944173-af03c65f-dd6e-43a0-b25d-eccdfa76dd2c.mov


https://user-images.githubusercontent.com/32574227/176944179-5624733b-3203-4e88-a0e6-2213c972c54f.mov


