### PR TITLE
PHC-4300 Fixes TypeError when rowData has read-only property

### DIFF
--- a/src/components/TableModule/TableModule.test.tsx
+++ b/src/components/TableModule/TableModule.test.tsx
@@ -187,25 +187,33 @@ test('it renders columns using "header.content"', async () => {
   expect(columns?.[1].textContent).toEqual('undefined1');
 });
 
-test('it renders a table with data using "cell.content"', async () => {
-  const { findAllByTestId } = renderWithTheme(
-    <TableModule
-      data-testid={testId}
-      config={configWithCellContent}
-      data={data}
-    />
-  );
+test.each`
+  config                   | data    | enableRowSelection
+  ${configWithCellContent} | ${data} | ${false}
+  ${configWithCellContent} | ${data} | ${true}
+`(
+  'it renders a table with data using "cell.content"',
+  async ({ config, data, enableRowSelection }) => {
+    const { findAllByTestId } = renderWithTheme(
+      <TableModule
+        data-testid={testId}
+        config={config}
+        data={data}
+        enableRowSelection={enableRowSelection}
+      />
+    );
 
-  const rows = await findAllByTestId(testIds.bodyRow);
-  expect(rows?.length).toEqual(2);
+    const rows = await findAllByTestId(testIds.bodyRow);
+    expect(rows?.length).toEqual(2);
 
-  const rowCells = await findAllByTestId(testIds.bodyCell);
-  expect(rowCells?.length).toEqual(4);
-  expect(rowCells?.[0]?.textContent).toEqual(data[0].description);
-  expect(rowCells?.[1]?.textContent).toEqual(data[0].calories);
-  expect(rowCells?.[2]?.textContent).toEqual(data[1].description);
-  expect(rowCells?.[3]?.textContent).toEqual(data[1].calories);
-});
+    const rowCells = await findAllByTestId(testIds.bodyCell);
+    expect(rowCells?.length).toEqual(4);
+    expect(rowCells?.[0]?.textContent).toEqual(data[0].description);
+    expect(rowCells?.[1]?.textContent).toEqual(data[0].calories);
+    expect(rowCells?.[2]?.textContent).toEqual(data[1].description);
+    expect(rowCells?.[3]?.textContent).toEqual(data[1].calories);
+  }
+);
 
 test('it renders a table with data using "cell.valuePath"', async () => {
   const { findAllByTestId } = renderWithTheme(

--- a/src/components/TableModule/TableModule.tsx
+++ b/src/components/TableModule/TableModule.tsx
@@ -433,6 +433,7 @@ export const TableModule = React.memo(
 
       const createRow = React.useCallback(
         (row: any, index: number): RowSelectionRow => ({
+          ...row,
           getIsSelected: () => {
             return isRowSelected(row, index);
           },
@@ -553,7 +554,7 @@ export const TableModule = React.memo(
                   onRowClick={onRowClick}
                   rowRole={rowRole}
                   maxCellWidth={maxCellWidth}
-                  row={Object.assign(row, rowData)}
+                  row={rowData}
                   headingsLength={headings?.length}
                   cells={cells}
                   rowActions={rowActions}


### PR DESCRIPTION
## Problem

Since `row` is in `any` type, when it has a read-only property like `__typename` when the row data comes from a GQL response object, the `Object.assign()` will fail. E.g.,

```
TypeError: Cannot assign to read only property '__typename' of object '#<Object>'
        at Function.assign (<anonymous>)
```