### PR TITLE
build: includes docs:build target into branch build workflow

### DIFF
--- a/.github/workflows/pr-branch-build.yml
+++ b/.github/workflows/pr-branch-build.yml
@@ -10,16 +10,31 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        include:
+          - group: 1
+            node-version: 16.x
+            run: |
+              yarn test --ci --reporters="github-actions"
+              yarn build
+          - group: 2
+            node-version: 18.x
+            run: |
+              yarn test --ci --reporters="github-actions"
+              yarn build
+          - group: 3
+            node-version: 18.x
+            run: |
+              yarn run docs:build
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+          cache-dependency-path: 'yarn.lock'
           cache: 'yarn'
-      - name: Build and Test
+      - name: Lint
         run: |
           yarn
           yarn lint
-          yarn test --ci --reporters="github-actions"
-          yarn build
+      - name: Test
+        run: ${{ matrix.run }}

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ esm/
 docs/
 deploy/docs
 build/
+
+storybook-static/


### PR DESCRIPTION
## Before

it doesn't build storybook during PR and branch build workflow

## After

it will exercise the target `docs:build` during PR and branch build workflow.

Although it adds 30s more to the build time, it will make sure the storybook setup works all the time