### PR TITLE
[NO-JIRA] Make TableModule Row Menu Sticky Again

### DIFF
--- a/src/components/TableModule/TableModule.tsx
+++ b/src/components/TableModule/TableModule.tsx
@@ -188,6 +188,11 @@ export const useStyles = makeStyles(
         cursor: 'pointer',
       },
     },
+    stickyMenuButton: {
+      position: 'sticky',
+      willChange: 'transform',
+      right: 0,
+    },
     isSticky: {
       background: theme.palette.graphite[50],
       left: 0,

--- a/src/components/TableModule/TableModuleRow.tsx
+++ b/src/components/TableModule/TableModuleRow.tsx
@@ -123,7 +123,11 @@ const TableModuleRow: React.FC<TableModuleRowProps> = React.memo(
         {rowContents}
         {(onRowClick || rowActions) && (
           <td
-            className={clsx(classes.tableRowCell, classes.tableRowActionCell)}
+            className={clsx(
+              classes.tableRowCell,
+              classes.tableRowActionCell,
+              classes.stickyMenuButton
+            )}
             role="cell"
           >
             {(Boolean(maybeRowActions) || onRowClick) && (


### PR DESCRIPTION
# Problem
- Previous changes made it so you had to scroll to the end of a table's columns to access the hoverable context menu on a row
- The desired effect is to see this context menu at all times, even on tables with tons of columns

BEFORE | AFTER
-- | --
![table-actions-before](https://user-images.githubusercontent.com/485903/205108154-5bdc5f03-01c9-4d25-96d4-e9599f583ed6.gif) | ![table-action-after](https://user-images.githubusercontent.com/485903/205108203-a31aa646-a127-43d6-86b7-f7a31b28cd55.gif)

# What Caused the Problem
- Removal of a class, `sticky`, that made the menu stick to the right of the table
- Since there were both `sticky` and `isSticky` classes, I took `sticky` for being redundant and removed it

# Solution
- Added class back to TableModule and TableModuleRow
- Renamed it `stickyMenuButton` to eliminate future confusion