### PR TITLE
chore: start reporting master build failures to #open-source

### DIFF
--- a/.github/lifeomic-probot.yml
+++ b/.github/lifeomic-probot.yml
@@ -1,2 +1,6 @@
 enforceSemanticCommits: true
 requestIndividualReviewersFromTeam: '@lifeomic/chroma'
+reportWorkflowFailures:
+  Release:
+    # This is #open-source
+    slackChannel: C04928K3H5Z


### PR DESCRIPTION
## Motivation
This probot behavior allows reporting `master` build failures to a Slack channel. For our open source repos, we should use `#open-source`.

https://github.com/lifeomic/probot#reportworkflowfailures