### PR TITLE
[PHC-4158] SelectOption Title Typing 

### DIFF
--- a/src/components/Select/SelectOption.tsx
+++ b/src/components/Select/SelectOption.tsx
@@ -60,8 +60,8 @@ export interface SelectOptionProps {
   disabled?: boolean;
   isChecked?: boolean;
   meta?: any;
-  subtitle?: string;
-  title?: string;
+  subtitle?: string | React.ReactNode | React.ReactNode[];
+  title?: string | React.ReactNode | React.ReactNode[];
   value: string;
 }
 


### PR DESCRIPTION
# What Was Changed

- To fix a type error [for this PR](https://github.com/lifeomic/phc-ui/pull/2735/), adding the typed ReactNode and ReactNode[] to `<SelectOption />` titles
- The error came about by using `react-intl`'s imperative API to add a styled `<i>` to the title, which makes the title's type a ReactNode[] not a string.

## Questions for the Team

- There are currently no stories for [SelectOption](https://lifeomic.github.io/chroma-react/?path=/story/form-components-select--default) in the storybook - do you think I should create some?
- This could be potentially useful in other components where people might want to use these styled sub elements
  - i.e. the `<MenuItem />` is essentially the same use case, etc. 
  - Should we make an effort to update all potentially applicable use cases now, or go on a need-to-build basis?

# Screenshots

_see [linked PR](https://github.com/lifeomic/phc-ui/pull/2735/) for a visual example_
