### PR TITLE
fix(PHC-4380): avoid break change in type

### DIFF
--- a/src/components/TableModule/TableModule.stories.tsx
+++ b/src/components/TableModule/TableModule.stories.tsx
@@ -3,6 +3,7 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { TableModule } from './TableModule';
 import {
+  RowSelectionRow,
   RowSelectionState,
   TableConfiguration,
   TableSortClickProps,
@@ -453,13 +454,12 @@ export const RowSelection: ComponentStory<typeof TableModule> = (args) => {
   const tableRef = useRef<HTMLTableElement | null>(null);
   const initialRowSelection: RowSelectionState = { '0': true };
   const [rowSelection, setRowSelection] = React.useState(initialRowSelection);
-  const selectionColumn = {
-    id: 'select',
+  const selectionColumn: TableConfiguration<RowSelectionRow> = {
     header: {
       content: () => '',
     },
     cell: {
-      content: (rowData: any) => (
+      content: (rowData: RowSelectionRow) => (
         <Checkbox
           label=" "
           checked={rowData.getIsSelected()}

--- a/src/components/TableModule/TableModule.test.tsx
+++ b/src/components/TableModule/TableModule.test.tsx
@@ -14,7 +14,7 @@ import { log, error } from 'console';
 
 const testId = 'TableModule';
 
-const configWithCellContent: Array<TableConfiguration<any>> = [
+const configWithCellContent: Array<TableConfiguration> = [
   {
     header: {
       label: 'Description',
@@ -37,7 +37,7 @@ const configWithCellContent: Array<TableConfiguration<any>> = [
   },
 ];
 
-const configWithCellValuePath: Array<TableConfiguration<any>> = [
+const configWithCellValuePath: Array<TableConfiguration> = [
   {
     header: {
       label: 'Description',
@@ -125,7 +125,7 @@ test('it renders the provided "noResultsMessage"', async () => {
 });
 
 test('it renders columns using "header.label"', async () => {
-  const config: Array<TableConfiguration<any>> = [
+  const config: Array<TableConfiguration> = [
     {
       header: {
         label: 'Description',
@@ -154,7 +154,7 @@ test('it renders columns using "header.label"', async () => {
 });
 
 test('it renders columns using "header.content"', async () => {
-  const config: Array<TableConfiguration<any>> = [
+  const config: Array<TableConfiguration> = [
     {
       header: {
         content: (header: TableHeader) => {
@@ -228,7 +228,7 @@ test('it renders a table with data using "cell.valuePath"', async () => {
 });
 
 test('it applies the provided class to a cell with data using "cell.className"', async () => {
-  const config: Array<TableConfiguration<any>> = [
+  const config: Array<TableConfiguration> = [
     {
       header: {
         label: 'foo',
@@ -261,7 +261,7 @@ test('it applies the provided class to a cell with data using "cell.className"',
 });
 
 test('it respects the "align" properties on "config"', async () => {
-  const config: Array<TableConfiguration<any>> = [
+  const config: Array<TableConfiguration> = [
     {
       header: {
         align: 'right',
@@ -310,7 +310,7 @@ test('it respects the "align" properties on "config"', async () => {
 });
 
 test('it renders a single column table appropriately', async () => {
-  const config: Array<TableConfiguration<any>> = [
+  const config: Array<TableConfiguration> = [
     {
       header: {
         label: 'Description',
@@ -414,7 +414,7 @@ test('it applies "maxCellWidth=2"', async () => {
 test('it sorts on column click from no sort => sort asc', async () => {
   const sortFn = jest.fn();
 
-  const config: Array<TableConfiguration<any>> = [
+  const config: Array<TableConfiguration> = [
     {
       header: {
         label: 'Description',
@@ -468,7 +468,7 @@ test('it sorts on column click from no sort => sort asc', async () => {
 test('it sorts on column click from no sort => sort asc => sort desc', async () => {
   const sortFn = jest.fn();
 
-  const config: Array<TableConfiguration<any>> = [
+  const config: Array<TableConfiguration> = [
     {
       header: {
         label: 'Description',
@@ -527,7 +527,7 @@ test('it sorts on column click from no sort => sort asc => sort desc', async () 
 test('it sorts on column click from no sort => sort asc => sort desc => no sort', async () => {
   const sortFn = jest.fn();
 
-  const config: Array<TableConfiguration<any>> = [
+  const config: Array<TableConfiguration> = [
     {
       header: {
         label: 'Description',
@@ -590,7 +590,7 @@ test('it sorts by first column click, then resets sort when a secondary column i
   const col1SortFn = jest.fn();
   const col2SortFn = jest.fn();
 
-  const config: Array<TableConfiguration<any>> = [
+  const config: Array<TableConfiguration> = [
     {
       header: {
         label: 'Description',
@@ -671,7 +671,7 @@ test('it uses the provided "sortState"', async () => {
 });
 
 test('it sets isSticky class on all sticky columns', async () => {
-  const config: Array<TableConfiguration<any>> = configWithStickyColumns;
+  const config: Array<TableConfiguration> = configWithStickyColumns;
 
   const { findByTestId } = renderWithTheme(
     <TableModule data-testid={testId} config={config} data={data} />
@@ -705,7 +705,7 @@ test('it sets isSticky class on all sticky columns', async () => {
 });
 
 test('it sets "isStickyLast" class on last sticky column', async () => {
-  const config: Array<TableConfiguration<any>> = configWithStickyColumns;
+  const config: Array<TableConfiguration> = configWithStickyColumns;
 
   const { findByTestId } = renderWithTheme(
     <TableModule data-testid={testId} config={config} data={data} />

--- a/src/components/TableModule/types.ts
+++ b/src/components/TableModule/types.ts
@@ -39,7 +39,7 @@ export interface TableCell<Item = any> extends TableAlignOptions {
   className?: string;
 }
 
-export interface TableConfiguration<Item extends RowSelectionRow> {
+export interface TableConfiguration<Item = any> {
   header: TableHeader;
   cell: TableCell<Item>;
   isSticky?: boolean;
@@ -53,8 +53,8 @@ export interface TableState {
 }
 
 export interface RowSelectionRow {
-  getIsSelected?: () => boolean;
-  getCanSelect?: () => boolean;
-  toggleSelected?: (value?: boolean) => void;
-  getToggleSelectedHandler?: () => (event: unknown) => void;
+  getIsSelected: () => boolean;
+  getCanSelect: () => boolean;
+  toggleSelected: (value?: boolean) => void;
+  getToggleSelectedHandler: () => (event: unknown) => void;
 }


### PR DESCRIPTION
## Before

After merging of #333, type `TableConfiguration<Item>` will require one type argument, which will break all applications that uses `TableModule`.

## After

type `TableConfiguration<Item>` will not require any type argument, it could use `TableConfiguration<RowSelectionRow>` when using the row selection API.