### PR TITLE
fix: added ellipsis to title in Chroma Modal

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -162,6 +162,11 @@ export const useStyles = makeStyles(
         },
       },
     },
+    modalTitle: {
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+    },
   }),
   { name: ModalStylesKey }
 );
@@ -345,7 +350,7 @@ const Content = React.forwardRef<HTMLDivElement, ModalProps>(
             className={clsx(classes.modalHeader, classes.verticalPadding)}
           >
             {!!title && (
-              <Text size="subbody" weight="bold">
+              <Text className={classes.modalTitle} size="subbody" weight="bold">
                 {title}
               </Text>
             )}


### PR DESCRIPTION
fix: change Chroma Modal title to be one line and end with ellipsis.

https://user-images.githubusercontent.com/86892478/186474735-a3cd2513-e159-483b-a556-b7eb0a973738.mov


