### PR TITLE
fix: MUI component overrides and styling injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,20 @@ To get started with Chroma, follow these steps:
 
    Chroma leverages `@material-ui/styles` for CSS-in-JS and `react-router-dom` for link-related components.
 
-2. Wrap your application with the `ThemeProvider` provided by Chroma.
+2. Wrap your application with the `StyledEngineProvider` and `ThemeProvider` provided by Chroma.
 
    ```jsx
-   import { ThemeProvider } from '@lifeomic/chroma-react/styles';
+   import {
+     StyledEngineProvider,
+     ThemeProvider,
+   } from '@lifeomic/chroma-react/styles';
 
    function App({ children }) {
-     return <ThemeProvider>{children}</ThemeProvider>;
+     return (
+       <StyledEngineProvider injectFirst>
+         <ThemeProvider theme={theme}>{children}</ThemeProvider>
+       </StyledEngineProvider>
+     );
    }
    ```
 
@@ -100,7 +107,11 @@ Want to override the default theme of Chroma? No problem!
    import { theme } from './theme';
 
    function App({ children }) {
-     return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
+     return (
+       <StyledEngineProvider injectFirst>
+         <ThemeProvider theme={theme}>{children}</ThemeProvider>
+       </StyledEngineProvider>
+     );
    }
    ```
 

--- a/src/styles/__snapshots__/createTheme.test.ts.snap
+++ b/src/styles/__snapshots__/createTheme.test.ts.snap
@@ -35,6 +35,9 @@ Object {
   },
   "components": Object {
     "MuiButton": Object {
+      "defaultProps": Object {
+        "color": "secondary",
+      },
       "styleOverrides": Object {
         "containedPrimary": Object {
           "&$focusVisible": Object {
@@ -112,6 +115,21 @@ Object {
         },
       },
     },
+    "MuiCheckbox": Object {
+      "defaultProps": Object {
+        "color": "secondary",
+      },
+    },
+    "MuiFormControl": Object {
+      "defaultProps": Object {
+        "variant": "standard",
+      },
+    },
+    "MuiSelect": Object {
+      "defaultProps": Object {
+        "variant": "standard",
+      },
+    },
     "MuiTab": Object {
       "styleOverrides": Object {
         "iconWrapper": Object {
@@ -159,6 +177,11 @@ Object {
           "minHeight": "initial",
           "width": "100%",
         },
+      },
+    },
+    "MuiTextField": Object {
+      "defaultProps": Object {
+        "variant": "standard",
       },
     },
     "MuiTooltip": Object {
@@ -472,7 +495,6 @@ Object {
       "secondaryChannel": "0 0 0",
     },
     "tonalOffset": 0.2,
-    "type": "light",
     "warning": Object {
       "contrastText": "#fff",
       "dark": "#e65100",
@@ -695,6 +717,9 @@ Object {
       },
     },
     "MuiButton": Object {
+      "defaultProps": Object {
+        "color": "secondary",
+      },
       "styleOverrides": Object {
         "containedPrimary": Object {
           "&$focusVisible": Object {
@@ -773,6 +798,21 @@ Object {
         },
       },
     },
+    "MuiCheckbox": Object {
+      "defaultProps": Object {
+        "color": "secondary",
+      },
+    },
+    "MuiFormControl": Object {
+      "defaultProps": Object {
+        "variant": "standard",
+      },
+    },
+    "MuiSelect": Object {
+      "defaultProps": Object {
+        "variant": "standard",
+      },
+    },
     "MuiTab": Object {
       "styleOverrides": Object {
         "iconWrapper": Object {
@@ -820,6 +860,11 @@ Object {
           "minHeight": "initial",
           "width": "100%",
         },
+      },
+    },
+    "MuiTextField": Object {
+      "defaultProps": Object {
+        "variant": "standard",
       },
     },
     "MuiTooltip": Object {
@@ -1133,7 +1178,6 @@ Object {
       "secondaryChannel": "0 0 0",
     },
     "tonalOffset": 0.2,
-    "type": "light",
     "warning": Object {
       "contrastText": "#fff",
       "dark": "#e65100",

--- a/src/styles/createPalette.ts
+++ b/src/styles/createPalette.ts
@@ -19,7 +19,7 @@ const baseMuiPalette = {
   primary: blue,
   secondary: green,
   error: red,
-  type: 'light',
+  mode: 'light',
   common: {
     black: black.main,
     white: '#ffffff',

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1,3 +1,4 @@
+export { StyledEngineProvider } from '@mui/material';
 export { ThemeProvider } from '@mui/material/styles';
 export { createTheme, Theme, useTheme } from './createTheme';
 export { createPalette, Palette, PaletteOptions } from './createPalette';

--- a/src/styles/overrides/index.ts
+++ b/src/styles/overrides/index.ts
@@ -15,10 +15,17 @@ export const createOverrides = (
   overridesCreator?: OverridesCreator
 ) => {
   const baseOverrides: Components = {
-    MuiButton: { styleOverrides: createMuiButtonOverrides(theme) },
+    MuiButton: {
+      defaultProps: { color: 'secondary' },
+      styleOverrides: createMuiButtonOverrides(theme),
+    },
+    MuiCheckbox: { defaultProps: { color: 'secondary' } },
+    MuiFormControl: { defaultProps: { variant: 'standard' } },
+    MuiSelect: { defaultProps: { variant: 'standard' } },
     MuiTooltip: { styleOverrides: createMuiTooltipOverrides(theme) },
     MuiTabs: { styleOverrides: createMuiTabsOverrides(theme) },
     MuiTab: { styleOverrides: createMuiTabOverrides(theme) },
+    MuiTextField: { defaultProps: { variant: 'standard' } },
   };
 
   if (!overridesCreator) {

--- a/src/testUtils/renderWithTheme.tsx
+++ b/src/testUtils/renderWithTheme.tsx
@@ -1,6 +1,6 @@
 import { Queries, render, RenderOptions } from '@testing-library/react';
 import * as React from 'react';
-import { createTheme, ThemeProvider } from '../styles';
+import { createTheme, StyledEngineProvider, ThemeProvider } from '../styles';
 
 export const theme = createTheme();
 
@@ -9,12 +9,18 @@ export function renderWithTheme<Q extends Queries>(
   options?: RenderOptions<Q> | Omit<RenderOptions, 'queries'>
 ) {
   const { rerender, ...result } = render(
-    <ThemeProvider theme={theme}>{ui}</ThemeProvider>,
+    <StyledEngineProvider injectFirst>
+      <ThemeProvider theme={theme}>{ui}</ThemeProvider>
+    </StyledEngineProvider>,
     options
   );
 
   const wrappedRerender = (ui: React.ReactElement<any>) =>
-    rerender(<ThemeProvider theme={theme}>{ui}</ThemeProvider>);
+    rerender(
+      <StyledEngineProvider injectFirst>
+        <ThemeProvider theme={theme}>{ui}</ThemeProvider>
+      </StyledEngineProvider>
+    );
 
   return {
     ...result,

--- a/stories/components/Paper/Paper.stories.tsx
+++ b/stories/components/Paper/Paper.stories.tsx
@@ -1,20 +1,32 @@
+import { FormControl } from '@mui/material';
 import { select } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 import * as React from 'react';
 import { Paper } from '../../../src/components/Paper';
 import { Container } from '../../storyComponents/Container';
+import { makeStyles, Theme } from '../../../src/styles';
 import md from './default.md';
 
-const PaperStory: React.FC = () => (
-  <Container
-    containerStyles={{ display: 'flex', justifyContent: 'space-around' }}
-  >
-    <Paper padding={select('padding', [0, 1, 2], 2)}>
-      <p>Your content here</p>
-    </Paper>
-  </Container>
-);
+const useStyles = makeStyles((theme: Theme) => ({
+  formControl: {
+    marginBottom: theme.spacing(4),
+  },
+}));
 
+const PaperStory: React.FC = () => {
+  const classes = useStyles({});
+
+  return (
+    <Container
+      containerStyles={{ display: 'flex', justifyContent: 'space-around' }}
+    >
+      <Paper padding={select('padding', [0, 1, 2], 2)}>
+        <FormControl className={classes.formControl}>asjkdgk</FormControl>
+        <p>Your content here</p>
+      </Paper>
+    </Container>
+  );
+};
 storiesOf('Components/Paper', module).add('Default', () => <PaperStory />, {
   readme: { content: md },
 });

--- a/stories/components/Paper/Paper.stories.tsx
+++ b/stories/components/Paper/Paper.stories.tsx
@@ -1,32 +1,20 @@
-import { FormControl } from '@mui/material';
 import { select } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 import * as React from 'react';
 import { Paper } from '../../../src/components/Paper';
 import { Container } from '../../storyComponents/Container';
-import { makeStyles, Theme } from '../../../src/styles';
 import md from './default.md';
 
-const useStyles = makeStyles((theme: Theme) => ({
-  formControl: {
-    marginBottom: theme.spacing(4),
-  },
-}));
+const PaperStory: React.FC = () => (
+  <Container
+    containerStyles={{ display: 'flex', justifyContent: 'space-around' }}
+  >
+    <Paper padding={select('padding', [0, 1, 2], 2)}>
+      <p>Your content here</p>
+    </Paper>
+  </Container>
+);
 
-const PaperStory: React.FC = () => {
-  const classes = useStyles({});
-
-  return (
-    <Container
-      containerStyles={{ display: 'flex', justifyContent: 'space-around' }}
-    >
-      <Paper padding={select('padding', [0, 1, 2], 2)}>
-        <FormControl className={classes.formControl}>asjkdgk</FormControl>
-        <p>Your content here</p>
-      </Paper>
-    </Container>
-  );
-};
 storiesOf('Components/Paper', module).add('Default', () => <PaperStory />, {
   readme: { content: md },
 });

--- a/stories/decorators/withTheme.tsx
+++ b/stories/decorators/withTheme.tsx
@@ -3,19 +3,25 @@ import { CssBaseline } from '@mui/material';
 // we should be able to re-add these typings
 // import { StoryDecorator } from '@storybook/react';
 import * as React from 'react';
-import { createTheme, ThemeProvider } from '../../src/styles';
+import {
+  createTheme,
+  StyledEngineProvider,
+  ThemeProvider,
+} from '../../src/styles';
 
 const phcTheme = createTheme();
 
 // See comment above, the typings for latest storybook are out of whack
 // So we are defaulting to `any` here.
 const withTheme: any = (story: any) => (
-  <ThemeProvider theme={phcTheme}>
-    <React.Fragment>
-      <CssBaseline />
-      {story()}
-    </React.Fragment>
-  </ThemeProvider>
+  <StyledEngineProvider injectFirst>
+    <ThemeProvider theme={phcTheme}>
+      <React.Fragment>
+        <CssBaseline />
+        {story()}
+      </React.Fragment>
+    </ThemeProvider>
+  </StyledEngineProvider>
 );
 
 export default withTheme;

--- a/stories/styles/color/color.stories.tsx
+++ b/stories/styles/color/color.stories.tsx
@@ -15,7 +15,6 @@ const {
   background,
   divider,
   text,
-  type,
   ...additionalColors
 } = palette;
 

--- a/stories/styles/theme/default.md
+++ b/stories/styles/theme/default.md
@@ -7,7 +7,11 @@
 Chroma requires that a theme be created for each application. To accomplish this a `createTheme` utility is exported. By default, if no arguments are passed, the theme for PHC will be used. Any part of the theme can be overridden by passing different options to createTheme. Anything passed in is deeply merged with the base theme.
 
 ```tsx
-import { ThemeProvider, createTheme } from '@lifeomic/chroma-react/styles';
+import {
+  ThemeProvider,
+  createTheme,
+  StyledEngineProvider,
+} from '@lifeomic/chroma-react/styles';
 import { black } from '@lifeomic/chroma-react/colors/black';
 import connectGreen from './colors/customGreen';
 
@@ -20,7 +24,9 @@ const connectTheme = createTheme({
 });
 
 const App: React.FC = () => (
-  <ThemeProvider theme={connectTheme}>{...app}</ThemeProvider>
+  <StyledEngineProvider injectFirst>
+    <ThemeProvider theme={connectTheme}>{...app}</ThemeProvider>
+  </StyledEngineProvider>
 );
 ```
 

--- a/stories/styles/theme/theme.stories.tsx
+++ b/stories/styles/theme/theme.stories.tsx
@@ -15,7 +15,11 @@ import purple from '../../../src/colors/purple';
 import red from '../../../src/colors/red';
 import yellow from '../../../src/colors/yellow';
 import { Button } from '../../../src/components/Button';
-import { createTheme, ThemeProvider } from '../../../src/styles';
+import {
+  createTheme,
+  StyledEngineProvider,
+  ThemeProvider,
+} from '../../../src/styles';
 import { Container } from '../../storyComponents/Container';
 import md from './default.md';
 
@@ -59,20 +63,22 @@ const ThemeStory: React.FC = () => {
   );
 
   return (
-    <ThemeProvider theme={theme}>
-      <Container theme="light">
-        <Button>Text Button</Button>
-        <Button>Text Button</Button>
-      </Container>
-      <Container theme="light">
-        <Button variant="outlined">Outlined Button</Button>
-        <Button variant="outlined">Outlined Button</Button>
-      </Container>
-      <Container theme="light">
-        <Button variant="contained">Contained Button</Button>
-        <Button variant="contained">Contained Button</Button>
-      </Container>
-    </ThemeProvider>
+    <StyledEngineProvider injectFirst>
+      <ThemeProvider theme={theme}>
+        <Container theme="light">
+          <Button>Text Button</Button>
+          <Button>Text Button</Button>
+        </Container>
+        <Container theme="light">
+          <Button variant="outlined">Outlined Button</Button>
+          <Button variant="outlined">Outlined Button</Button>
+        </Container>
+        <Container theme="light">
+          <Button variant="contained">Contained Button</Button>
+          <Button variant="contained">Contained Button</Button>
+        </Container>
+      </ThemeProvider>
+    </StyledEngineProvider>
   );
 };
 


### PR DESCRIPTION
**Changes**
- Updated component props and styling to previous values so that no breaking changes are introduced
- Added `StyledEngineProvider` export and updated documentation
  - This provider is required in order for our styles to override the MUI emotion component styles 