### PR TITLE
[NO-JIRA] Improve TableModule Sticky Columns

### DIFF
--- a/src/components/TableModule/TableHeaderCell.tsx
+++ b/src/components/TableModule/TableHeaderCell.tsx
@@ -27,7 +27,7 @@ export const useStyles = makeStyles(
       textAlign: 'left',
       top: 0,
       whiteSpace: 'nowrap',
-      zIndex: theme.zIndex.byValueUpTo20[3],
+      zIndex: theme.zIndex.byValueUpTo20[8],
       '&::after': {
         content: `''`,
         position: 'absolute',
@@ -84,7 +84,7 @@ export const useStyles = makeStyles(
       background: theme.palette.graphite[50],
       position: 'sticky',
       left: 0,
-      zIndex: theme.zIndex.byValueUpTo20[4],
+      zIndex: theme.zIndex.byValueUpTo20[10],
       willChange: 'transform',
     },
   }),

--- a/src/components/TableModule/TableModule.stories.tsx
+++ b/src/components/TableModule/TableModule.stories.tsx
@@ -48,10 +48,12 @@ const data = [
   },
 ];
 
+const dataLong = [...data, ...data, ...data, ...data];
+
 const Template: ComponentStory<typeof TableModule> = (args) => {
   const tableRef = useRef<HTMLTableElement>(null);
   return (
-    <div style={{ overflow: 'auto', width: '80%' }}>
+    <div style={{ overflow: 'auto', width: '80%', height: '400px' }}>
       <TableModule {...args} ref={tableRef} rowClickLabel="row-click-label" />
     </div>
   );
@@ -136,7 +138,7 @@ Default.args = {
 
 export const Sticky = Template.bind({});
 Sticky.args = {
-  data,
+  data: dataLong,
   config: [
     {
       header: {

--- a/src/components/TableModule/TableModule.tsx
+++ b/src/components/TableModule/TableModule.tsx
@@ -196,7 +196,7 @@ export const useStyles = makeStyles(
       willChange: 'transform',
     },
     isStickyLast: {
-      borderRight: `2px solid ${theme.palette.primary.main}`,
+      boxShadow: `inset -2px 0 ${theme.palette.primary.main}`,
     },
   }),
   { name: TableModuleStylesKey }

--- a/src/components/TableModule/TableModule.tsx
+++ b/src/components/TableModule/TableModule.tsx
@@ -155,6 +155,9 @@ export const useStyles = makeStyles(
     isStickyLast: {
       borderRight: `2px solid ${theme.palette.primary.main}`,
     },
+    isStickyHeader: {
+      zIndex: theme.zIndex.byValueUpTo20[5],
+    },
     tableModuleActions: {
       background: `linear-gradient(135deg,
         ${theme.palette.primary.light} 0%,
@@ -325,6 +328,9 @@ export const TableModule = React.memo(
           document.querySelectorAll('.sticky-cell-hook')
         );
         allStickyCells.forEach((cell, index) => {
+          if (index < stickyCols.length) {
+            cell?.classList.add(classes.isStickyHeader);
+          }
           if ((index + 1) % stickyCols.length === 0) {
             cell?.classList.add(classes.isStickyLast);
           }

--- a/src/components/TableModule/TableModule.tsx
+++ b/src/components/TableModule/TableModule.tsx
@@ -344,6 +344,10 @@ export const TableModule = React.memo(
             }
           });
           setStickyCellsLeft(stickyCellsLeft);
+        } else {
+          console.error(
+            "Table's forwardRef is null, please set it if you want the sticky cell's left value to be set correctly"
+          );
         }
       }, [forwardedRef, stickyCols]);
 

--- a/src/components/TableModule/TableModule.tsx
+++ b/src/components/TableModule/TableModule.tsx
@@ -133,7 +133,7 @@ export const useStyles = makeStyles(
       position: 'relative',
       textAlign: 'right',
       width: theme.pxToRem(1),
-      zIndex: theme.zIndex.byValueUpTo20[10],
+      zIndex: theme.zIndex.byValueUpTo20[6],
       // Add bottom border to table action row
       // when actions are hidden
       '&::after': {
@@ -197,9 +197,6 @@ export const useStyles = makeStyles(
     },
     isStickyLast: {
       borderRight: `2px solid ${theme.palette.primary.main}`,
-    },
-    isStickyHeader: {
-      zIndex: theme.zIndex.byValueUpTo20[5],
     },
   }),
   { name: TableModuleStylesKey }
@@ -323,9 +320,6 @@ export const TableModule = React.memo(
           document.querySelectorAll('.sticky-cell-hook')
         );
         allStickyCells.forEach((cell, index) => {
-          if (index < stickyCols.length) {
-            cell?.classList.add(classes.isStickyHeader);
-          }
           if ((index + 1) % stickyCols.length === 0) {
             cell?.classList.add(classes.isStickyLast);
           }

--- a/src/components/TableModule/TableModule.tsx
+++ b/src/components/TableModule/TableModule.tsx
@@ -147,17 +147,6 @@ export const useStyles = makeStyles(
         bottom: theme.pxToRem(-1),
       },
     },
-    sticky: {
-      position: 'sticky',
-      willChange: 'transform',
-      right: 0,
-    },
-    isStickyLast: {
-      borderRight: `2px solid ${theme.palette.primary.main}`,
-    },
-    isStickyHeader: {
-      zIndex: theme.zIndex.byValueUpTo20[5],
-    },
     tableModuleActions: {
       background: `linear-gradient(135deg,
         ${theme.palette.primary.light} 0%,
@@ -205,6 +194,12 @@ export const useStyles = makeStyles(
       position: 'sticky',
       zIndex: theme.zIndex.byValueUpTo20[4],
       willChange: 'transform',
+    },
+    isStickyLast: {
+      borderRight: `2px solid ${theme.palette.primary.main}`,
+    },
+    isStickyHeader: {
+      zIndex: theme.zIndex.byValueUpTo20[5],
     },
   }),
   { name: TableModuleStylesKey }

--- a/src/components/TableModule/TableModuleRow.tsx
+++ b/src/components/TableModule/TableModuleRow.tsx
@@ -123,11 +123,7 @@ const TableModuleRow: React.FC<TableModuleRowProps> = React.memo(
         {rowContents}
         {(onRowClick || rowActions) && (
           <td
-            className={clsx(
-              classes.tableRowCell,
-              classes.tableRowActionCell,
-              classes.sticky
-            )}
+            className={clsx(classes.tableRowCell, classes.tableRowActionCell)}
             role="cell"
           >
             {(Boolean(maybeRowActions) || onRowClick) && (


### PR DESCRIPTION
# What Was Changed

- While implementing sticky columns in PHC's OE I found some issues that needed to be fixed
  - Sticky header zIndex needed to be higher than the cells below
  - Got zIndex order right for the rightmost header cell and the action button cell
  - Redid the right border as a box shadow because in some situations the border was scrolling when it should have been sticky

## Sanity Checks

- Updated the Sticky Story to make sure the new zIndicies work both vertically and horizontally

# Screenshots

## Before

https://user-images.githubusercontent.com/5824697/203387793-37f5db56-2767-4531-a3c8-a38e0b2164ff.mov

## After

https://user-images.githubusercontent.com/5824697/203387824-d75c4ca9-68fe-42f5-95d9-b593ad0284a5.mov

