### PR TITLE
Add Node 18.x support

### DIFF
--- a/.github/workflows/pr-branch-build.yml
+++ b/.github/workflows/pr-branch-build.yml
@@ -8,11 +8,14 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [16.x, 18.x]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: ${{ matrix.node-version }}
           cache: 'yarn'
       - name: Build and Test
         run: |

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "start": "yarn docs:start",
     "test": "TZ=UTC jest"
   },
+  "engines": {
+    "node": "16.x || 18.x"
+  },
   "husky": {
     "hooks": {
       "pre-commit": "pretty-quick --staged"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6098,9 +6098,9 @@
   integrity sha512-Abq9fBviLV93OiXMu+f6r0elxCzRwc0RC5f99cU892uBITL44pTvgvEqlRlPRi8EGcO1z7Cp8A4d0s/p3J/+Nw==
 
 "@types/node@^16.0.0":
-  version "16.18.3"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.3.tgz#d7f7ba828ad9e540270f01ce00d391c54e6e0abc"
-  integrity sha512-jh6m0QUhIRcZpNv7Z/rpN+ZWXOicUUQbSoWks7Htkbb9IjFQj4kzcX/xFCkjstCj5flMsN8FiSvt+q+Tcs4Llg==
+  version "16.18.40"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.40.tgz#968d64746d20cac747a18ca982c0f1fe518c031c"
+  integrity sha512-+yno3ItTEwGxXiS/75Q/aHaa5srkpnJaH+kdkTVJ3DtJEwv92itpKbxU+FjPoh2m/5G9zmUQfrL4A4C13c+iGA==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"


### PR DESCRIPTION
Looking forward to other repos moving to Node `18.x`, we're making sure Chrōma can support it as well.

## Notes to the Team
- I wasn't 100% certain what to do with the semantic commit for this one. It's not a breaking change and doesn't change anything for our public API, so I'm thinking it should be a patch. Is there a better tag than `fix:` for patches in this case?