### PR TITLE
fix(TableModule): provide rowIndex to rowActions

### DIFF
--- a/src/components/TableModule/TableModule.stories.tsx
+++ b/src/components/TableModule/TableModule.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useRef, useState } from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { TableModule } from './TableModule';
@@ -520,4 +520,42 @@ RowSelection.parameters = {
       handler.`,
     },
   },
+};
+
+export const RowAddRemove = () => {
+  const [tableData, setTableData] = useState(data);
+  const tableRef = useRef<HTMLTableElement>(null);
+  return (
+    <div style={{ overflow: 'auto', width: '80%' }}>
+      <Button
+        onClick={() => {
+          setTableData([...tableData, data[0]]);
+        }}
+      >
+        Add row
+      </Button>
+      <TableModule
+        data={tableData}
+        config={HoverActions.args.config}
+        ref={tableRef}
+        rowClickLabel="row-click-label"
+        rowActions={(row: any, index?: number) => (
+          <Button
+            variant="text"
+            color="inverse"
+            style={{ marginRight: '8px' }}
+            onClick={() => {
+              if (index !== undefined) {
+                setTableData(
+                  tableData.slice(0, index).concat(tableData.slice(index + 1))
+                );
+              }
+            }}
+          >
+            Remove
+          </Button>
+        )}
+      />
+    </div>
+  );
 };

--- a/src/components/TableModule/TableModule.tsx
+++ b/src/components/TableModule/TableModule.tsx
@@ -228,7 +228,7 @@ export interface TableModuleProps<Item = any>
   noResultsMessage?: string;
   sortState?: TableSortState;
   maxCellWidth?: 1 | 2;
-  rowActions?: (row: any) => React.ReactNode;
+  rowActions?: (row: any, index?: number) => React.ReactNode;
   rowClickLabel?: string;
   state?: Partial<TableState>;
   enableRowSelection?: boolean;
@@ -557,6 +557,7 @@ export const TableModule = React.memo(
                   headingsLength={headings?.length}
                   cells={cells}
                   rowActions={rowActions}
+                  rowIndex={rowIndex}
                   rowClickLabel={rowClickLabel}
                   stickyCols={stickyCols}
                   stickyCellsLeft={stickyCellsLeft}

--- a/src/components/TableModule/TableModuleRow.tsx
+++ b/src/components/TableModule/TableModuleRow.tsx
@@ -23,6 +23,7 @@ export interface TableModuleRowProps
   headingsLength: number;
   cells: Array<TableCell>;
   rowActions?: TableModuleProps['rowActions'];
+  rowIndex?: number;
   rowClickLabel?: TableModuleProps['rowClickLabel'];
   stickyCols?: Array<number>;
   stickyCellsLeft?: Array<number>;
@@ -37,6 +38,7 @@ const TableModuleRow: React.FC<TableModuleRowProps> = React.memo(
     headingsLength,
     cells,
     rowActions,
+    rowIndex,
     rowClickLabel,
     stickyCols = [],
     stickyCellsLeft = [],
@@ -107,7 +109,7 @@ const TableModuleRow: React.FC<TableModuleRowProps> = React.memo(
       [cells, headingsLength, maxCellWidth, row, stickyCols, stickyCellsLeft]
     );
 
-    const maybeRowActions = React.useMemo(() => rowActions?.(row), [
+    const maybeRowActions = React.useMemo(() => rowActions?.(row, rowIndex), [
       row,
       rowActions,
     ]);


### PR DESCRIPTION
Add an optional prop `rowIndex` to `rowActions` to be able to delete current row from table