### PR TITLE
fix: set type of button on step

### DIFF
--- a/src/components/Stepper/Step.test.tsx
+++ b/src/components/Stepper/Step.test.tsx
@@ -116,6 +116,7 @@ test('it renders as a button', async () => {
 
   const root = await findByTestId(testId);
   expect(root.nodeName).toEqual('BUTTON');
+  expect(root).toHaveProperty('type', 'button');
 });
 
 test('it applies the correct classes for "active" as a div', async () => {

--- a/src/components/Stepper/Step.tsx
+++ b/src/components/Stepper/Step.tsx
@@ -261,6 +261,7 @@ export const Step: React.FC<StepProps> = ({
           )}
           disabled={disabled}
           onClick={handleClick}
+          type="button"
           {...rootProps}
         >
           {content}


### PR DESCRIPTION
## Motivation

When a button does not specify type, then the default is "submit" when inside a `form` element. https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button

This pr will fix undesired behavior where if the `Stepper` is used inside a form, then pressing a `Step` will cause the form to submit 

A consumer can fix this by passing `type="button"` to `Step` but the props are not typed as such and I don't think there is a reason not to specify the type for this component 