### PR TITLE
Fix table ref warn

### DIFF
--- a/src/components/TableModule/TableModule.tsx
+++ b/src/components/TableModule/TableModule.tsx
@@ -378,8 +378,9 @@ export const TableModule = React.memo(
           });
           setStickyCellsLeft(stickyCellsLeft);
         } else {
-          console.warn(
-            "Table's forwardRef is null, please set it if you want the sticky cell's left value to be set correctly"
+          warning(
+            process.env.NODE_ENV === 'development',
+            "Chroma Warning: Table's forwardRef is null, please set it in order to set the sticky cell's left value correctly"
           );
         }
       }, [forwardedRef, stickyCols]);

--- a/src/components/TableModule/TableModule.tsx
+++ b/src/components/TableModule/TableModule.tsx
@@ -289,9 +289,7 @@ export const TableModule = React.memo(
       const classes = useStyles({});
 
       warning(
-        Boolean(onRowClick) &&
-          !rowClickLabel &&
-          process.env.NODE_ENV === 'development',
+        Boolean(onRowClick) && !rowClickLabel,
         'Chroma Warning: It is recommended you provide "rowClickLabel" if specifying a "onRowClick" for the <TableModule> component. This will be a required prop in a future major version.'
       );
 
@@ -378,8 +376,7 @@ export const TableModule = React.memo(
           });
           setStickyCellsLeft(stickyCellsLeft);
         } else {
-          warning(
-            process.env.NODE_ENV === 'development',
+          console.warn(
             "Chroma Warning: Table's forwardRef is null, please set it in order to set the sticky cell's left value correctly"
           );
         }

--- a/src/components/TableModule/TableModule.tsx
+++ b/src/components/TableModule/TableModule.tsx
@@ -361,6 +361,10 @@ export const TableModule = React.memo(
       });
 
       const setStickyCellLeftValues = React.useCallback(() => {
+        if (stickyCols.length === 0) {
+          return;
+        }
+
         let sum = 0;
         const stickyCellsLeft: Array<number> = [];
         // only need to grab column width from one row, since all rows should be the same in each column


### PR DESCRIPTION
# What Was Changed

- Finally fixing some console pollution I introduced back when we added sticky columns to `<TableModule />`
- We now only show the 'Table doesn't have a ref...' warning if some sticky columns are set
    - This will also prevent unnecessary spacing calculations being run when there are no sticky cols
- We also now only show this warning in Dev

# Screenshots

## Before

This warning appeared for every table on every page that did not have a ref, regardless of whether it needed sticky cols

<img width="1048" alt="Screenshot 2023-08-04 at 4 52 22 PM" src="https://github.com/lifeomic/chroma-react/assets/5824697/8cb0315c-3367-4831-8d1a-39dd32211e85">

## After

Now nothing should appear for non-sticky tables, or in Prod


