### PR TITLE
feat: Add title icon to list

### DIFF
--- a/src/components/List/List.stories.tsx
+++ b/src/components/List/List.stories.tsx
@@ -4,7 +4,7 @@ import { List } from './List';
 import { ListItem } from './ListItem';
 import { ListGroupHeading } from './ListGroupHeading';
 import { Avatar } from '../Avatar';
-import { HeartCircle } from '@lifeomic/chromicons';
+import { Database, HeartCircle } from '@lifeomic/chromicons';
 import Avatar1 from '../../assets/example-avatar-1.jpg';
 import Avatar2 from '../../assets/example-avatar-2.jpg';
 
@@ -62,6 +62,46 @@ const Template: ComponentStory<typeof List> = (args) => <List {...args} />;
 export const Default = Template.bind({});
 Default.args = {
   'aria-label': 'List with multiple items',
+  items: [
+    <ListItem key="1">Option 1</ListItem>,
+    <ListItem key="2">Option 2</ListItem>,
+    <ListItem key="3">Option 3</ListItem>,
+  ],
+};
+
+export const Title = Template.bind({});
+Title.parameters = {
+  docs: {
+    description: {
+      story: 'The List component takes an `title` prop.',
+    },
+  },
+};
+
+Title.args = {
+  'aria-label': 'List with a title',
+  title: 'Title',
+  items: [
+    <ListItem key="1">Option 1</ListItem>,
+    <ListItem key="2">Option 2</ListItem>,
+    <ListItem key="3">Option 3</ListItem>,
+  ],
+};
+
+export const TitleIcon = Template.bind({});
+TitleIcon.parameters = {
+  docs: {
+    description: {
+      story:
+        "The List component takes an `titleIcon` prop. It's recommended to use the [Chromicons](https://lifeomic.github.io/chromicons.com/) icon set.",
+    },
+  },
+};
+
+TitleIcon.args = {
+  'aria-label': 'List with title icon and title',
+  title: 'Title',
+  titleIcon: Database,
   items: [
     <ListItem key="1">Option 1</ListItem>,
     <ListItem key="2">Option 2</ListItem>,

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -5,6 +5,7 @@ import { ListItemProps } from './ListItem';
 import { ListGroupHeadingProps } from './ListGroupHeading';
 import { Text } from '../Text';
 import clsx from 'clsx';
+import { Box } from '../Box';
 
 export const ListStylesKey = 'ChromaList';
 
@@ -16,20 +17,32 @@ export const useStyles = makeStyles<ListProps>(
     };
 
     return {
-      root: {
+      title: {
+        color: theme.palette.text.primary,
+      },
+      hasTitleIcon: {
+        '& + $list': {
+          marginLeft: theme.pxToRem(30),
+        },
+        alignItems: 'center',
+        display: 'grid',
+        gap: theme.spacing(1),
+        gridTemplateColumns: `${theme.pxToRem(22)} 1fr`,
+      },
+      titleIcon: {
+        color: theme.palette.text.hint,
+        height: theme.pxToRem(22),
+        width: theme.pxToRem(22),
+      },
+      list: {
         backgroundColor: theme.palette.common.white,
+        margin: 0,
         maxHeight: theme.pxToRem(432),
         minWidth: theme.pxToRem(224),
         overflowY: 'auto',
         listStyle: 'none',
         paddingBottom: theme.spacing(1),
-        paddingLeft: 0,
-        paddingTop: theme.spacing(1),
-      },
-      title: {
-        paddingBottom: theme.spacing(2),
-        paddingLeft: theme.spacing(2.5),
-        paddingRight: theme.spacing(2.5),
+        padding: 0,
       },
       margin: { margin: ({ margin }) => stringOrThemeSpacing(margin) },
       marginLeft: {
@@ -90,6 +103,7 @@ export interface ListProps {
     | React.ReactElement<ListGroupHeadingProps>
   >;
   title?: string;
+  titleIcon?: React.ComponentType<React.SVGProps<SVGSVGElement>>;
   margin?: number | string;
   marginTop?: number | string;
   marginBottom?: number | string;
@@ -126,6 +140,7 @@ export const List: React.FC<ListProps> = (props) => {
     className,
     items,
     title,
+    titleIcon: TitleIcon,
     margin,
     marginTop,
     marginBottom,
@@ -146,34 +161,44 @@ export const List: React.FC<ListProps> = (props) => {
   const classes = useStyles(props);
 
   return (
-    <ul
-      aria-label={ariaLabel}
-      className={clsx(
-        classes.root,
-        className,
-        margin && classes.margin,
-        marginTop && classes.marginTop,
-        marginBottom && classes.marginBottom,
-        marginLeft && classes.marginLeft,
-        marginRight && classes.marginRight,
-        marginX && classes.marginX,
-        marginY && classes.marginY,
-        padding && classes.padding,
-        paddingTop && classes.paddingTop,
-        paddingBottom && classes.paddingBottom,
-        paddingLeft && classes.paddingLeft,
-        paddingRight && classes.paddingRight,
-        paddingX && classes.paddingX,
-        paddingY && classes.paddingY
-      )}
-      {...rootProps}
-    >
+    <>
       {!!title && (
-        <Text className={classes.title} weight="bold" size="subbody">
-          {title}
-        </Text>
+        <Box
+          className={clsx(classes.title, !!TitleIcon && classes.hasTitleIcon)}
+          marginBottom={1.5}
+        >
+          {!!TitleIcon && (
+            <TitleIcon role="img" aria-hidden className={classes.titleIcon} />
+          )}
+          <Text weight="bold" size="body">
+            {title}
+          </Text>
+        </Box>
       )}
-      {items}
-    </ul>
+      <ul
+        aria-label={ariaLabel}
+        className={clsx(
+          classes.list,
+          className,
+          margin && classes.margin,
+          marginTop && classes.marginTop,
+          marginBottom && classes.marginBottom,
+          marginLeft && classes.marginLeft,
+          marginRight && classes.marginRight,
+          marginX && classes.marginX,
+          marginY && classes.marginY,
+          padding && classes.padding,
+          paddingTop && classes.paddingTop,
+          paddingBottom && classes.paddingBottom,
+          paddingLeft && classes.paddingLeft,
+          paddingRight && classes.paddingRight,
+          paddingX && classes.paddingX,
+          paddingY && classes.paddingY
+        )}
+        {...rootProps}
+      >
+        {items}
+      </ul>
+    </>
   );
 };

--- a/src/components/List/ListGroupHeading.tsx
+++ b/src/components/List/ListGroupHeading.tsx
@@ -12,7 +12,7 @@ export const useStyles = makeStyles(
       fontSize: theme.pxToRem(10),
       fontWeight: theme.typography.fontWeightBold,
       letterSpacing: theme.pxToRem(1),
-      padding: theme.spacing(0.25, 2, 0.5),
+      padding: theme.spacing(0.25, 0, 0.5),
       textTransform: 'uppercase',
       '&:not(:first-child)': {
         borderTop: `solid 1px ${theme.palette.divider}`,

--- a/src/components/List/ListItem.tsx
+++ b/src/components/List/ListItem.tsx
@@ -25,7 +25,7 @@ export const useStyles = makeStyles(
       margin: 0,
       outline: 'none',
       overflow: 'hidden',
-      padding: theme.spacing(1, 2),
+      padding: theme.spacing(1, 0),
       textAlign: 'left',
       userSelect: 'none',
       width: '100%',


### PR DESCRIPTION
I noticed `title` prop was getting rendered as a `<div>` as a direct descendent of a `<ul>`, which was failing a11y checks due to invalid markup. I'm adjusting the markup in this PR so that `title` precedes the `<ul>`, identical to the way `title` is handled in `<DescriptionList`.

### Changes
- Add `titleIcon` prop to `<List`
- Make title and title icon styles consistent between list and description list

