### PR TITLE
CHROM 199 Update rgba to hexToRgba()

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -71,8 +71,7 @@ export const useStyles = makeStyles(
         boxShadow: theme.boxShadows.focusVisibleInverse,
       },
       '&:disabled, &[disabled]': {
-        backgroundColor: 'rgba(255, 255, 255, 0.45)',
-        opacity: 1,
+        backgroundColor: theme.hexToRgba(theme.palette.common.white, 0.45),
         color: theme.palette.text.secondary,
       },
     },
@@ -99,15 +98,15 @@ export const useStyles = makeStyles(
       '&:hover': {
         color: theme.palette.common.white,
         opacity: 0.85,
-        borderColor: 'rgba(255, 255, 255, 0.85)',
+        borderColor: theme.hexToRgba(theme.palette.common.white, 0.85),
       },
       '&:focus.focus-visible': {
         boxShadow: theme.boxShadows.focusVisibleInverse,
       },
       '&:disabled, &[disabled]': {
-        color: 'rgba(255, 255, 255, 0.45)',
+        color: theme.hexToRgba(theme.palette.common.white, 0.45),
         opacity: 1,
-        borderColor: 'rgba(255, 255, 255, 0.45)',
+        borderColor: theme.hexToRgba(theme.palette.common.white, 0.45),
       },
     },
     text: {

--- a/src/components/ButtonFilePicker/ButtonFilePicker.tsx
+++ b/src/components/ButtonFilePicker/ButtonFilePicker.tsx
@@ -73,7 +73,7 @@ export const useStyles = makeStyles(
       },
     },
     containedInverseDisabled: {
-      backgroundColor: 'rgba(255, 255, 255, 0.45)',
+      backgroundColor: theme.hexToRgba(theme.palette.common.white, 0.45),
       opacity: 1,
       color: theme.palette.text.secondary,
     },
@@ -100,18 +100,18 @@ export const useStyles = makeStyles(
       '&:hover': {
         color: theme.palette.common.white,
         opacity: 0.85,
-        borderColor: 'rgba(255, 255, 255, 0.85)',
+        borderColor: theme.hexToRgba(theme.palette.common.white, 0.85),
       },
       '&:focus': {
         color: theme.palette.common.white,
         opacity: 0.75,
-        borderColor: 'rgba(255, 255, 255, 0.75)',
+        borderColor: theme.hexToRgba(theme.palette.common.white, 0.75),
       },
     },
     outlinedInverseDisabled: {
-      color: 'rgba(255, 255, 255, 0.45)',
+      color: theme.hexToRgba(theme.palette.common.white, 0.45),
       opacity: 1,
-      borderColor: 'rgba(255, 255, 255, 0.45)',
+      borderColor: theme.hexToRgba(theme.palette.common.white, 0.45),
     },
     text: {
       backgroundColor: 'transparent',

--- a/src/components/ButtonLink/ButtonLink.tsx
+++ b/src/components/ButtonLink/ButtonLink.tsx
@@ -85,12 +85,12 @@ export const useStyles = makeStyles(
       '&:hover': {
         color: theme.palette.common.white,
         opacity: 0.85,
-        borderColor: 'rgba(255, 255, 255, 0.85)',
+        borderColor: theme.hexToRgba(theme.palette.common.white, 0.85),
       },
       '&:focus': {
         color: theme.palette.common.white,
         opacity: 0.75,
-        borderColor: 'rgba(255, 255, 255, 0.75)',
+        borderColor: theme.hexToRgba(theme.palette.common.white, 0.75),
       },
       '&:focus.focus-visible': {
         boxShadow: theme.boxShadows.focusVisibleInverse,

--- a/src/components/ColorPicker/ColorPicker.tsx
+++ b/src/components/ColorPicker/ColorPicker.tsx
@@ -58,7 +58,7 @@ export const useStyles = makeStyles(
       },
     },
     input: {
-      backgroundColor: 'rgba(132, 137, 166, 0.15)',
+      backgroundColor: theme.hexToRgba(theme.palette.graphite[900], 0.15),
       border: `1px solid transparent`,
       borderRadius: theme.pxToRem(4),
       color: theme.palette.text.primary,
@@ -73,8 +73,11 @@ export const useStyles = makeStyles(
       transition: 'border 0.25s ease',
       '&:focus': {
         outline: 'none',
-        backgroundColor: 'rgba(255, 255, 255, 0.5)',
-        border: `1px solid rgba(132, 137, 166, 0.45)`,
+        backgroundColor: theme.hexToRgba(theme.palette.common.white, 0.5),
+        border: `1px solid ${theme.hexToRgba(
+          theme.palette.graphite[900],
+          0.45
+        )}`,
       },
       '&:disabled': {
         cursor: 'not-allowed',
@@ -84,7 +87,7 @@ export const useStyles = makeStyles(
         cursor: 'not-allowed',
         opacity: 0.9,
         '&:focus': {
-          backgroundColor: 'rgba(132, 137, 166, 0.15)',
+          backgroundColor: theme.hexToRgba(theme.palette.graphite[900], 0.15),
           border: `1px solid transparent`,
         },
       },
@@ -102,29 +105,32 @@ export const useStyles = makeStyles(
       },
     },
     inputInverse: {
-      backgroundColor: 'rgba(230, 231, 237, 0.1)',
+      backgroundColor: theme.hexToRgba(theme.palette.graphite[100], 0.1),
       color: theme.palette.common.white,
       '&:focus': {
-        backgroundColor: 'rgba(230, 231, 237, 0.1)',
-        border: `1px solid rgba(230, 231, 237, 0.55)`,
+        backgroundColor: theme.hexToRgba(theme.palette.graphite[100], 0.1),
+        border: `1px solid ${theme.hexToRgba(
+          theme.palette.graphite[100],
+          0.55
+        )}`,
       },
       '&:read-only': {
         opacity: 1,
         '&:focus': {
-          backgroundColor: 'rgba(230, 231, 237, 0.1)',
+          backgroundColor: theme.hexToRgba(theme.palette.graphite[100], 0.1),
         },
       },
       '&::-webkit-input-placeholder': {
-        color: 'rgba(255, 255, 255, 0.8)',
+        color: theme.hexToRgba(theme.palette.common.white, 0.8),
       },
       '&::-moz-placeholder': {
-        color: 'rgba(255, 255, 255, 0.8)',
+        color: theme.hexToRgba(theme.palette.common.white, 0.8),
       },
       '&:-ms-input-placeholder': {
-        color: 'rgba(255, 255, 255, 0.8)',
+        color: theme.hexToRgba(theme.palette.common.white, 0.8),
       },
       '&:-moz-placeholder': {
-        color: 'rgba(255, 255, 255, 0.8)',
+        color: theme.hexToRgba(theme.palette.common.white, 0.8),
       },
     },
     hasTrailer: {
@@ -135,7 +141,7 @@ export const useStyles = makeStyles(
       width: 'fit-content',
     },
     inputError: {
-      backgroundColor: 'rgba(230, 231, 237, 0.1)',
+      backgroundColor: theme.hexToRgba(theme.palette.graphite[100], 0.1),
       border: `1px solid ${theme.palette.error.main}`,
       '&:focus': {
         border: `1px solid ${theme.palette.error.main}`,

--- a/src/components/Divider/Divider.tsx
+++ b/src/components/Divider/Divider.tsx
@@ -8,7 +8,7 @@ export const DividerStylesKey = 'ChromaDivider';
 export const useStyles = makeStyles(
   (theme) => ({
     root: {
-      backgroundColor: 'rgba(0, 0, 0, 0.15)',
+      backgroundColor: theme.hexToRgba(theme.palette.common.black, 0.15),
       border: 'none',
       flexShrink: 0,
       margin: 0,
@@ -21,7 +21,7 @@ export const useStyles = makeStyles(
       width: 1,
     },
     inverseColor: {
-      backgroundColor: 'rgba(255, 255, 255, 0.25)',
+      backgroundColor: theme.hexToRgba(theme.palette.common.white, 0.25),
     },
     vSpacing0: {
       margin: 0,

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -12,7 +12,10 @@ export const useStyles = makeStyles(
     root: {
       alignItems: 'center',
       backgroundColor: theme.palette.common.white,
-      boxShadow: '0px 4px 54px rgba(0, 0, 0, 0.12);',
+      boxShadow: `0px 4px 54px ${theme.hexToRgba(
+        theme.palette.common.black,
+        0.12
+      )};`,
       display: 'flex',
       flex: 1,
       height: headerHeight,

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -55,7 +55,7 @@ export const useStyles = makeStyles(
         },
       },
       '&:disabled': {
-        color: `rgba(255, 255, 255, 0.45)`,
+        color: theme.hexToRgba(theme.palette.common.white, 0.45),
       },
     },
     negative: {

--- a/src/components/IconTile/IconTileBadge.tsx
+++ b/src/components/IconTile/IconTileBadge.tsx
@@ -16,7 +16,10 @@ export const useStyles = makeStyles(
       left: 'calc(50% - 2.125rem)',
       backgroundColor: theme.palette.common.white,
       borderRadius: '100%',
-      boxShadow: '0px 4px 34px rgba(0, 0, 0, 0.25)',
+      boxShadow: `0px 4px 34px ${theme.hexToRgba(
+        theme.palette.common.black,
+        0.25
+      )}`,
       color: theme.palette.primary.main,
     },
     icon: {

--- a/src/components/IconTile/IconTileHero.tsx
+++ b/src/components/IconTile/IconTileHero.tsx
@@ -6,7 +6,7 @@ import { GetClasses, StandardProps } from '../../typeUtils';
 export const IconTileHeroStylesKey = 'ChromaIconTileHero';
 
 export const useStyles = makeStyles(
-  () => ({
+  (theme) => ({
     root: {
       position: 'relative',
       display: 'flex',
@@ -17,7 +17,12 @@ export const useStyles = makeStyles(
     },
     background: ({
       backgroundUrl,
-      backgroundColor = 'linear-gradient(45deg, #C947FD 0%, #2B4EFB 46.4%, #02BFF1 99.89%, rgba(48,177,251,0.85) 100%, #50D8FC 100%)',
+      backgroundColor = `linear-gradient(45deg, 
+        ${theme.palette.purple[700]} 0%, 
+        ${theme.palette.primary.main} 46.4%, 
+        ${theme.palette.primary[300]} 99.9%, 
+        ${theme.hexToRgba(theme.palette.primary[400], 0.85)} 100%, 
+        ${theme.palette.primary[200]} 100%)`,
     }: IconTileHeroOwnProps) => ({
       background: `url(${backgroundUrl}), ${backgroundColor}`,
       width: '100%',

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -12,7 +12,7 @@ export const LinkStylesKey = 'ChromaLink';
 export const useStyles = makeStyles(
   (theme) => ({
     root: {
-      color: 'rgba(0, 83, 154, 0.9)',
+      color: theme.hexToRgba(theme.palette.primary[900], 0.9),
       transition: 'color 0.25s ease',
       textDecoration: 'none',
       '&:hover': {
@@ -21,7 +21,7 @@ export const useStyles = makeStyles(
       },
     },
     inverse: {
-      color: 'rgba(255, 255, 255, 0.9)',
+      color: theme.hexToRgba(theme.palette.common.white, 0.9),
       '&:hover': {
         color: theme.palette.common.white,
       },

--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -25,7 +25,7 @@ export const useStyles = makeStyles(
       userSelect: 'none',
       width: '100%',
       '&:hover,&:focus': {
-        backgroundColor: 'rgba(222,244,252, 0.6)',
+        backgroundColor: theme.hexToRgba(theme.palette.primary[50], 0.6),
       },
       '&:focus': {
         outline: 'none',

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -29,7 +29,7 @@ export const OVERLAY_TEST_ID = 'chroma-overlay-testid';
 export const useStyles = makeStyles(
   (theme) => ({
     overlay: {
-      backgroundColor: 'rgba(0, 0, 0, 0.5)',
+      backgroundColor: theme.hexToRgba(theme.palette.common.black, 0.5),
       bottom: 0,
       display: 'flex',
       flexDirection: 'column',

--- a/src/components/Pill/Pill.tsx
+++ b/src/components/Pill/Pill.tsx
@@ -31,11 +31,17 @@ export const useStyles = makeStyles(
       background: theme.palette.positive.main,
     },
     highlight: {
-      background: `linear-gradient(135deg, ${theme.palette.primary.light} 0%, ${theme.palette.primary.main} 40%, rgb(166, 66, 254) 92%)`,
+      background: `linear-gradient(135deg, ${theme.palette.primary.light} 0%, ${theme.palette.primary.main} 40%, ${theme.palette.purple[700]} 92%)`,
       boxShadow: theme.boxShadows.table,
       borderRadius: theme.spacing(0.25, 1),
-      borderBottom: 'solid 1px rgba(0, 83, 154, 0.75)',
-      borderRight: 'solid 1px rgba(0, 83, 154, 0.75)',
+      borderBottom: `solid 1px ${theme.hexToRgba(
+        theme.palette.primary[900],
+        0.75
+      )}`,
+      borderRight: `solid 1px ${theme.hexToRgba(
+        theme.palette.primary[900],
+        0.75
+      )}`,
       color: theme.palette.common.white,
       fontSize: theme.pxToRem(9),
       fontWeight: theme.typography.fontWeightBolder,

--- a/src/components/Popover/PopoverItem.tsx
+++ b/src/components/Popover/PopoverItem.tsx
@@ -19,7 +19,7 @@ export const useStyles = makeStyles(
     },
     hoverPointer: {
       '&:hover, &:focus': {
-        backgroundColor: 'rgba(222,244,252, 0.6)',
+        backgroundColor: theme.hexToRgba(theme.palette.primary[50], 0.6),
         cursor: 'pointer',
       },
     },

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -24,14 +24,14 @@ export const useStyles = makeStyles(
       '& > input[type="radio"]::after': {
         opacity: 0,
         transition:
-          'transform .3s cubic-bezier(.2, .85, .32, 1.2), opacity .2s',
+          'transform 0.3s cubic-bezier(0.2, 0.85, 0.32, 1.2), opacity 0.2s',
       },
       '& > input[type="radio"]:checked::after': {
         opacity: 1,
       },
     },
     input: {
-      background: 'rgba(132, 137, 166, 0.15)',
+      background: theme.hexToRgba(theme.palette.graphite[900], 0.15),
       border: '1px solid transparent',
       borderRadius: '50%',
       cursor: 'pointer',
@@ -41,7 +41,7 @@ export const useStyles = makeStyles(
       MozAppearance: 'none',
       outline: 'none',
       position: 'relative',
-      transition: 'background .3s, border-color .3s, box-shadow .2s',
+      transition: 'background 0.3s, border-color 0.3s, box-shadow 0.2s',
       verticalAlign: 'top',
       WebkitAppearance: 'none',
       width: theme.pxToRem(21),
@@ -69,20 +69,29 @@ export const useStyles = makeStyles(
         },
       },
       '&:focus': {
-        boxShadow: '0 0 0 2px rgba(0, 150, 225, .3)',
+        boxShadow: `0 0 0 2px ${theme.hexToRgba(
+          theme.palette.primary[600],
+          0.3
+        )}`,
       },
       '&:hover:not(:disabled):not(:checked)': {
         border: `1px solid ${theme.palette.primary[700]}`,
       },
     },
     inputInverse: {
-      backgroundColor: 'rgba(230, 231, 237, 0.1)',
+      backgroundColor: theme.hexToRgba(theme.palette.graphite[100], 0.1),
       '&:checked': {
-        backgroundColor: 'rgba(230, 231, 237, 0.1)',
-        border: `1px solid rgba(230, 231, 237, 0.55)`,
+        backgroundColor: theme.hexToRgba(theme.palette.graphite[100], 0.1),
+        border: `1px solid ${theme.hexToRgba(
+          theme.palette.graphite[100],
+          0.55
+        )}`,
       },
       '&:focus': {
-        boxShadow: '0 0 0 2px rgba(255, 255, 255, .3)',
+        boxShadow: `0 0 0 2px ${theme.hexToRgba(
+          theme.palette.common.white,
+          0.3
+        )}`,
       },
       '&:hover:not(:disabled):not(:checked)': {
         border: `1px solid ${theme.palette.common.white}`,

--- a/src/components/Radio/RadioGroupMinimal.tsx
+++ b/src/components/Radio/RadioGroupMinimal.tsx
@@ -36,7 +36,7 @@ export const useStyles = makeStyles(
       color: theme.palette.common.white,
     },
     radios: {
-      background: 'rgba(132, 137, 166, 0.15)',
+      background: theme.hexToRgba(theme.palette.graphite[900], 0.15),
       borderRadius: theme.pxToRem(20),
       border: 'solid 1px transparent',
       display: 'inline-flex',
@@ -99,7 +99,10 @@ export const useStyles = makeStyles(
         },
         '&:focus + div': {
           '&::before': {
-            boxShadow: '0 0 0 2px rgba(0, 150, 225, .3)',
+            boxShadow: `0 0 0 2px ${theme.hexToRgba(
+              theme.palette.primary[600],
+              0.3
+            )}`,
           },
         },
       },
@@ -117,10 +120,10 @@ export const useStyles = makeStyles(
       },
     },
     radiosInverse: {
-      backgroundColor: 'rgba(230, 231, 237, 0.1)',
+      backgroundColor: theme.hexToRgba(theme.palette.graphite[100], 0.1),
       '& input:checked + div': {
         '&::before': {
-          background: 'rgba(255, 255, 255, 0.5)',
+          background: theme.hexToRgba(theme.palette.common.white, 0.5),
         },
         '& label > p, & svg': {
           color: 'unset',
@@ -128,7 +131,10 @@ export const useStyles = makeStyles(
       },
       '& input:focus + div': {
         '&::before': {
-          boxShadow: '0 0 0 2px rgba(255, 255, 255, .3)',
+          boxShadow: `0 0 0 2px ${theme.hexToRgba(
+            theme.palette.common.white,
+            0.3
+          )}`,
         },
       },
     },

--- a/src/components/SearchField/SearchField.tsx
+++ b/src/components/SearchField/SearchField.tsx
@@ -19,7 +19,7 @@ export const useStyles = makeStyles(
       position: 'relative',
     },
     input: {
-      backgroundColor: 'rgba(132, 137, 166, 0.15)',
+      backgroundColor: theme.hexToRgba(theme.palette.graphite[900], 0.15),
       border: `1px solid transparent`,
       borderRadius: theme.pxToRem(4),
       color: theme.palette.text.primary,
@@ -34,8 +34,11 @@ export const useStyles = makeStyles(
       maxWidth: theme.pxToRem(173),
       '&:focus': {
         outline: 'none',
-        backgroundColor: 'rgba(255, 255, 255, 0.5)',
-        border: `1px solid rgba(132, 137, 166, 0.45)`,
+        backgroundColor: theme.hexToRgba(theme.palette.common.white, 0.5),
+        border: `1px solid ${theme.hexToRgba(
+          theme.palette.graphite[900],
+          0.45
+        )}`,
       },
       '&:disabled': {
         cursor: 'not-allowed',
@@ -63,23 +66,26 @@ export const useStyles = makeStyles(
       },
     },
     inputInverse: {
-      backgroundColor: 'rgba(230, 231, 237, 0.1)',
+      backgroundColor: theme.hexToRgba(theme.palette.graphite[100], 0.1),
       color: theme.palette.common.white,
       '&:focus': {
-        backgroundColor: 'rgba(230, 231, 237, 0.1)',
-        border: `1px solid rgba(230, 231, 237, 0.55)`,
+        backgroundColor: theme.hexToRgba(theme.palette.graphite[100], 0.1),
+        border: `1px solid ${theme.hexToRgba(
+          theme.palette.graphite[100],
+          0.55
+        )}`,
       },
       '&::-webkit-input-placeholder': {
-        color: 'rgba(255, 255, 255, 0.8)',
+        color: theme.hexToRgba(theme.palette.common.white, 0.8),
       },
       '&::-moz-placeholder': {
-        color: 'rgba(255, 255, 255, 0.8)',
+        color: theme.hexToRgba(theme.palette.common.white, 0.8),
       },
       '&:-ms-input-placeholder': {
-        color: 'rgba(255, 255, 255, 0.8)',
+        color: theme.hexToRgba(theme.palette.common.white, 0.8),
       },
       '&:-moz-placeholder': {
-        color: 'rgba(255, 255, 255, 0.8)',
+        color: theme.hexToRgba(theme.palette.common.white, 0.8),
       },
     },
     inputHeight0: {

--- a/src/components/Select/RoverOption.tsx
+++ b/src/components/Select/RoverOption.tsx
@@ -20,7 +20,7 @@ export const useStyles = makeStyles(
       paddingRight: theme.spacing(2),
       transition: 'background-color 0.25s ease',
       '&:hover, &:focus': {
-        backgroundColor: 'rgba(222,244,252, 0.6)',
+        backgroundColor: theme.hexToRgba(theme.palette.primary[50], 0.6),
       },
     },
   }),

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -84,7 +84,7 @@ export const useStyles = makeStyles(
     },
     button: {
       alignItems: 'center',
-      backgroundColor: 'rgba(132, 137, 166, 0.15)',
+      backgroundColor: theme.hexToRgba(theme.palette.graphite[900], 0.15),
       border: 'solid 1px transparent',
       borderRadius: theme.pxToRem(4),
       color: theme.palette.text.primary,
@@ -106,7 +106,10 @@ export const useStyles = makeStyles(
         opacity: 0.625,
       },
       '&:focus': {
-        boxShadow: '0 0 0 2px rgba(0, 150, 225, .3)',
+        boxShadow: `0 0 0 2px ${theme.hexToRgba(
+          theme.palette.primary[600],
+          0.3
+        )}`,
         outline: 'none',
       },
       '&::-moz-focus-inner': {
@@ -114,13 +117,16 @@ export const useStyles = makeStyles(
       },
     },
     buttonInverse: {
-      backgroundColor: 'rgba(230, 231, 237, 0.1)',
+      backgroundColor: theme.hexToRgba(theme.palette.graphite[100], 0.1),
       color: theme.palette.common.white,
       '&:focus': {
-        boxShadow: '0 0 0 2px rgba(255, 255, 255, .3)',
+        boxShadow: `0 0 0 2px ${theme.hexToRgba(
+          theme.palette.common.white,
+          0.3
+        )}`,
       },
       '& $chip': {
-        background: 'rgba(255, 255, 255, 0.5)',
+        background: theme.hexToRgba(theme.palette.common.white, 0.5),
         color: theme.palette.text.primary,
       },
       '& $buttonText$placeholderText': {
@@ -128,7 +134,7 @@ export const useStyles = makeStyles(
       },
     },
     buttonError: {
-      backgroundColor: 'rgba(230, 231, 237, 0.1)',
+      backgroundColor: theme.hexToRgba(theme.palette.graphite[100], 0.1),
       border: `1px solid ${theme.palette.error.main}`,
       '&:focus': {
         border: `1px solid ${theme.palette.error.main}`,
@@ -199,7 +205,7 @@ export const useStyles = makeStyles(
       paddingRight: theme.spacing(2),
       transition: 'background-color 0.25s ease',
       '&:hover, &:focus': {
-        backgroundColor: 'rgba(222,244,252, 0.6)',
+        backgroundColor: theme.hexToRgba(theme.palette.primary[50], 0.6),
       },
     },
     chipList: {

--- a/src/components/Skeleton/Skeleton.tsx
+++ b/src/components/Skeleton/Skeleton.tsx
@@ -41,8 +41,7 @@ export const useStyles = makeStyles(
 
       '&::after': {
         animation: '$shine 1.6s linear 0.5s infinite',
-        background:
-          'linear-gradient(90deg, transparent, rgba(230, 231, 237, 1), transparent)', // graphite[200] with opacity
+        background: `linear-gradient(90deg, transparent, ${theme.palette.graphite[100]}, transparent)`,
         bottom: 0,
         content: `''`,
         left: 0,

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -40,7 +40,7 @@ export const useStyles = makeStyles(
       },
     },
     track: {
-      backgroundColor: 'rgba(132, 137, 166, 0.15)',
+      backgroundColor: theme.hexToRgba(theme.palette.graphite[900], 0.15),
       borderRadius: 2,
       cursor: 'pointer',
       flexGrow: 1,
@@ -51,7 +51,7 @@ export const useStyles = makeStyles(
       },
     },
     trackInverse: {
-      backgroundColor: 'rgba(230, 231, 237, 0.1)',
+      backgroundColor: theme.hexToRgba(theme.palette.graphite[100], 0.1),
     },
     range: {
       backgroundColor: theme.palette.primary.main,
@@ -79,14 +79,20 @@ export const useStyles = makeStyles(
         borderColor: theme.palette.graphite[600],
       },
       '&:hover, &:focus': {
-        boxShadow: '0 0 0 5px rgba(132, 137, 166, 0.08)',
+        boxShadow: `0 0 0 5px ${theme.hexToRgba(
+          theme.palette.graphite[900],
+          0.08
+        )}`,
       },
     },
     thumbInverse: {
       backgroundColor: theme.palette.graphite[100],
       borderColor: theme.palette.common.white,
       '&:hover, &:focus': {
-        boxShadow: '0 0 0 5px rgba(255, 255, 255, 0.09)',
+        boxShadow: `0 0 0 5px ${theme.hexToRgba(
+          theme.palette.common.white,
+          0.09
+        )}`,
       },
     },
     thumbError: {

--- a/src/components/Stepper/Step.tsx
+++ b/src/components/Stepper/Step.tsx
@@ -250,7 +250,7 @@ export const Step: React.FC<StepProps> = ({
     <li aria-current={active ? 'step' : undefined}>
       {as === 'button' ? (
         <button
-          aria-describedBy={getDescribedBy()}
+          aria-describedby={getDescribedBy()}
           aria-label={ariaLabel}
           className={clsx(
             classes.buttonRoot,
@@ -268,7 +268,7 @@ export const Step: React.FC<StepProps> = ({
       ) : (
         <Box
           align="center"
-          aria-describedBy={getDescribedBy()}
+          aria-describedby={getDescribedBy()}
           aria-label={ariaLabel}
           className={clsx(
             classes.divRoot,

--- a/src/components/Tabs/TabList.tsx
+++ b/src/components/Tabs/TabList.tsx
@@ -17,7 +17,7 @@ export const useStyles = makeStyles(
       overflow: 'hidden',
     },
     pill: {
-      background: 'rgba(132, 137, 166, 0.15)',
+      background: theme.hexToRgba(theme.palette.graphite[900], 0.15),
       borderRadius: theme.pxToRem(20),
       border: 'solid 1px transparent',
       display: 'inline-flex',

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -50,7 +50,7 @@ export const useStyles = makeStyles(
       },
     },
     textarea: {
-      backgroundColor: 'rgba(132, 137, 166, 0.15)',
+      backgroundColor: theme.hexToRgba(theme.palette.graphite[900], 0.15),
       border: `1px solid transparent`,
       borderRadius: theme.pxToRem(4),
       color: theme.palette.text.primary,
@@ -68,8 +68,11 @@ export const useStyles = makeStyles(
       transition: 'border 0.25s ease',
       '&:focus': {
         outline: 'none',
-        backgroundColor: 'rgba(255, 255, 255, 0.5)',
-        border: `1px solid rgba(132, 137, 166, 0.45)`,
+        backgroundColor: theme.hexToRgba(theme.palette.common.white, 0.5),
+        border: `1px solid ${theme.hexToRgba(
+          theme.palette.graphite[900],
+          0.45
+        )}`,
       },
       '&:disabled': {
         cursor: 'not-allowed',
@@ -79,9 +82,9 @@ export const useStyles = makeStyles(
         cursor: 'not-allowed',
         opacity: 0.9,
         '&:focus': {
-          backgroundColor: 'rgba(132, 137, 166, 0.15)',
+          backgroundColor: theme.hexToRgba(theme.palette.graphite[900], 0.15),
           border: `1px solid transparent`,
-        }
+        },
       },
       '&::-webkit-input-placeholder': {
         color: theme.palette.black[400],
@@ -97,33 +100,36 @@ export const useStyles = makeStyles(
       },
     },
     textareaInverse: {
-      backgroundColor: 'rgba(230, 231, 237, 0.1)',
+      backgroundColor: theme.hexToRgba(theme.palette.graphite[100], 0.1),
       color: theme.palette.common.white,
       '&:focus': {
-        backgroundColor: 'rgba(230, 231, 237, 0.1)',
-        border: `1px solid rgba(230, 231, 237, 0.55)`,
+        backgroundColor: theme.hexToRgba(theme.palette.graphite[100], 0.1),
+        border: `1px solid ${theme.hexToRgba(
+          theme.palette.graphite[100],
+          0.55
+        )}`,
       },
       '&:read-only': {
         opacity: 1,
         '&:focus': {
-          backgroundColor: 'rgba(230, 231, 237, 0.1)',
-        }
+          backgroundColor: theme.hexToRgba(theme.palette.graphite[100], 0.1),
+        },
       },
       '&::-webkit-input-placeholder': {
-        color: 'rgba(255, 255, 255, 0.8)',
+        color: theme.hexToRgba(theme.palette.common.white, 0.8),
       },
       '&::-moz-placeholder': {
-        color: 'rgba(255, 255, 255, 0.8)',
+        color: theme.hexToRgba(theme.palette.common.white, 0.8),
       },
       '&:-ms-input-placeholder': {
-        color: 'rgba(255, 255, 255, 0.8)',
+        color: theme.hexToRgba(theme.palette.common.white, 0.8),
       },
       '&:-moz-placeholder': {
-        color: 'rgba(255, 255, 255, 0.8)',
+        color: theme.hexToRgba(theme.palette.common.white, 0.8),
       },
     },
     textareaError: {
-      backgroundColor: 'rgba(230, 231, 237, 0.1)',
+      backgroundColor: theme.hexToRgba(theme.palette.graphite[100], 0.1),
       border: `1px solid ${theme.palette.error.main}`,
       '&:focus': {
         border: `1px solid ${theme.palette.error.main}`,

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -60,7 +60,7 @@ export const useStyles = makeStyles(
       },
     },
     input: {
-      backgroundColor: 'rgba(132, 137, 166, 0.15)',
+      backgroundColor: theme.hexToRgba(theme.palette.graphite[900], 0.15),
       border: `1px solid transparent`,
       borderRadius: theme.pxToRem(4),
       color: theme.palette.text.primary,
@@ -75,8 +75,11 @@ export const useStyles = makeStyles(
       transition: 'border 0.25s ease',
       '&:focus': {
         outline: 'none',
-        backgroundColor: 'rgba(255, 255, 255, 0.5)',
-        border: `1px solid rgba(132, 137, 166, 0.45)`,
+        backgroundColor: theme.hexToRgba(theme.palette.common.white, 0.5),
+        border: `1px solid ${theme.hexToRgba(
+          theme.palette.graphite[900],
+          0.45
+        )}`,
       },
       '&:disabled': {
         cursor: 'not-allowed',
@@ -86,7 +89,7 @@ export const useStyles = makeStyles(
         cursor: 'not-allowed',
         opacity: 0.9,
         '&:focus': {
-          backgroundColor: 'rgba(132, 137, 166, 0.15)',
+          backgroundColor: theme.hexToRgba(theme.palette.graphite[900], 0.15),
           border: `1px solid transparent`,
         },
       },
@@ -107,29 +110,32 @@ export const useStyles = makeStyles(
       maxWidth: theme.pxToRem(152),
     },
     inputInverse: {
-      backgroundColor: 'rgba(230, 231, 237, 0.1)',
+      backgroundColor: theme.hexToRgba(theme.palette.graphite[100], 0.1),
       color: theme.palette.common.white,
       '&:focus': {
-        backgroundColor: 'rgba(230, 231, 237, 0.1)',
-        border: `1px solid rgba(230, 231, 237, 0.55)`,
+        backgroundColor: theme.hexToRgba(theme.palette.graphite[100], 0.1),
+        border: `1px solid ${theme.hexToRgba(
+          theme.palette.graphite[100],
+          0.55
+        )}`,
       },
       '&:read-only': {
         opacity: 1,
         '&:focus': {
-          backgroundColor: 'rgba(230, 231, 237, 0.1)',
+          backgroundColor: theme.hexToRgba(theme.palette.graphite[100], 0.1),
         },
       },
       '&::-webkit-input-placeholder': {
-        color: 'rgba(255, 255, 255, 0.8)',
+        color: theme.hexToRgba(theme.palette.common.white, 0.8),
       },
       '&::-moz-placeholder': {
-        color: 'rgba(255, 255, 255, 0.8)',
+        color: theme.hexToRgba(theme.palette.common.white, 0.8),
       },
       '&:-ms-input-placeholder': {
-        color: 'rgba(255, 255, 255, 0.8)',
+        color: theme.hexToRgba(theme.palette.common.white, 0.8),
       },
       '&:-moz-placeholder': {
-        color: 'rgba(255, 255, 255, 0.8)',
+        color: theme.hexToRgba(theme.palette.common.white, 0.8),
       },
     },
     inputStartAdornment: {
@@ -171,7 +177,7 @@ export const useStyles = makeStyles(
       marginBottom: theme.spacing(0.5),
     },
     inputError: {
-      backgroundColor: 'rgba(230, 231, 237, 0.1)',
+      backgroundColor: theme.hexToRgba(theme.palette.graphite[100], 0.1),
       border: `1px solid ${theme.palette.error.main}`,
       '&:focus': {
         border: `1px solid ${theme.palette.error.main}`,

--- a/src/components/Toggle/Toggle.tsx
+++ b/src/components/Toggle/Toggle.tsx
@@ -38,7 +38,7 @@ export const useStyles = makeStyles(
       },
     },
     input: {
-      background: 'rgba(132, 137, 166, 0.15)',
+      background: theme.hexToRgba(theme.palette.graphite[900], 0.15),
       border: '1px solid transparent',
       borderRadius: theme.pxToRem(11),
       cursor: 'pointer',
@@ -76,22 +76,28 @@ export const useStyles = makeStyles(
         },
       },
       '&:focus': {
-        boxShadow: '0 0 0 2px rgba(0, 150, 225, .3)',
+        boxShadow: `0 0 0 2px ${theme.hexToRgba(
+          theme.palette.primary[600],
+          0.3
+        )}`,
       },
       '&:hover:not(:disabled):not(:checked)': {
         border: `1px solid ${theme.palette.primary[700]}`,
       },
     },
     inputInverse: {
-      backgroundColor: 'rgba(230, 231, 237, 0.1)',
-      border: '1px solid rgba(255, 255, 255, 0.2)',
+      backgroundColor: theme.hexToRgba(theme.palette.graphite[100], 0.1),
+      border: `1px solid ${theme.hexToRgba(theme.palette.common.white, 0.2)}`,
       mixBlendMode: 'hard-light',
       '&:checked': {
         background: theme.palette.secondary[500],
         border: `1px solid ${theme.palette.secondary[500]}`,
       },
       '&:focus': {
-        boxShadow: '0 0 0 2px rgba(255, 255, 255, .3)',
+        boxShadow: `0 0 0 2px ${theme.hexToRgba(
+          theme.palette.common.white,
+          0.3
+        )}`,
       },
       '&:hover:not(:disabled):not(:checked)': {
         border: `1px solid ${theme.palette.common.white}`,

--- a/src/styles/createTheme.ts
+++ b/src/styles/createTheme.ts
@@ -16,15 +16,14 @@ import {
   TypographyOptions,
 } from './createTypography';
 import { createOverrides, OverridesCreator } from './overrides';
-import { hexToRgba } from './utils/colorManipulator';
-
+import { hexToDec, isHex, sliceHex } from './utils/colorManipulator';
 export interface Theme extends Omit<MuiTheme, 'palette'> {
   palette: Palette;
   typography: Typography;
   boxShadows: BoxShadows;
   pxToRem: (size: number) => string;
+  hexToRgba: (hex: string, opacity: number) => string;
 }
-
 export interface ThemeOptions
   extends Omit<MuiThemeOptions, 'overrides' | 'palette' | 'typography'> {
   palette?: PaletteOptions;
@@ -32,6 +31,7 @@ export interface ThemeOptions
   overrides?: OverridesCreator;
   boxShadows?: BoxShadowsOptions;
   pxToRem?: (size: number) => string;
+  hexToRgba?: (hex: string, opacity: number) => string;
 }
 
 export const createTheme = ({
@@ -40,6 +40,7 @@ export const createTheme = ({
   overrides,
   boxShadows,
   pxToRem,
+  hexToRgba,
   ...muiOptions
 }: ThemeOptions = {}): Theme => {
   const themeWithoutOverrides = (createMuiTheme({
@@ -47,7 +48,24 @@ export const createTheme = ({
     typography: createTypography(typography),
     boxShadows: createBoxShadows(boxShadows),
     pxToRem: (size: number) => `${size / 16}rem`,
-    hexToRgba: hexToRgba,
+    hexToRgba: (hex: string, opacity?: number): string => {
+      let rgba = '';
+      if (isHex(hex)) {
+        const hexArr = sliceHex(hex);
+        const r = hexToDec(hexArr[0]);
+        const g = hexToDec(hexArr[1]);
+        const b = hexToDec(hexArr[2]);
+        if (opacity) {
+          const percent = opacity > 1 ? '%' : '';
+          rgba = `rgba(${r},${g},${b},${opacity}${percent})`;
+        } else {
+          rgba = `rgba(${r},${g},${b},1)`;
+        }
+      } else {
+        throw new Error('Invalid hex code');
+      }
+      return rgba;
+    },
     ...muiOptions,
   } as any) as any) as Theme;
 

--- a/src/styles/createTheme.ts
+++ b/src/styles/createTheme.ts
@@ -16,7 +16,7 @@ import {
   TypographyOptions,
 } from './createTypography';
 import { createOverrides, OverridesCreator } from './overrides';
-import { hexToDec, isHex, sliceHex } from './utils/colorManipulator';
+import { hexToRgba } from './utils/colorManipulator';
 export interface Theme extends Omit<MuiTheme, 'palette'> {
   palette: Palette;
   typography: Typography;
@@ -31,7 +31,6 @@ export interface ThemeOptions
   overrides?: OverridesCreator;
   boxShadows?: BoxShadowsOptions;
   pxToRem?: (size: number) => string;
-  hexToRgba?: (hex: string, opacity: number) => string;
 }
 
 export const createTheme = ({
@@ -40,7 +39,6 @@ export const createTheme = ({
   overrides,
   boxShadows,
   pxToRem,
-  hexToRgba,
   ...muiOptions
 }: ThemeOptions = {}): Theme => {
   const themeWithoutOverrides = (createMuiTheme({
@@ -48,24 +46,7 @@ export const createTheme = ({
     typography: createTypography(typography),
     boxShadows: createBoxShadows(boxShadows),
     pxToRem: (size: number) => `${size / 16}rem`,
-    hexToRgba: (hex: string, opacity?: number): string => {
-      let rgba = '';
-      if (isHex(hex)) {
-        const hexArr = sliceHex(hex);
-        const r = hexToDec(hexArr[0]);
-        const g = hexToDec(hexArr[1]);
-        const b = hexToDec(hexArr[2]);
-        if (opacity) {
-          const percent = opacity > 1 ? '%' : '';
-          rgba = `rgba(${r},${g},${b},${opacity}${percent})`;
-        } else {
-          rgba = `rgba(${r},${g},${b},1)`;
-        }
-      } else {
-        throw new Error('Invalid hex code');
-      }
-      return rgba;
-    },
+    hexToRgba,
     ...muiOptions,
   } as any) as any) as Theme;
 

--- a/src/styles/utils/colorManipulator.ts
+++ b/src/styles/utils/colorManipulator.ts
@@ -2,9 +2,9 @@ export function hexToRgba(hex: string, opacity?: number): string {
   let rgba = '';
   if (isHex(hex)) {
     const hexArr = sliceHex(hex);
-    const r = decToHex(hexArr[0]);
-    const g = decToHex(hexArr[1]);
-    const b = decToHex(hexArr[2]);
+    const r = hexToDec(hexArr[0]);
+    const g = hexToDec(hexArr[1]);
+    const b = hexToDec(hexArr[2]);
     if (opacity) {
       const percent = opacity > 1 ? '%' : '';
       rgba = `rgba(${r},${g},${b},${opacity}${percent})`;
@@ -17,7 +17,7 @@ export function hexToRgba(hex: string, opacity?: number): string {
   return rgba;
 }
 
-function decToHex(hex: string): number {
+export function hexToDec(hex: string): number {
   if (hex.length === 2) {
     return parseInt(hex[0], 16) * 16 + parseInt(hex[1], 16);
   } else {
@@ -25,11 +25,11 @@ function decToHex(hex: string): number {
   }
 }
 
-function isHex(hex: string): boolean {
+export function isHex(hex: string): boolean {
   return /^#([A-Fa-f0-9]{3}){1,2}$/.test(hex);
 }
 
-function sliceHex(hex: string): Array<string> {
+export function sliceHex(hex: string): Array<string> {
   const arr = [];
   hex = hex.slice(1); // remove #
   const l = hex.length;

--- a/stories/storyComponents/LabeledInput.tsx
+++ b/stories/storyComponents/LabeledInput.tsx
@@ -1,6 +1,30 @@
 import * as React from 'react';
-import black from '../../src/colors/black';
-import { spacing } from '../storyStyles';
+import { makeStyles } from '../../src/styles';
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    marginBottom: theme.spacing(4),
+  },
+  input: {
+    appearance: 'none',
+    borderRadius: '0.25rem',
+    border: `1px solid ${theme.palette.black[100]}`,
+    paddingTop: '0.5rem',
+    paddingBottom: '0.5rem',
+    paddingLeft: '0.75rem',
+    paddingRight: '0.75rem',
+    boxShadow: `
+      0 1px 3px 0 ${theme.hexToRgba(theme.palette.common.black, 0.1)}, 
+      0 1px 2px 0 ${theme.hexToRgba(theme.palette.common.black, 0.06)}
+    `,
+  },
+  label: {
+    display: 'block',
+    marginBottom: theme.spacing(2),
+    fontWeight: 'bold',
+    color: theme.palette.black[700],
+  },
+}));
 
 interface LabeledInputProps {
   label?: string;
@@ -15,17 +39,10 @@ export const LabeledInput: React.FC<LabeledInputProps> = ({
   type = 'number',
   onChange,
 }) => {
+  const classes = useStyles({});
   return (
-    <div style={{ marginBottom: spacing[4] }}>
-      <label
-        htmlFor={label}
-        style={{
-          display: 'block',
-          marginBottom: spacing[2],
-          fontWeight: 'bold',
-          color: black[700],
-        }}
-      >
+    <div className={classes.root}>
+      <label htmlFor={label} className={classes.label}>
         {label}
       </label>
       <input
@@ -34,16 +51,7 @@ export const LabeledInput: React.FC<LabeledInputProps> = ({
         id={label}
         value={value}
         onInput={onChange}
-        style={{
-          appearance: 'none',
-          borderRadius: '0.25rem',
-          border: `1px solid ${black[100]}`,
-          paddingTop: '0.5rem',
-          paddingBottom: '0.5rem',
-          paddingLeft: '0.75rem',
-          paddingRight: '0.75rem',
-          boxShadow: '0 1px 3px 0 rgba(0,0,0,.1), 0 1px 2px 0 rgba(0,0,0,.06)',
-        }}
+        className={classes.input}
       />
     </div>
   );

--- a/stories/storyComponents/LabeledInput.tsx
+++ b/stories/storyComponents/LabeledInput.tsx
@@ -21,7 +21,7 @@ const useStyles = makeStyles((theme) => ({
   label: {
     display: 'block',
     marginBottom: theme.spacing(2),
-    fontWeight: 'bold',
+    fontWeight: theme.typography.fontWeightBold,
     color: theme.palette.black[700],
   },
 }));


### PR DESCRIPTION
# What Was Changed

- Replaced all usage of rgba(x, y, z, a) with hexToRgba('some color', a)
  - This allows us to use theme colors from various palettes to keep things consistent and easier to change
  - I went ahead and changed some additional hex colors to use palettes
  - This PR can be an example to anyone who wants to start using the hexToRgba util in other repos

## Sanity Checks

- I searched for rgba() in VSCode
  - I left test files alone, as well as boxshadows since they were declared outside of a component. If you'd like me to address these as well, I can.
  - let me know if I missed any refs!
