### PR TITLE
Add `gap` prop to `<DescriptionList`

### DIFF
--- a/src/components/DescriptionList/DescriptionList.stories.tsx
+++ b/src/components/DescriptionList/DescriptionList.stories.tsx
@@ -325,6 +325,31 @@ TextAlign.args = {
   ],
 };
 
+export const Gap = Template.bind({});
+Gap.parameters = {
+  docs: {
+    description: {
+      story:
+        'The DescriptionList component takes a `gap` prop. If changing gap sizes is desired, all units of measure (space-seperated) are accepted, or a combination of both. Some examples include: `24px 32px`, `20%`, and `21px 82%`. `gap` defaults to `8px 16px`. This property is specified as a value for row gap followed optionally by a value for column gap. If column gap is omitted, it’s set to the same value as row gap.',
+    },
+  },
+};
+
+Gap.args = {
+  'aria-label': 'List with a custom gap',
+  gap: '24px 32px',
+  items: [
+    <DescriptionTerm key="term-1">Term 1</DescriptionTerm>,
+    <DescriptionDetails key="details-1">Details 1</DescriptionDetails>,
+    <DescriptionDivider key="divider-1" />,
+    <DescriptionTerm key="term-2">Term 2</DescriptionTerm>,
+    <DescriptionDetails key="details-2">Details 2</DescriptionDetails>,
+    <DescriptionDivider key="divider-2" />,
+    <DescriptionTerm key="term-3">Term 3</DescriptionTerm>,
+    <DescriptionDetails key="details-3">Details 3</DescriptionDetails>,
+  ],
+};
+
 export const SecondaryText = Template.bind({});
 SecondaryText.args = {
   'aria-label': 'List with some items with secondary text',

--- a/src/components/DescriptionList/DescriptionList.tsx
+++ b/src/components/DescriptionList/DescriptionList.tsx
@@ -46,6 +46,9 @@ export const useStyles = makeStyles<DescriptionListProps>(
         listStyle: 'none',
         padding: 0,
       },
+      gap: {
+        gap: ({ gap }) => gap,
+      },
       margin: { margin: ({ margin }) => stringOrThemeSpacing(margin) },
       marginLeft: {
         marginLeft: ({ marginLeft }) => stringOrThemeSpacing(marginLeft),
@@ -104,6 +107,7 @@ export interface DescriptionListProps {
   children?: React.ReactNode;
   className?: string;
   columnsWidth?: string;
+  gap?: string;
   items?: Array<
     | React.ReactElement<DescriptionTermProps>
     | React.ReactElement<DescriptionDetailsProps>
@@ -146,6 +150,7 @@ export const DescriptionList: React.FC<DescriptionListProps> = (props) => {
     children,
     className,
     columnsWidth,
+    gap,
     items,
     title,
     titleIcon: TitleIcon,
@@ -189,6 +194,7 @@ export const DescriptionList: React.FC<DescriptionListProps> = (props) => {
           classes.list,
           className,
           columnsWidth && classes.columnsWidth,
+          gap && classes.gap,
           margin && classes.margin,
           marginTop && classes.marginTop,
           marginBottom && classes.marginBottom,


### PR DESCRIPTION
### AFTER 

<img width="1071" alt="Screenshot 2023-08-15 at 9 41 10 AM" src="https://github.com/lifeomic/chroma-react/assets/485903/13b32de3-8a7d-4782-bc41-20ca55a72b4d">

---

**NOTE**: This PR is merging into `feat-description-list` branch
