### PR TITLE
[PoC] Add a new component ReactTable

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,5 +110,8 @@
   },
   "resolutions": {
     "jsdom": "^16.3.0"
+  },
+  "optionalDependencies": {
+    "@tanstack/react-table": "^8.7.9"
   }
 }

--- a/src/components/ReactTable/ReactTable.stories.tsx
+++ b/src/components/ReactTable/ReactTable.stories.tsx
@@ -1,0 +1,131 @@
+import React, { useRef } from 'react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { createColumnHelper, Row } from '@tanstack/react-table';
+import { Checkbox } from '../Checkbox';
+
+import { ReactTable } from './ReactTable';
+
+export default {
+  title: 'Components/ReactTable',
+  component: ReactTable,
+  argTypes: {},
+} as ComponentMeta<typeof ReactTable>;
+
+type Food = {
+  description: string;
+  calories: string;
+  fat: string;
+  carbs: string;
+  category: string;
+};
+
+const data: Food[] = [
+  {
+    description: 'Frozen yoghurt',
+    calories: '159',
+    fat: '6.0',
+    carbs: '24',
+    category: 'yogurt',
+  },
+  {
+    description: 'Ice cream sandwich',
+    calories: '237',
+    fat: '9.0',
+    carbs: '37',
+    category: 'ice cream',
+  },
+  {
+    description: 'Eclair',
+    calories: '262',
+    fat: '16.0',
+    carbs: '24',
+    category: 'dessert',
+  },
+  {
+    description: 'Cupcake',
+    calories: '305',
+    fat: '3.7',
+    carbs: '67',
+    category: 'cake',
+  },
+];
+
+const columnHelper = createColumnHelper<Food>();
+
+const columns = [
+  columnHelper.accessor('description', {
+    cell: (info) => info.getValue(),
+    header: 'Description',
+  }),
+  columnHelper.accessor((row) => row.calories, {
+    id: 'calories',
+    cell: (info) => <i>{info.getValue()}</i>,
+    header: () => <span>Calories</span>,
+  }),
+  columnHelper.accessor('fat', {
+    header: () => 'Fat',
+    cell: (info) => info.renderValue(),
+  }),
+  columnHelper.accessor('carbs', {
+    header: () => <span>Carbs</span>,
+  }),
+  columnHelper.accessor('category', {
+    header: 'Category',
+  }),
+];
+
+const Template: ComponentStory<typeof ReactTable> = (args) => {
+  const tableRef = useRef<HTMLTableElement>(null);
+
+  const [rowSelection, setRowSelection] = React.useState({});
+
+  if (args.enableRowSelection) {
+    args.state = { rowSelection };
+    args.onRowSelectionChange = setRowSelection;
+  }
+
+  return (
+    <div style={{ overflow: 'auto', width: '80%', height: '400px' }}>
+      <ReactTable {...args} ref={tableRef} />
+    </div>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  data,
+  columns,
+};
+
+export const RowSelection = Template.bind({});
+const selectionColumn = {
+  id: 'select',
+  header: ({ table }) => (
+    <Checkbox
+      {...{
+        label: ' ',
+        checked: table.getIsAllRowsSelected(),
+        indeterminate: table.getIsSomeRowsSelected(),
+        onChange: table.getToggleAllRowsSelectedHandler(),
+      }}
+    />
+  ),
+  cell: ({ row }) => (
+    <div className="px-1">
+      <Checkbox
+        {...{
+          label: ' ',
+          checked: row.getIsSelected(),
+          disabled: !row.getCanSelect(),
+          onChange: row.getToggleSelectedHandler(),
+        }}
+      />
+    </div>
+  ),
+};
+
+RowSelection.args = {
+  data,
+  columns: [selectionColumn, ...columns],
+  enableRowSelection: true,
+};

--- a/src/components/ReactTable/ReactTable.tsx
+++ b/src/components/ReactTable/ReactTable.tsx
@@ -1,0 +1,104 @@
+import * as React from 'react';
+import clsx from 'clsx';
+
+import {
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+  ColumnDef,
+  OnChangeFn,
+  TableState,
+} from '@tanstack/react-table';
+
+import { TableModuleProps, useStyles } from '../TableModule/TableModule';
+
+export interface ReactTableProps<T> extends TableModuleProps {
+  data: Array<T>;
+  columns: ColumnDef<T, any>[];
+  enableRowSelection?: boolean;
+  onRowSelectionChange?: OnChangeFn<T>;
+  state?: Partial<TableState>;
+}
+
+export const ReactTable = React.memo(
+  React.forwardRef<HTMLTableElement, ReactTableProps<any>>(
+    (
+      {
+        columns,
+        className,
+        data,
+        enableRowSelection,
+        isLoading = false,
+        onRowSelectionChange,
+        rowRole,
+        sortState = { sortKey: null, sortDirection: null },
+        onStalledCapture,
+        maxCellWidth,
+        rowClickLabel,
+        state,
+        ...rootProps
+      },
+      forwardedRef
+    ) => {
+      const classes = useStyles({});
+
+      const table = useReactTable({
+        data,
+        columns,
+        enableRowSelection,
+        getCoreRowModel: getCoreRowModel(),
+        onRowSelectionChange,
+        state,
+      });
+
+      return (
+        <table
+          className={clsx(classes.root, className)}
+          ref={forwardedRef}
+          role="table"
+          {...rootProps}
+        >
+          <thead className={classes.tableHeader}>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <tr key={headerGroup.id} className={classes.tableRow} role="row">
+                {headerGroup.headers.map((header) => (
+                  <th key={header.id}>
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext()
+                        )}
+                  </th>
+                ))}
+              </tr>
+            ))}
+          </thead>
+          <tbody role="rowgroup">
+            {table.getRowModel().rows.map((row) => (
+              <tr
+                key={row.id}
+                className={clsx(classes.tableRow, classes.tableDataRow)}
+                role={rowRole || 'row'}
+              >
+                {row.getVisibleCells().map((cell) => (
+                  <td
+                    key={cell.id}
+                    className={clsx(
+                      classes.tableRowCell,
+                      classes.tableRowActionCell,
+                      classes.stickyMenuButton
+                    )}
+                    role="cell"
+                  >
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      );
+    }
+  )
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5619,6 +5619,18 @@
     "@svgr/plugin-svgo" "^4.2.0"
     loader-utils "^1.2.3"
 
+"@tanstack/react-table@^8.7.9":
+  version "8.7.9"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.7.9.tgz#9efcd168fb0080a7e0bc213b5eac8b55513babf4"
+  integrity sha512-6MbbQn5AupSOkek1+6IYu+1yZNthAKTRZw9tW92Vi6++iRrD1GbI3lKTjJalf8lEEKOqapPzQPE20nywu0PjCA==
+  dependencies:
+    "@tanstack/table-core" "8.7.9"
+
+"@tanstack/table-core@8.7.9":
+  version "8.7.9"
+  resolved "https://registry.yarnpkg.com/@tanstack/table-core/-/table-core-8.7.9.tgz#0e975f8a5079972f1827a569079943d43257c42f"
+  integrity sha512-4RkayPMV1oS2SKDXfQbFoct1w5k+pvGpmX18tCXMofK/VDRdA2hhxfsQlMvsJ4oTX8b0CI4Y3GDKn5T425jBCw==
+
 "@testing-library/dom@^7.2.1", "@testing-library/dom@^7.22.3":
   version "7.31.2"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.31.2.tgz#df361db38f5212b88555068ab8119f5d841a8c4a"


### PR DESCRIPTION
## Goal

bring in the row selection capability by using [react-table](https://www.npmjs.com/package/react-table)'s API.

## Progress

it works by adding a new module named `ReactTable`.

it will be lots of work to include react-table as a new Chroma component besides `TableModule`, will be lots of work to maintain and deprecate `TableModule` afterwards.

## Conclusion

Based on the similarity of `react-table` and `TableModule` API , it would be easier to just refactor `TableModule` by adding `react-table` as implementation and make it backward compatible.

 - when using `config` of `TableModule`, no changes to existing apps that use it.
 - when using `columns: ColumnRef[]` to configure TableModule , it will use react-table 's implementation.