### PR TITLE
[PML-226] Handle ExpansionPanel long titles

### DIFF
--- a/src/components/ExpansionPanel/ExpansionPanel.stories.tsx
+++ b/src/components/ExpansionPanel/ExpansionPanel.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { ExpansionPanel } from './ExpansionPanel';
-import { Check } from '@lifeomic/chromicons';
+import { Check, ArrowRight } from '@lifeomic/chromicons';
 
 export default {
   title: 'Components/ExpansionPanel',
@@ -26,4 +26,20 @@ export const Icon = Template.bind({});
 Icon.args = {
   title: 'Expansion Panel',
   leadingIcon: Check,
+};
+
+export const TruncatedTitle = Template.bind({});
+TruncatedTitle.args = {
+  title:
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
+  leadingIcon: ArrowRight,
+  truncateTitle: true,
+};
+
+TruncatedTitle.parameters = {
+  docs: {
+    description: {
+      story: `The title can be set to truncate with an ellipsis if it is too long for the expansion panel.`,
+    },
+  },
 };

--- a/src/components/ExpansionPanel/ExpansionPanel.test.tsx
+++ b/src/components/ExpansionPanel/ExpansionPanel.test.tsx
@@ -31,6 +31,17 @@ test('it renders an ExpansionPanel with leadingIcon', async () => {
   expect(icon).toBeInTheDocument();
 });
 
+test('it renders an ExpansionPanel with truncated title', async () => {
+  const props = getBaseProps();
+  const { getByTestId } = renderWithTheme(
+    <ExpansionPanel {...props} data-testid={testId} truncateTitle={true} />
+  );
+
+  const title = getByTestId(testId).querySelector(`p`);
+  expect(title).toBeTruthy();
+  expect(title).toHaveClass('ChromaExpansionPanel-truncate');
+});
+
 test('it renders ExpansionPanel expanded content on-click', async () => {
   const props = getBaseProps();
   const { container, findByTestId } = renderWithTheme(

--- a/src/components/ExpansionPanel/ExpansionPanel.tsx
+++ b/src/components/ExpansionPanel/ExpansionPanel.tsx
@@ -45,11 +45,13 @@ export const useStyles = makeStyles(
     },
     leadingIcon: {
       marginRight: theme.spacing(1),
+      minWidth: 'fit-content',
     },
     titleContainer: {
       alignItems: 'center',
       display: 'flex',
-      width: '100%',
+      maxWidth: '95%',
+      flexGrow: 1,
     },
     title: {
       color: theme.palette.text.secondary,
@@ -64,6 +66,7 @@ export const useStyles = makeStyles(
     icon: {
       transition: 'transform 0.25s ease',
       color: theme.palette.primary.main,
+      minWidth: 'fit-content',
     },
     rotate: {
       transform: 'rotate(45deg)',

--- a/src/components/ExpansionPanel/ExpansionPanel.tsx
+++ b/src/components/ExpansionPanel/ExpansionPanel.tsx
@@ -56,6 +56,11 @@ export const useStyles = makeStyles(
       letterSpacing: 'initial',
       transition: 'color 0.5s ease, transform 0.5s ease',
     },
+    truncate: {
+      whiteSpace: 'nowrap',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+    },
     icon: {
       transition: 'transform 0.25s ease',
       color: theme.palette.primary.main,
@@ -101,6 +106,7 @@ export interface ExpansionPanelProps
   innerContentClassName?: string;
   title: string;
   leadingIcon?: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+  truncateTitle?: boolean;
   onToggle?: (isExpanded: boolean) => void;
   isOpen?: boolean;
   contentDirection?: 'row' | 'column';
@@ -139,6 +145,7 @@ export const ExpansionPanel = React.forwardRef<
       contentDirection = 'column',
       title,
       leadingIcon: LeadingIcon,
+      truncateTitle = false,
       ...rootProps
     },
     ref
@@ -211,7 +218,11 @@ export const ExpansionPanel = React.forwardRef<
                 height={18}
               />
             )}
-            <Text className={classes.title} size="subbody" weight="bold">
+            <Text
+              className={clsx(classes.title, truncateTitle && classes.truncate)}
+              size="subbody"
+              weight="bold"
+            >
               {title}
             </Text>
           </div>

--- a/src/components/ExpansionPanel/ExpansionPanel.tsx
+++ b/src/components/ExpansionPanel/ExpansionPanel.tsx
@@ -50,7 +50,7 @@ export const useStyles = makeStyles(
     titleContainer: {
       alignItems: 'center',
       display: 'flex',
-      maxWidth: '95%',
+      maxWidth: `calc(100% - ${theme.pxToRem(34)})`, // 34 = icon width of 18px + 16px padding
       flexGrow: 1,
     },
     title: {


### PR DESCRIPTION
# What Was Changed

- Add option to truncate long titles with '...' in ExpansionPanel
- Needed for a usage of expansion panel in Patient ML where log payloads, which can be quite long, are both the title and the content of an expansion panel.
    - Intent is for the full payload to be shown in the content and a truncated preview to be shown in the title

# Screenshots

## Before

<img width="941" alt="Screenshot 2023-08-02 at 2 26 07 PM" src="https://github.com/lifeomic/chroma-react/assets/5824697/ec82a3eb-2d55-428c-90b2-b3dad742e6fe">

## After

<img width="1017" alt="Screenshot 2023-08-02 at 3 13 09 PM" src="https://github.com/lifeomic/chroma-react/assets/5824697/5c3a4a41-1d75-432b-b0fd-fe8fd5039fc2">

