### PR TITLE
feat: add forward refs

### DIFF
--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -47,26 +47,26 @@ export interface AlertProps {
   fullWidth?: boolean;
 }
 
-export const Alert: React.FC<AlertProps> = ({
-  className,
-  children,
-  fullWidth,
-  statusType = 'info',
-  ...rootProps
-}) => {
-  const classes = useStyles({});
-  return (
-    <div
-      className={clsx(
-        classes.root,
-        classes[statusType],
-        fullWidth && classes.fullWidth,
-        className
-      )}
-      role="alert"
-      {...rootProps}
-    >
-      {children}
-    </div>
-  );
-};
+export const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
+  (
+    { className, children, fullWidth, statusType = 'info', ...rootProps },
+    ref
+  ) => {
+    const classes = useStyles({});
+    return (
+      <div
+        className={clsx(
+          classes.root,
+          classes[statusType],
+          fullWidth && classes.fullWidth,
+          className
+        )}
+        ref={ref}
+        role="alert"
+        {...rootProps}
+      >
+        {children}
+      </div>
+    );
+  }
+);

--- a/src/components/ExpansionPanel/ExpansionPanel.tsx
+++ b/src/components/ExpansionPanel/ExpansionPanel.tsx
@@ -96,103 +96,116 @@ export interface ExpansionPanelProps
   contentDirection?: 'row' | 'column';
 }
 
-export const ExpansionPanel: React.FC<ExpansionPanelProps> = ({
-  ariaOwnsId,
-  children,
-  className,
-  contentClassName,
-  innerContentClassName,
-  onToggle,
-  isOpen = false,
-  contentDirection = 'column',
-  title,
-  ...rootProps
-}) => {
-  const classes = useStyles({});
-  const [isExpanded, setIsExpanded] = React.useState(isOpen);
-
-  const ref = React.useRef<HTMLDivElement>(null);
-  const [contentHeight, setContentHeight] = React.useState<number>(0);
-
-  const [ariaId] = React.useState<string>(
-    () => ariaOwnsId || generateUniqueId('exppanel-')
-  );
-
-  // Watch for `isOpen` changes
-  React.useEffect(() => {
-    setIsExpanded(isOpen);
-  }, [isOpen]);
-
-  // TODO: Look into https://medium.com/@teh_builder/ref-objects-inside-useeffect-hooks-eb7c15198780
-  //
-  // Determine the size of our content so we can expand/collapse
-  // accordingly.  If the children are dynamically generated, we should
-  // re-evaluate our size in case additional content is added/removed
-  React.useEffect(() => {
-    if (ref && ref.current && children) {
-      setContentHeight(ref.current.scrollHeight + 25);
-    }
-  }, [children, ref?.current?.scrollHeight]);
-
-  const handleClick = React.useCallback(
-    (e: React.SyntheticEvent) => {
-      e.preventDefault();
-      e.stopPropagation();
-
-      const newState = !isExpanded;
-      if (typeof onToggle === 'function') {
-        onToggle(newState);
-      }
-
-      setIsExpanded(newState);
+export const ExpansionPanel = React.forwardRef<
+  HTMLDivElement,
+  ExpansionPanelProps
+>(
+  (
+    {
+      ariaOwnsId,
+      children,
+      className,
+      contentClassName,
+      innerContentClassName,
+      onToggle,
+      isOpen = false,
+      contentDirection = 'column',
+      title,
+      ...rootProps
     },
-    [isExpanded, onToggle]
-  );
+    ref
+  ) => {
+    const classes = useStyles({});
+    const [isExpanded, setIsExpanded] = React.useState(isOpen);
 
-  return (
-    <div
-      className={clsx(classes.root, isExpanded && classes.rootOpen, className)}
-      {...rootProps}
-    >
-      <button
-        aria-expanded={isExpanded}
-        aria-owns={ariaId}
-        className={clsx(classes.button, isExpanded && classes.buttonShadow)}
-        onClick={handleClick}
-        tabIndex={0}
-      >
-        <Text className={classes.title} size="subbody" weight="bold">
-          {title}
-        </Text>
-        <Plus
-          className={clsx(classes.icon, isExpanded && classes.rotate)}
-          aria-hidden="true"
-          width={18}
-          height={18}
-        />
-      </button>
+    const innerRef = React.useRef<HTMLDivElement>(null);
+    const [contentHeight, setContentHeight] = React.useState<number>(0);
+
+    const [ariaId] = React.useState<string>(
+      () => ariaOwnsId || generateUniqueId('exppanel-')
+    );
+
+    // Watch for `isOpen` changes
+    React.useEffect(() => {
+      setIsExpanded(isOpen);
+    }, [isOpen]);
+
+    // TODO: Look into https://medium.com/@teh_builder/ref-objects-inside-useeffect-hooks-eb7c15198780
+    //
+    // Determine the size of our content so we can expand/collapse
+    // accordingly.  If the children are dynamically generated, we should
+    // re-evaluate our size in case additional content is added/removed
+    React.useEffect(() => {
+      if (innerRef && innerRef.current && children) {
+        setContentHeight(innerRef.current.scrollHeight + 25);
+      }
+    }, [children, innerRef?.current?.scrollHeight]);
+
+    const handleClick = React.useCallback(
+      (e: React.SyntheticEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const newState = !isExpanded;
+        if (typeof onToggle === 'function') {
+          onToggle(newState);
+        }
+
+        setIsExpanded(newState);
+      },
+      [isExpanded, onToggle]
+    );
+
+    return (
       <div
-        aria-hidden={!isExpanded}
-        id={ariaId}
-        className={clsx(classes.content, contentClassName)}
-        style={{ maxHeight: isExpanded ? contentHeight : 0 }}
+        className={clsx(
+          classes.root,
+          isExpanded && classes.rootOpen,
+          className
+        )}
+        ref={ref}
+        {...rootProps}
       >
-        <div
-          ref={ref}
-          className={clsx(
-            classes.inner,
-            innerContentClassName,
-            {
-              [classes.directionRow]: contentDirection === 'row',
-            },
-            !isExpanded && classes.innerHidden
-          )}
+        <button
+          aria-expanded={isExpanded}
+          aria-owns={ariaId}
+          className={clsx(classes.button, isExpanded && classes.buttonShadow)}
+          onClick={handleClick}
+          tabIndex={0}
         >
-          {children}
+          <Text className={classes.title} size="subbody" weight="bold">
+            {title}
+          </Text>
+          <Plus
+            className={clsx(classes.icon, isExpanded && classes.rotate)}
+            aria-hidden="true"
+            width={18}
+            height={18}
+          />
+        </button>
+        <div
+          aria-hidden={!isExpanded}
+          id={ariaId}
+          className={clsx(classes.content, contentClassName)}
+          style={{ maxHeight: isExpanded ? contentHeight : 0 }}
+        >
+          <div
+            ref={innerRef}
+            className={clsx(
+              classes.inner,
+              innerContentClassName,
+              {
+                [classes.directionRow]: contentDirection === 'row',
+              },
+              !isExpanded && classes.innerHidden
+            )}
+          >
+            {children}
+          </div>
         </div>
       </div>
-    </div>
-  );
-};
+    );
+  }
+);
 
 export default ExpansionPanel;

--- a/src/components/FormBox/FormBox.tsx
+++ b/src/components/FormBox/FormBox.tsx
@@ -147,66 +147,72 @@ export interface FormBoxProps extends BoxProps {
   paddingX?: 0 | 0.5 | 1 | 1.5 | 2;
 }
 
-export const FormBox: React.FC<FormBoxProps> = ({
-  className,
-  children,
-  direction = 'column',
-  spacing = 2,
-  padding,
-  paddingY,
-  paddingX,
-  ...rootProps
-}) => {
-  const classes = useStyles({});
-  return (
-    <Box
-      direction={direction}
-      className={clsx(
-        classes.root,
-        {
-          [classes.vSpacing0]: spacing === 0 && direction === 'column',
-          [classes.vSpacing05]: spacing === 0.5 && direction === 'column',
-          [classes.vSpacing10]: spacing === 1 && direction === 'column',
-          [classes.vSpacing15]: spacing === 1.5 && direction === 'column',
-          [classes.vSpacing20]: spacing === 2 && direction === 'column',
-          [classes.vSpacing25]: spacing === 2.5 && direction === 'column',
-          [classes.vSpacing30]: spacing === 3 && direction === 'column',
-        },
-        {
-          [classes.hSpacing0]: spacing === 0 && direction === 'row',
-          [classes.hSpacing05]: spacing === 0.5 && direction === 'row',
-          [classes.hSpacing10]: spacing === 1 && direction === 'row',
-          [classes.hSpacing15]: spacing === 1.5 && direction === 'row',
-          [classes.hSpacing20]: spacing === 2 && direction === 'row',
-          [classes.hSpacing25]: spacing === 2.5 && direction === 'row',
-          [classes.hSpacing30]: spacing === 3 && direction === 'row',
-        },
-        {
-          [classes.padding0]: padding === 0,
-          [classes.padding05]: padding === 0.5,
-          [classes.padding10]: padding === 1,
-          [classes.padding15]: padding === 1.5,
-          [classes.padding20]: padding === 2,
-        },
-        {
-          [classes.yPadding0]: paddingY === 0,
-          [classes.yPadding05]: paddingY === 0.5,
-          [classes.yPadding10]: paddingY === 1,
-          [classes.yPadding15]: paddingY === 1.5,
-          [classes.yPadding20]: paddingY === 2,
-        },
-        {
-          [classes.xPadding0]: paddingX === 0,
-          [classes.xPadding05]: paddingX === 0.5,
-          [classes.xPadding10]: paddingX === 1,
-          [classes.xPadding15]: paddingX === 1.5,
-          [classes.xPadding20]: paddingX === 2,
-        },
-        className
-      )}
-      {...rootProps}
-    >
-      {children}
-    </Box>
-  );
-};
+export const FormBox = React.forwardRef<HTMLDivElement, FormBoxProps>(
+  (
+    {
+      className,
+      children,
+      direction = 'column',
+      spacing = 2,
+      padding,
+      paddingY,
+      paddingX,
+      ...rootProps
+    },
+    ref
+  ) => {
+    const classes = useStyles({});
+    return (
+      <Box
+        direction={direction}
+        className={clsx(
+          classes.root,
+          {
+            [classes.vSpacing0]: spacing === 0 && direction === 'column',
+            [classes.vSpacing05]: spacing === 0.5 && direction === 'column',
+            [classes.vSpacing10]: spacing === 1 && direction === 'column',
+            [classes.vSpacing15]: spacing === 1.5 && direction === 'column',
+            [classes.vSpacing20]: spacing === 2 && direction === 'column',
+            [classes.vSpacing25]: spacing === 2.5 && direction === 'column',
+            [classes.vSpacing30]: spacing === 3 && direction === 'column',
+          },
+          {
+            [classes.hSpacing0]: spacing === 0 && direction === 'row',
+            [classes.hSpacing05]: spacing === 0.5 && direction === 'row',
+            [classes.hSpacing10]: spacing === 1 && direction === 'row',
+            [classes.hSpacing15]: spacing === 1.5 && direction === 'row',
+            [classes.hSpacing20]: spacing === 2 && direction === 'row',
+            [classes.hSpacing25]: spacing === 2.5 && direction === 'row',
+            [classes.hSpacing30]: spacing === 3 && direction === 'row',
+          },
+          {
+            [classes.padding0]: padding === 0,
+            [classes.padding05]: padding === 0.5,
+            [classes.padding10]: padding === 1,
+            [classes.padding15]: padding === 1.5,
+            [classes.padding20]: padding === 2,
+          },
+          {
+            [classes.yPadding0]: paddingY === 0,
+            [classes.yPadding05]: paddingY === 0.5,
+            [classes.yPadding10]: paddingY === 1,
+            [classes.yPadding15]: paddingY === 1.5,
+            [classes.yPadding20]: paddingY === 2,
+          },
+          {
+            [classes.xPadding0]: paddingX === 0,
+            [classes.xPadding05]: paddingX === 0.5,
+            [classes.xPadding10]: paddingX === 1,
+            [classes.xPadding15]: paddingX === 1.5,
+            [classes.xPadding20]: paddingX === 2,
+          },
+          className
+        )}
+        ref={ref}
+        {...rootProps}
+      >
+        {children}
+      </Box>
+    );
+  }
+);

--- a/src/components/Stepper/Stepper.tsx
+++ b/src/components/Stepper/Stepper.tsx
@@ -36,62 +36,68 @@ export interface StepperProps {
   onClick?: (index: number) => void;
 }
 
-export const Stepper: React.FC<StepperProps> = ({
-  activeStep,
-  as = 'button',
-  children,
-  className,
-  connectorClassName,
-  onClick,
-  ...rootProps
-}) => {
-  const classes = useStyles({});
-  const childrenArray = Array.isArray(children)
-    ? children
-    : React.Children.toArray(children);
-
-  const steps = childrenArray.map((child: any, index: number) => {
-    const childrenProps = {
-      active: false,
-      as,
-      completed: false,
-      index,
+export const Stepper = React.forwardRef<HTMLDivElement, StepperProps>(
+  (
+    {
+      activeStep,
+      as = 'button',
+      children,
+      className,
+      connectorClassName,
       onClick,
-    };
+      ...rootProps
+    },
+    ref
+  ) => {
+    const classes = useStyles({});
+    const childrenArray = Array.isArray(children)
+      ? children
+      : React.Children.toArray(children);
 
-    if (activeStep === index) {
-      childrenProps.active = true;
-    } else if (activeStep > index) {
-      childrenProps.completed = true;
-    }
+    const steps = childrenArray.map((child: any, index: number) => {
+      const childrenProps = {
+        active: false,
+        as,
+        completed: false,
+        index,
+        onClick,
+      };
 
-    const connector = <StepConnector />;
+      if (activeStep === index) {
+        childrenProps.active = true;
+      } else if (activeStep > index) {
+        childrenProps.completed = true;
+      }
 
-    return [
-      index !== 0 &&
-        React.cloneElement(connector, {
-          className: connectorClassName,
-          hasSubTitle: child.props.subTitle,
-          hasSubTitlePill: child.props.subTitlePillLabel,
-          key: `connector-${index}`,
+      const connector = <StepConnector />;
+
+      return [
+        index !== 0 &&
+          React.cloneElement(connector, {
+            className: connectorClassName,
+            hasSubTitle: child.props.subTitle,
+            hasSubTitlePill: child.props.subTitlePillLabel,
+            key: `connector-${index}`,
+            ...childrenProps,
+          }),
+        React.cloneElement(child, {
+          key: `step-${index}`,
+          numberOfSteps: childrenArray.length,
           ...childrenProps,
         }),
-      React.cloneElement(child, {
-        key: `step-${index}`,
-        numberOfSteps: childrenArray.length,
-        ...childrenProps,
-      }),
-    ];
-  });
+      ];
+    });
 
-  return (
-    <Box
-      fullWidth
-      className={clsx(classes.root, className)}
-      role="group"
-      {...rootProps}
-    >
-      <ol className={classes.innerRoot}>{steps}</ol>
-    </Box>
-  );
-};
+    return (
+      <Box
+        fullWidth
+        className={clsx(classes.root, className)}
+        ref={ref}
+        role="group"
+        {...rootProps}
+      >
+        <ol className={classes.innerRoot}>{steps}</ol>
+      </Box>
+    );
+  }
+);


### PR DESCRIPTION
Please hide whitespace when reviewing.

**Changes**
- Added `forwardRef` for `Alert`, `ExpansionPanel`, `FormBox`, and `Stepper`
  - I am seeing `Cannot read property scrollTop of null` when we are using a MUI transition and the child isn't a forward ref. 