### PR TITLE
Correct Step Aria Capitalization

### DIFF
--- a/src/components/Stepper/Step.tsx
+++ b/src/components/Stepper/Step.tsx
@@ -250,7 +250,7 @@ export const Step: React.FC<StepProps> = ({
     <li aria-current={active ? 'step' : undefined}>
       {as === 'button' ? (
         <button
-          aria-describedBy={getDescribedBy()}
+          aria-describedby={getDescribedBy()}
           aria-label={ariaLabel}
           className={clsx(
             classes.buttonRoot,
@@ -268,7 +268,7 @@ export const Step: React.FC<StepProps> = ({
       ) : (
         <Box
           align="center"
-          aria-describedBy={getDescribedBy()}
+          aria-describedby={getDescribedBy()}
           aria-label={ariaLabel}
           className={clsx(
             classes.divRoot,


### PR DESCRIPTION
Noticed an error complaining `aria-describedBy` didn't exist while working with `Stepper` for hackathon. Corrected to `aria-describedby`

<img width="596" alt="Screen Shot 2022-07-12 at 12 04 25 PM" src="https://user-images.githubusercontent.com/5824697/178574029-dbc7a20c-7681-4d4e-bbed-ecc54b08c7d8.png">
