### PR TITLE
PW-96 Add Required Styling to TextField

### DIFF
--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -288,7 +288,7 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
                   color === 'inverse' && classes.requiredInverse
                 )}
               >
-                *
+                &#42;
               </span>
             )}
             {label}

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -234,6 +234,8 @@ export interface TextFieldProps
   // Icon, IconButton, or IconButtonLink
   startAdornment?: React.ReactNode;
   endAdornment?: React.ReactNode;
+  /** This property shows the required asterisk (*). Required validation needs to be implemented separately. */
+  showRequiredLabel?: boolean;
 }
 
 export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
@@ -254,7 +256,7 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
       tooltipMessage,
       startAdornment,
       endAdornment,
-      required,
+      showRequiredLabel,
       ...rootProps
     },
     ref
@@ -281,7 +283,7 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
             )}
             htmlFor={uniqueId}
           >
-            {required && (
+            {showRequiredLabel && (
               <span
                 className={clsx(
                   classes.required,

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -206,6 +206,13 @@ export const useStyles = makeStyles(
       display: 'flex',
       outline: 'none',
     },
+    required: {
+      color: theme.palette.error[500],
+      margin: theme.spacing(0, 0.5),
+    },
+    requiredInverse: {
+      color: theme.palette.common.white,
+    },
   }),
   { name: TextFieldStylesKey }
 );
@@ -247,6 +254,7 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
       tooltipMessage,
       startAdornment,
       endAdornment,
+      required,
       ...rootProps
     },
     ref
@@ -273,6 +281,16 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
             )}
             htmlFor={uniqueId}
           >
+            {required && (
+              <span
+                className={clsx(
+                  classes.required,
+                  color === 'inverse' && classes.requiredInverse
+                )}
+              >
+                *
+              </span>
+            )}
             {label}
             {!!Icon && tooltipMessage && (
               <Tooltip title={tooltipMessage}>

--- a/stories/components/TextField/TextField.stories.tsx
+++ b/stories/components/TextField/TextField.stories.tsx
@@ -59,6 +59,7 @@ const AllTextFieldsStory: React.FC = () => {
             <TextField
               label="Name"
               hasError
+              required
               placeholder="Required"
               errorMessage="This is required!"
             />
@@ -133,6 +134,7 @@ const AllTextFieldsStory: React.FC = () => {
             <TextField
               label="Name"
               hasError
+              required
               placeholder="Required"
               errorMessage="This is required!"
             />
@@ -216,6 +218,7 @@ const AllTextFieldsStory: React.FC = () => {
             <TextField
               label="Name"
               hasError
+              required
               placeholder="Required"
               errorMessage="This is required!"
               color="inverse"
@@ -459,6 +462,7 @@ const InverseTextFieldStory: React.FC = () => {
           <TextField
             label="Name"
             hasError
+            required
             placeholder="Required"
             errorMessage="This is required!"
             color="inverse"

--- a/stories/components/TextField/TextField.stories.tsx
+++ b/stories/components/TextField/TextField.stories.tsx
@@ -59,7 +59,7 @@ const AllTextFieldsStory: React.FC = () => {
             <TextField
               label="Name"
               hasError
-              required
+              showRequiredLabel
               placeholder="Required"
               errorMessage="This is required!"
             />
@@ -134,7 +134,7 @@ const AllTextFieldsStory: React.FC = () => {
             <TextField
               label="Name"
               hasError
-              required
+              showRequiredLabel
               placeholder="Required"
               errorMessage="This is required!"
             />
@@ -218,7 +218,7 @@ const AllTextFieldsStory: React.FC = () => {
             <TextField
               label="Name"
               hasError
-              required
+              showRequiredLabel
               placeholder="Required"
               errorMessage="This is required!"
               color="inverse"
@@ -306,6 +306,7 @@ const AllTextFieldsStory: React.FC = () => {
             <TextField
               label="Name"
               hasError
+              showRequiredLabel
               placeholder="Required"
               errorMessage="This is required!"
               color="inverse"
@@ -398,6 +399,7 @@ const TextFieldStory: React.FC = () => {
         <TextField
           label="Name"
           hasError
+          showRequiredLabel
           placeholder="Required"
           errorMessage="This is required!"
         />
@@ -462,7 +464,7 @@ const InverseTextFieldStory: React.FC = () => {
           <TextField
             label="Name"
             hasError
-            required
+            showRequiredLabel
             placeholder="Required"
             errorMessage="This is required!"
             color="inverse"


### PR DESCRIPTION
# What Was Changed

- Added a left-aligned red asterisk to TextField to show that a field is required

## Questions for the Team

- @HaleyWardo pointed out that the 'required' prop may be confused for validation. Can I get thoughts on a solution?
  - Idea: Change to "styleRequired" or similar
  - Idea: Add docs note that this is just visual and validation still needs to be done

# Screenshots

## Before
![Screen Shot 2022-07-29 at 12 41 25 PM](https://user-images.githubusercontent.com/5824697/181832539-89667adf-0cbd-40b5-a426-757ea5950b3a.png)

## After
![Screen Shot 2022-07-29 at 12 41 09 PM](https://user-images.githubusercontent.com/5824697/181832532-dfb2f1d3-14a9-447c-b42c-a6750ed98394.png)

