### PR TITLE
[PHC-4098] Add secondaryAction to SelectOption

### DIFF
--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -3,7 +3,7 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { Select } from './Select';
 import { SelectOption } from './SelectOption';
-import { Edit } from '@lifeomic/chromicons';
+import { ChevronRight, Edit } from '@lifeomic/chromicons';
 import { GroupHeading } from './GroupHeading';
 
 export default {
@@ -13,19 +13,44 @@ export default {
   subcomponents: { SelectOption, GroupHeading },
 } as ComponentMeta<typeof Select>;
 
-const Template: ComponentStory<typeof Select> = (args) => (
-  <Select {...args}>
-    <SelectOption title="Option 1" value="option 1" />
-    <SelectOption
-      title="Option 2"
-      subtitle="This is a subtitle. For options that need a little extra description."
-      value="option 2"
-    />
-    <GroupHeading data-select-role="heading">Group 1</GroupHeading>
-    <SelectOption disabled title="Option 3" value="option 3" />
-    <SelectOption title="Option 4" value="option 4" />
-  </Select>
-);
+const Template: ComponentStory<typeof Select> = (args) => {
+  const [selected, setSelected] = React.useState<string>('');
+
+  return (
+    <Select
+      {...args}
+      value={selected}
+      onChange={(value) => {
+        setSelected(value);
+        console.log(value);
+      }}
+    >
+      <SelectOption
+        title="Option 1"
+        value="option 1"
+        secondaryAction={args.secondaryAction}
+      />
+      <SelectOption
+        title="Option 2"
+        subtitle="This is a subtitle. For options that need a little extra description."
+        value="option 2"
+        secondaryAction={args.secondaryAction}
+      />
+      <GroupHeading data-select-role="heading">Group 1</GroupHeading>
+      <SelectOption
+        disabled
+        title="Option 3"
+        value="option 3"
+        secondaryAction={args.secondaryAction}
+      />
+      <SelectOption
+        title="Option 4"
+        value="option 4"
+        secondaryAction={args.secondaryAction}
+      />
+    </Select>
+  );
+};
 
 export const Default = Template.bind({});
 Default.args = {
@@ -74,6 +99,19 @@ Tooltip.args = {
   label: 'Select',
   icon: Edit,
   tooltipMessage: 'Tooltip Message',
+};
+
+export const SecondaryAction = Template.bind({});
+SecondaryAction.args = {
+  label: 'Select',
+  secondaryAction: {
+    args: 'https://lifeomic.com/',
+    action: (args: string) => {
+      alert(`You can do something with arg "${args}"`);
+    },
+    label: 'Do something',
+    icon: ChevronRight,
+  },
 };
 
 export const InverseDark = Template.bind({});

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -20,7 +20,7 @@ import {
 } from '../_private/forms';
 import { generateUniqueId } from '../_private/UniqueId';
 import { Text } from '../Text';
-import { SelectOptionProps } from './SelectOption';
+import { SelectOptionProps, SelectSecondaryAction } from './SelectOption';
 import { motion, useReducedMotion } from 'framer-motion';
 import { RoverOption } from './RoverOption';
 import { useRoverState } from 'reakit/Rover';
@@ -331,6 +331,7 @@ export interface SelectProps
     > {
   ['aria-label']?: string;
   children?: React.ReactNode;
+  secondaryAction?: SelectSecondaryAction;
   secondaryLabel?: string;
   fullWidth?: boolean;
   icon?: React.ComponentType<React.SVGProps<SVGSVGElement>>;
@@ -395,6 +396,7 @@ export const Select: React.FC<SelectProps> = ({
   icon: Icon,
   id,
   label,
+  secondaryAction,
   secondaryLabel,
   onChange,
   placeholder,

--- a/src/components/Select/SelectOption.tsx
+++ b/src/components/Select/SelectOption.tsx
@@ -6,6 +6,7 @@ import { GetClasses } from '../../typeUtils';
 import { Box } from '../Box';
 import { Text } from '../Text';
 import { IconButton } from '../IconButton';
+import { Tooltip } from '../Tooltip';
 
 export const SelectOptionStylesKey = 'ChromaSelectOption';
 
@@ -121,16 +122,18 @@ export const SelectOption: React.FC<SelectOptionProps> = ({
         {children}
       </Box>
       {secondaryAction && (
-        <IconButton
-          className={classes.obviousHover}
-          aria-label={secondaryAction?.label}
-          icon={secondaryAction?.icon}
-          onClick={(e) => {
-            e.stopPropagation();
-            secondaryAction.action(secondaryAction.args);
-          }}
+        <Tooltip title={`${title}: ${secondaryAction.label}`}>
+          <IconButton
+            className={classes.obviousHover}
+            aria-label={secondaryAction?.label}
+            icon={secondaryAction?.icon}
+            onClick={(e) => {
+              e.stopPropagation();
+              secondaryAction.action(secondaryAction.args);
+            }}
             size={0}
-        />
+          />
+        </Tooltip>
       )}
     </Box>
   );

--- a/src/components/Select/SelectOption.tsx
+++ b/src/components/Select/SelectOption.tsx
@@ -91,7 +91,7 @@ export const SelectOption: React.FC<SelectOptionProps> = ({
 }) => {
   const classes = useStyles({});
   return (
-    <Box fullWidth justify="space-between">
+    <Box fullWidth justify="space-between" align="center">
       <Box className={clsx(classes.root, className)} fullWidth {...rootProps}>
         {isChecked && (
           // This is required for a11y: we need to have some indicator for our screenreader friends
@@ -129,6 +129,7 @@ export const SelectOption: React.FC<SelectOptionProps> = ({
             e.stopPropagation();
             secondaryAction.action(secondaryAction.args);
           }}
+            size={0}
         />
       )}
     </Box>

--- a/src/components/Select/SelectOption.tsx
+++ b/src/components/Select/SelectOption.tsx
@@ -92,8 +92,14 @@ export const SelectOption: React.FC<SelectOptionProps> = ({
 }) => {
   const classes = useStyles({});
   return (
-    <Box fullWidth justify="space-between" align="center">
-      <Box className={clsx(classes.root, className)} fullWidth {...rootProps}>
+    <Box
+      className={clsx(classes.root, className)}
+      fullWidth
+      justify="space-between"
+      align="center"
+      {...rootProps}
+    >
+      <Box fullWidth>
         {isChecked && (
           // This is required for a11y: we need to have some indicator for our screenreader friends
           <VisuallyHidden>&#x2713;</VisuallyHidden>

--- a/src/components/Select/SelectOption.tsx
+++ b/src/components/Select/SelectOption.tsx
@@ -5,6 +5,7 @@ import { makeStyles } from '../../styles';
 import { GetClasses } from '../../typeUtils';
 import { Box } from '../Box';
 import { Text } from '../Text';
+import { IconButton } from '../IconButton';
 
 export const SelectOptionStylesKey = 'ChromaSelectOption';
 
@@ -48,15 +49,28 @@ export const useStyles = makeStyles(
       cursor: 'not-allowed',
       opacity: 0.625,
     },
+    obviousHover: {
+      '&:hover': {
+        backgroundColor: theme.palette.primary[100],
+      },
+    },
   }),
   { name: SelectOptionStylesKey }
 );
 
 export type SelectOptionClasses = GetClasses<typeof useStyles>;
 
+export type SelectSecondaryAction = {
+  action: (args: any | undefined) => void;
+  args: any | undefined;
+  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+  label: string;
+};
+
 export interface SelectOptionProps {
   className?: string;
   children?: React.ReactNode;
+  secondaryAction?: SelectSecondaryAction;
   disabled?: boolean;
   isChecked?: boolean;
   meta?: any;
@@ -68,6 +82,7 @@ export interface SelectOptionProps {
 export const SelectOption: React.FC<SelectOptionProps> = ({
   className,
   children,
+  secondaryAction,
   isChecked,
   title,
   subtitle,
@@ -76,33 +91,46 @@ export const SelectOption: React.FC<SelectOptionProps> = ({
 }) => {
   const classes = useStyles({});
   return (
-    <Box className={clsx(classes.root, className)} fullWidth {...rootProps}>
-      {isChecked && (
-        // This is required for a11y: we need to have some indicator for our screenreader friends
-        <VisuallyHidden>&#x2713;</VisuallyHidden>
+    <Box fullWidth justify="space-between">
+      <Box className={clsx(classes.root, className)} fullWidth {...rootProps}>
+        {isChecked && (
+          // This is required for a11y: we need to have some indicator for our screenreader friends
+          <VisuallyHidden>&#x2713;</VisuallyHidden>
+        )}
+        {title && (
+          <Box
+            direction="column"
+            justify="flex-start"
+            className={clsx(
+              isChecked && classes.checked,
+              disabled && classes.disabled
+            )}
+          >
+            {title && (
+              <Text className={classes.title} size="subbody">
+                {title}
+              </Text>
+            )}
+            {subtitle && (
+              <Text className={classes.subtitle} size="caption">
+                {subtitle}
+              </Text>
+            )}
+          </Box>
+        )}
+        {children}
+      </Box>
+      {secondaryAction && (
+        <IconButton
+          className={classes.obviousHover}
+          aria-label={secondaryAction?.label}
+          icon={secondaryAction?.icon}
+          onClick={(e) => {
+            e.stopPropagation();
+            secondaryAction.action(secondaryAction.args);
+          }}
+        />
       )}
-      {title && (
-        <Box
-          direction="column"
-          justify="flex-start"
-          className={clsx(
-            isChecked && classes.checked,
-            disabled && classes.disabled
-          )}
-        >
-          {title && (
-            <Text className={classes.title} size="subbody">
-              {title}
-            </Text>
-          )}
-          {subtitle && (
-            <Text className={classes.subtitle} size="caption">
-              {subtitle}
-            </Text>
-          )}
-        </Box>
-      )}
-      {children}
     </Box>
   );
 };


### PR DESCRIPTION
# What Was Changed

- Added new properties to `<SelectOption />` to allow for a 'secondaryAction' so that you can both select an option's value in the parent `<Select />` `onChange` and do something else with the individual `<SelectOption />` (e.g. navigate somewhere with more info about the option)
- Update Select story so it actually selects the value when you click an option

## Questions for the Team

- @dexterca, when you get back into the office, can I get your opinion on the design of this? We can add a link as `children` to a <SelectOption /> as it is, but this takes a lot more vertical space and imo is a little harder to tell which option each link goes with at first glance. Thoughts?

| *As-is option* | *Example new option from this PR* |
|---|---|
| ![Screenshot 2023-04-20 at 5 05 43 PM](https://user-images.githubusercontent.com/5824697/233761226-0d7b45f9-8f1f-4de3-b4dd-64c070e0969a.png) | <img width="275" alt="Screenshot 2023-04-21 at 2 16 43 PM" src="https://user-images.githubusercontent.com/5824697/233761237-f3aea9b5-b3bd-46bd-84d7-a2acc36c910a.png"> |

# Screenshots

## Before

https://user-images.githubusercontent.com/5824697/233761493-b535bc4e-0078-4cd2-b688-7db3824f1a59.mov

## After First Pass

https://user-images.githubusercontent.com/5824697/233761497-8c09bbde-b886-4082-9058-7d88e1d62921.mov

## After Updates

https://user-images.githubusercontent.com/5824697/234093129-e7529ef1-5028-4e5a-9b17-4da494163e69.mov



