### PR TITLE
[PHC-4736] Wrap cell content

### DIFF
--- a/src/components/TableModule/TableModule.stories.tsx
+++ b/src/components/TableModule/TableModule.stories.tsx
@@ -142,6 +142,95 @@ Default.args = {
   ] as Array<TableConfiguration>,
 };
 
+export const WrappedCells = Template.bind({});
+WrappedCells.args = {
+  data,
+  maxCellWidth: 3,
+  wrapCellContent: true,
+  config: [
+    {
+      header: {
+        label: 'Description',
+      },
+      cell: {
+        content: (dataValue: any) => {
+          return dataValue.description;
+        },
+      },
+    },
+    {
+      header: {
+        label: 'Calories',
+      },
+      cell: {
+        content: (dataValue: any) => {
+          if (dataValue.calories === '159') {
+            return 'Vanilla: 250\nStrawberry: 175\nPlain: 80\n\nYogurt is known to provide probiotics through naturally included bacterial cultures. Beware of increaing your sugar intake though.\nNon-dairy options exist for those with lactose intolerance.';
+          }
+          return dataValue.calories;
+        },
+      },
+    },
+    {
+      header: {
+        label: 'Fat',
+      },
+      cell: {
+        content: (dataValue: any) => {
+          return dataValue.fat;
+        },
+      },
+    },
+    {
+      header: {
+        label: 'Carbs',
+      },
+      cell: {
+        content: (dataValue: any) => {
+          return dataValue.carbs;
+        },
+      },
+    },
+    {
+      header: {
+        label: 'Category',
+      },
+      cell: {
+        content: (dataValue: any) => {
+          return dataValue.category;
+        },
+      },
+    },
+    {
+      header: {
+        label: 'Category',
+      },
+      cell: {
+        content: (dataValue: any) => {
+          return dataValue.category;
+        },
+      },
+    },
+    {
+      header: {
+        label: 'Category',
+      },
+      cell: {
+        content: (dataValue: any) => {
+          return dataValue.category;
+        },
+      },
+    },
+  ] as Array<TableConfiguration>,
+};
+WrappedCells.parameters = {
+  docs: {
+    description: {
+      story: `If a table involves content that is very long and needs to be fully displayed, use wrapCellContent to show it all. This will also cover content that needs to honor new lines, i.e. a couple paragraphs with a break between or a list of items.`,
+    },
+  },
+};
+
 export const Sticky = Template.bind({});
 Sticky.args = {
   data: dataLong,

--- a/src/components/TableModule/TableModule.tsx
+++ b/src/components/TableModule/TableModule.tsx
@@ -212,6 +212,9 @@ export const useStyles = makeStyles(
     isStickyLast: {
       boxShadow: `inset -4px 0 ${theme.palette.divider}`,
     },
+    wrapContent: {
+      whiteSpace: 'pre-wrap',
+    },
   }),
   { name: TableModuleStylesKey }
 );
@@ -231,6 +234,7 @@ export interface TableModuleProps<Item = any>
   noResultsMessage?: string;
   sortState?: TableSortState;
   maxCellWidth?: 1 | 2 | 3;
+  wrapCellContent?: boolean;
   rowActions?: (row: any, index?: number) => React.ReactNode;
   rowClickLabel?: string;
   state?: Partial<TableState>;
@@ -271,6 +275,7 @@ export const TableModule = React.memo(
         noResultsMessage,
         sortState = { sortKey: null, sortDirection: null },
         maxCellWidth,
+        wrapCellContent,
         rowActions,
         rowClickLabel,
         state,
@@ -556,6 +561,7 @@ export const TableModule = React.memo(
                   onRowClick={onRowClick}
                   rowRole={rowRole}
                   maxCellWidth={maxCellWidth}
+                  wrapCellContent={wrapCellContent}
                   row={rowData}
                   headingsLength={headings?.length}
                   cells={cells}

--- a/src/components/TableModule/TableModule.tsx
+++ b/src/components/TableModule/TableModule.tsx
@@ -131,6 +131,9 @@ export const useStyles = makeStyles(
     tableRowCellMaxWidth2: {
       maxWidth: '10rem',
     },
+    tableRowCellMaxWidth3: {
+      maxWidth: '13.125rem',
+    },
     tableRowActionCell: {
       paddingTop: 0,
       paddingBottom: 0,
@@ -227,7 +230,7 @@ export interface TableModuleProps<Item = any>
   rowRole?: 'link';
   noResultsMessage?: string;
   sortState?: TableSortState;
-  maxCellWidth?: 1 | 2;
+  maxCellWidth?: 1 | 2 | 3;
   rowActions?: (row: any, index?: number) => React.ReactNode;
   rowClickLabel?: string;
   state?: Partial<TableState>;

--- a/src/components/TableModule/TableModuleCell.tsx
+++ b/src/components/TableModule/TableModuleCell.tsx
@@ -10,7 +10,7 @@ export interface TableModuleCell
     HTMLTableElement
   > {
   children: any;
-  maxCellWidth?: 1 | 2;
+  maxCellWidth?: 1 | 2 | 3;
   isLastCellInRow: boolean;
   cell: TableCell;
   isSticky?: boolean;
@@ -47,6 +47,7 @@ export const TableModuleCell: React.FC<TableModuleCell> = React.memo(
           {
             [classes.tableRowCellMaxWidth1]: maxCellWidth === 1,
             [classes.tableRowCellMaxWidth2]: maxCellWidth === 2,
+            [classes.tableRowCellMaxWidth3]: maxCellWidth === 3,
           },
           cell.className,
           isSticky && classes.isSticky,

--- a/src/components/TableModule/TableModuleCell.tsx
+++ b/src/components/TableModule/TableModuleCell.tsx
@@ -11,6 +11,7 @@ export interface TableModuleCell
   > {
   children: any;
   maxCellWidth?: 1 | 2 | 3;
+  wrapCellContent?: boolean;
   isLastCellInRow: boolean;
   cell: TableCell;
   isSticky?: boolean;
@@ -20,6 +21,7 @@ export interface TableModuleCell
 export const TableModuleCell: React.FC<TableModuleCell> = React.memo(
   ({
     maxCellWidth,
+    wrapCellContent,
     isLastCellInRow,
     cell,
     children,
@@ -49,6 +51,7 @@ export const TableModuleCell: React.FC<TableModuleCell> = React.memo(
             [classes.tableRowCellMaxWidth2]: maxCellWidth === 2,
             [classes.tableRowCellMaxWidth3]: maxCellWidth === 3,
           },
+          wrapCellContent && classes.wrapContent,
           cell.className,
           isSticky && classes.isSticky,
           isSticky && 'sticky-cell-hook'

--- a/src/components/TableModule/TableModuleRow.tsx
+++ b/src/components/TableModule/TableModuleRow.tsx
@@ -19,6 +19,7 @@ export interface TableModuleRowProps
   onRowClick?: (row: any) => void;
   rowRole?: 'link';
   maxCellWidth?: 1 | 2 | 3;
+  wrapCellContent?: boolean;
   row: any;
   headingsLength: number;
   cells: Array<TableCell>;
@@ -35,6 +36,7 @@ const TableModuleRow: React.FC<TableModuleRowProps> = React.memo(
     rowRole,
     row,
     maxCellWidth,
+    wrapCellContent,
     headingsLength,
     cells,
     rowActions,
@@ -96,6 +98,7 @@ const TableModuleRow: React.FC<TableModuleRowProps> = React.memo(
               }
               cell={cell}
               isSticky={stickyCols.indexOf(colIndex) >= 0}
+              wrapCellContent={wrapCellContent}
               left={
                 stickyCols.indexOf(colIndex) >= 0
                   ? stickyCellsLeft[stickyCols.indexOf(colIndex)]
@@ -106,7 +109,15 @@ const TableModuleRow: React.FC<TableModuleRowProps> = React.memo(
             </TableModuleCell>
           );
         }),
-      [cells, headingsLength, maxCellWidth, row, stickyCols, stickyCellsLeft]
+      [
+        cells,
+        headingsLength,
+        maxCellWidth,
+        wrapCellContent,
+        row,
+        stickyCols,
+        stickyCellsLeft,
+      ]
     );
 
     const maybeRowActions = React.useMemo(() => rowActions?.(row, rowIndex), [

--- a/src/components/TableModule/TableModuleRow.tsx
+++ b/src/components/TableModule/TableModuleRow.tsx
@@ -18,7 +18,7 @@ export interface TableModuleRowProps
   data?: any;
   onRowClick?: (row: any) => void;
   rowRole?: 'link';
-  maxCellWidth?: 1 | 2;
+  maxCellWidth?: 1 | 2 | 3;
   row: any;
   headingsLength: number;
   cells: Array<TableCell>;


### PR DESCRIPTION
# What Was Changed

- Added a 3rd option for cell max width
- Added option to wrap cell content instead of cutting it off with `...`
  - wrapped option uses `pre-wrap` css property, which respects newlines and spaces in the text content

## Sanity Checks

- Should I write a test to make sure the entire text content is visible? I'm still not sure what's too brittle in front end testing.

# Screenshots

## Before

![Screenshot 2023-05-04 at 12 22 33 PM](https://user-images.githubusercontent.com/5824697/236308531-30775ec1-52f9-44f7-a4cc-ef5bfa6408dd.png)

## After

![Screenshot 2023-05-04 at 12 22 09 PM](https://user-images.githubusercontent.com/5824697/236308575-4c5ab212-e453-41bc-bab5-07784bc51736.png)
