### PR TITLE
fix(PHC-4380): achieves backward compatibility #331

### DIFF
--- a/src/components/TableModule/TableModule.tsx
+++ b/src/components/TableModule/TableModule.tsx
@@ -543,7 +543,9 @@ export const TableModule = React.memo(
               </tr>
             )}
             {data?.map((row, rowIndex) => {
-              const rowData = createRow(row, rowIndex);
+              const rowData = enableRowSelection
+                ? createRow(row, rowIndex)
+                : row;
               return (
                 <TableModuleRow
                   key={`tableRow-${rowIndex}`}


### PR DESCRIPTION
This will support backward compatibility where table row will be kept as they were when row selection is disabled (default option).