### PR TITLE
fix: Add display block to `<TextArea`

### DIFF
--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -54,6 +54,7 @@ export const useStyles = makeStyles(
       border: `1px solid transparent`,
       borderRadius: theme.pxToRem(4),
       color: theme.palette.text.primary,
+      display: 'block',
       fontFamily: theme.typography.fontFamily,
       fontSize: theme.pxToRem(14),
       lineHeight: 1.25,


### PR DESCRIPTION
`<TextArea` was not filling height of parent container. This was increasing vertical padding between form elements any time `<TextArea` was used inside a `<FormBox`.

BEFORE | AFTER
-- | --
<img width="370" alt="Screen Shot 2022-08-22 at 12 49 30 PM" src="https://user-images.githubusercontent.com/485903/185975785-ad4e6667-744f-4438-bccf-2d8819495e85.png"> | <img width="370" alt="Screen Shot 2022-08-22 at 12 49 49 PM" src="https://user-images.githubusercontent.com/485903/185975788-ab402811-774f-4c05-aa21-1f0ce5e6d351.png">

