### PR TITLE
fix: override breakpoints

### DIFF
--- a/src/styles/__snapshots__/createTheme.test.ts.snap
+++ b/src/styles/__snapshots__/createTheme.test.ts.snap
@@ -26,10 +26,10 @@ Object {
     "unit": "px",
     "up": [Function],
     "values": Object {
-      "lg": 1200,
-      "md": 900,
+      "lg": 1280,
+      "md": 960,
       "sm": 600,
-      "xl": 1536,
+      "xl": 1920,
       "xs": 0,
     },
   },
@@ -701,11 +701,11 @@ Object {
     "unit": "px",
     "up": [Function],
     "values": Object {
-      "lg": 1200,
-      "md": 900,
-      "sm": 600,
-      "xl": 1536,
-      "xs": 0,
+      "lg": 1500,
+      "md": 1000,
+      "sm": 800,
+      "xl": 2000,
+      "xs": 100,
     },
   },
   "components": Object {
@@ -832,7 +832,7 @@ Object {
           "&:hover": Object {
             "color": "#637585",
           },
-          "@media (min-width:600px)": Object {
+          "@media (min-width:800px)": Object {
             "fontSize": "0.875rem",
           },
           "fontSize": "0.875rem",
@@ -889,12 +889,12 @@ Object {
   "hexToRgba": [Function],
   "mixins": Object {
     "toolbar": Object {
-      "@media (min-width:0px)": Object {
+      "@media (min-width:100px)": Object {
         "@media (orientation: landscape)": Object {
           "minHeight": 48,
         },
       },
-      "@media (min-width:600px)": Object {
+      "@media (min-width:800px)": Object {
         "minHeight": 64,
       },
       "minHeight": 56,

--- a/src/styles/createTheme.test.ts
+++ b/src/styles/createTheme.test.ts
@@ -22,5 +22,8 @@ test('overridden theme', () => {
     },
   });
 
-  expect(createTheme({ components })).toMatchSnapshot();
+  // Allows Chroma's default values to be overridden
+  const breakpoints = { xs: 100, sm: 800, md: 1000, lg: 1500, xl: 2000 };
+
+  expect(createTheme({ breakpoints, components })).toMatchSnapshot();
 });

--- a/src/styles/createTheme.ts
+++ b/src/styles/createTheme.ts
@@ -25,7 +25,11 @@ export interface Theme extends Omit<MuiTheme, 'palette'> {
   hexToRgba: (hex: string, opacity: number) => string;
 }
 export interface ThemeOptions
-  extends Omit<MuiThemeOptions, 'components' | 'palette' | 'typography'> {
+  extends Omit<
+    MuiThemeOptions,
+    'components' | 'palette' | 'typography' | 'breakpoints'
+  > {
+  breakpoints?: MuiTheme['breakpoints']['values'];
   palette?: PaletteOptions;
   typography?: TypographyOptions;
   components?: OverridesCreator;
@@ -34,6 +38,7 @@ export interface ThemeOptions
 }
 
 export const createTheme = ({
+  breakpoints,
   palette,
   typography,
   components,
@@ -42,6 +47,9 @@ export const createTheme = ({
   ...muiOptions
 }: ThemeOptions = {}): Theme => {
   const themeWithoutOverrides = (createMuiTheme({
+    breakpoints: {
+      values: { xs: 0, sm: 600, md: 960, lg: 1280, xl: 1920, ...breakpoints },
+    },
     palette: createPalette(palette),
     typography: createTypography(typography),
     boxShadows: createBoxShadows(boxShadows),


### PR DESCRIPTION
**Changes**
- Override theme breakpoints - reverted back to previous default values
  - [MUI changed the default values ](https://github.com/mui/material-ui/issues/21902)