### PR TITLE
Adjust sticky column border-color, -width and background colors

### DIFF
--- a/src/components/TableModule/TableHeaderCell.tsx
+++ b/src/components/TableModule/TableHeaderCell.tsx
@@ -4,6 +4,7 @@ import { ChevronDown } from '@lifeomic/chromicons';
 import { makeStyles } from '../../styles/index';
 import { GetClasses } from '../../typeUtils';
 import { TableSortDirection, TableHeader, TableSortClickProps } from './types';
+import { lighten } from '@mui/material/styles';
 
 export const TableHeaderCellStylesKey = 'ChromaTableHeaderCell';
 
@@ -81,7 +82,7 @@ export const useStyles = makeStyles(
       transform: 'rotate(180deg)',
     },
     isSticky: {
-      background: theme.palette.graphite[50],
+      background: lighten(theme.palette.graphite[50], 0.5),
       position: 'sticky',
       left: 0,
       zIndex: theme.zIndex.byValueUpTo20[10],

--- a/src/components/TableModule/TableModule.tsx
+++ b/src/components/TableModule/TableModule.tsx
@@ -207,16 +207,7 @@ export const useStyles = makeStyles(
       willChange: 'transform',
     },
     isStickyLast: {
-      '&::before': {
-        background: theme.palette.graphite[300],
-        content: `''`,
-        display: 'block',
-        height: `calc(100% + ${theme.pxToRem(1)})`,
-        position: 'absolute',
-        right: 0,
-        top: 0,
-        width: theme.pxToRem(4),
-      },
+      boxShadow: `inset -4px 0 ${theme.palette.divider}`,
     },
   }),
   { name: TableModuleStylesKey }

--- a/src/components/TableModule/TableModule.tsx
+++ b/src/components/TableModule/TableModule.tsx
@@ -200,14 +200,23 @@ export const useStyles = makeStyles(
       right: 0,
     },
     isSticky: {
-      background: theme.palette.graphite[50],
+      background: lighten(theme.palette.graphite[50], 0.5),
       left: 0,
       position: 'sticky',
       zIndex: theme.zIndex.byValueUpTo20[4],
       willChange: 'transform',
     },
     isStickyLast: {
-      boxShadow: `inset -2px 0 ${theme.palette.primary.main}`,
+      '&::before': {
+        background: theme.palette.graphite[300],
+        content: `''`,
+        display: 'block',
+        height: `calc(100% + ${theme.pxToRem(1)})`,
+        position: 'absolute',
+        right: 0,
+        top: 0,
+        width: theme.pxToRem(4),
+      },
     },
   }),
   { name: TableModuleStylesKey }


### PR DESCRIPTION
I wanted to lighten sticky cell background in order to make disabled checkboxes more visible. This also enabled me to use `palette.divider` color for sticky right border color. I also doubled the width of the right-border from `2px` to `4px` to help with delineation between sticky and static.

Another win for using `palette.divider` is we now have a continuous vertical line. Whereas with `primary.main` we had a disconnected blue divider due to the use of two different colors.

<img width="508" alt="Screenshot 2023-04-27 at 2 09 51 PM" src="https://user-images.githubusercontent.com/485903/234954643-f8f4f8c7-5499-481e-b60d-2d3e1fc0154b.png">

BEFORE | AFTER
-- | --
<img width="349" alt="Screenshot 2023-04-27 at 2 02 16 PM" src="https://user-images.githubusercontent.com/485903/234952661-3e6eca78-f3c2-4ff9-8f9f-c46ae8dd6a4d.png"> | <img width="349" alt="Screenshot 2023-04-27 at 1 57 29 PM" src="https://user-images.githubusercontent.com/485903/234952340-8beba173-660a-407e-840b-c0802ce1d7ab.png">

