### PR TITLE
Update A- Components to Storybook CSF3

### DIFF
--- a/src/components/Alert/Alert.stories.tsx
+++ b/src/components/Alert/Alert.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, Meta } from '@storybook/react';
 import { BrowserRouter } from 'react-router-dom';
 
 import { Alert } from './Alert';
@@ -18,10 +18,8 @@ import { Button } from '../Button';
 import { AlertActionsRow } from './AlertActionsRow';
 import { ButtonLink } from '../ButtonLink';
 
-export default {
-  title: 'Components/Alert',
+const meta: Meta<typeof Alert> = {
   component: Alert,
-  argTypes: {},
   decorators: [
     (story: Function) => (
       <div
@@ -35,128 +33,43 @@ export default {
       </div>
     ),
   ],
-} as ComponentMeta<typeof Alert>;
-
-export const Default: ComponentStory<typeof Alert> = (args) => {
-  return (
-    <Alert {...args}>
-      <AlertIcon icon={Info} />
-      <AlertBody>
-        <Text size="subbody">This is the latest version of Chroma.</Text>
-      </AlertBody>
-    </Alert>
-  );
 };
 
-export const MultiLine: ComponentStory<typeof Alert> = (args) => {
-  return (
-    <Alert {...args}>
-      <AlertIcon icon={Info} />
-      <AlertBody>
-        <Text size="subbody" weight="bold">
-          You are on the latest version!
-        </Text>
-        <Text size="caption">The latest version of Chroma is 9999.9.9.9</Text>
-      </AlertBody>
-    </Alert>
-  );
-};
+export default meta;
+type Story = StoryObj<typeof Alert>;
 
-export const Success: ComponentStory<typeof Alert> = (args) => {
-  return (
-    <Alert {...args}>
-      <AlertIcon icon={CheckCircle} />
-      <AlertBody>
-        <Text size="subbody" weight="bold">
-          Order complete!
-        </Text>
-        <Text size="caption">
-          We will send you your tracking information via email.
-        </Text>
-      </AlertBody>
-    </Alert>
-  );
-};
-Success.args = {
-  statusType: 'success',
-};
-Success.parameters = {
-  docs: {
-    description: {
-      story: 'The status types line up with the Snackbar component.',
-    },
+export const Default: Story = {
+  render: (args) => {
+    return (
+      <Alert {...args}>
+        <AlertIcon icon={Info} />
+        <AlertBody>
+          <Text size="subbody">This is the latest version of Chroma.</Text>
+        </AlertBody>
+      </Alert>
+    );
   },
 };
 
-export const Warning: ComponentStory<typeof Alert> = (args) => {
-  return (
-    <Alert {...args}>
-      <AlertIcon icon={AlertTriangle} />
-      <AlertBody>
-        <Text size="subbody" weight="bold">
-          Uh oh!
-        </Text>
-        <Text size="caption">
-          Looks like you may need to review something...
-        </Text>
-      </AlertBody>
-    </Alert>
-  );
-};
-Warning.args = {
-  statusType: 'warning',
-};
-
-export const Error: ComponentStory<typeof Alert> = (args) => {
-  return (
-    <Alert {...args}>
-      <AlertIcon icon={XCircle} />
-      <AlertBody>
-        <Text size="subbody" weight="bold">
-          Access Denied
-        </Text>
-        <Text size="caption">
-          You do not have the permissions to perform this action.
-        </Text>
-      </AlertBody>
-    </Alert>
-  );
-};
-Error.args = {
-  statusType: 'error',
-};
-
-export const ErrorList: ComponentStory<typeof Alert> = (args) => {
-  return (
-    <Alert {...args}>
-      <AlertIcon icon={XCircle} />
-      <AlertBody>
-        <Text size="subbody" weight="bold">
-          There were a few errors with submitting your order
-        </Text>
-        <ul>
-          <li>You did not provide your address</li>
-          <li>You did not provide your email</li>
-          <li>You did not provide a backup email</li>
-        </ul>
-      </AlertBody>
-    </Alert>
-  );
-};
-ErrorList.args = {
-  statusType: 'error',
-};
-ErrorList.parameters = {
-  docs: {
-    description: {
-      story: 'For Alerts with lists, you can leverage `ul` and `li` elements.',
-    },
+export const MultiLine: Story = {
+  render: (args) => {
+    return (
+      <Alert {...args}>
+        <AlertIcon icon={Info} />
+        <AlertBody>
+          <Text size="subbody" weight="bold">
+            You are on the latest version!
+          </Text>
+          <Text size="caption">The latest version of Chroma is 9999.9.9.9</Text>
+        </AlertBody>
+      </Alert>
+    );
   },
 };
 
-export const ActionsRow: ComponentStory<typeof Alert> = (args) => {
-  return (
-    <BrowserRouter>
+export const Success: Story = {
+  render: (args) => {
+    return (
       <Alert {...args}>
         <AlertIcon icon={CheckCircle} />
         <AlertBody>
@@ -166,79 +79,188 @@ export const ActionsRow: ComponentStory<typeof Alert> = (args) => {
           <Text size="caption">
             We will send you your tracking information via email.
           </Text>
-          <AlertActionsRow>
-            <ButtonLink to="/home" variant="text">
-              View Status
-            </ButtonLink>
-            <Button variant="text">Dismiss</Button>
-          </AlertActionsRow>
         </AlertBody>
       </Alert>
-    </BrowserRouter>
-  );
-};
-ActionsRow.args = {
-  statusType: 'success',
-};
-ActionsRow.parameters = {
-  docs: {
-    description: {
-      story:
-        'For Alerts with multiple action buttons, leverage the `AlertActionsRow` component.',
+    );
+  },
+  args: {
+    statusType: 'success',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'The status types line up with the Snackbar component.',
+      },
     },
   },
 };
 
-export const RightButton: ComponentStory<typeof Alert> = (args) => {
-  return (
-    <Alert {...args}>
-      <AlertIcon icon={Info} />
-      <AlertBody spaceBetween>
-        <Text size="subbody">The latest version of Chroma is 9999.9.9.9</Text>
-        <Button variant="text">Details</Button>
-      </AlertBody>
-    </Alert>
-  );
+export const Warning: Story = {
+  render: (args) => {
+    return (
+      <Alert {...args}>
+        <AlertIcon icon={AlertTriangle} />
+        <AlertBody>
+          <Text size="subbody" weight="bold">
+            Uh oh!
+          </Text>
+          <Text size="caption">
+            Looks like you may need to review something...
+          </Text>
+        </AlertBody>
+      </Alert>
+    );
+  },
+  args: {
+    statusType: 'warning',
+  },
 };
-RightButton.args = {
-  fullWidth: true,
+
+export const Error: Story = {
+  render: (args) => {
+    return (
+      <Alert {...args}>
+        <AlertIcon icon={XCircle} />
+        <AlertBody>
+          <Text size="subbody" weight="bold">
+            Access Denied
+          </Text>
+          <Text size="caption">
+            You do not have the permissions to perform this action.
+          </Text>
+        </AlertBody>
+      </Alert>
+    );
+  },
+  args: {
+    statusType: 'error',
+  },
 };
-RightButton.parameters = {
-  docs: {
-    description: {
-      story:
-        'Alerts with a single action button _do not_ need to leverage the `AlertActionsRow`. Instead, they can inline the button in the `AlertBody`.',
+
+export const ErrorList: Story = {
+  render: (args) => {
+    return (
+      <Alert {...args}>
+        <AlertIcon icon={XCircle} />
+        <AlertBody>
+          <Text size="subbody" weight="bold">
+            There were a few errors with submitting your order
+          </Text>
+          <ul>
+            <li>You did not provide your address</li>
+            <li>You did not provide your email</li>
+            <li>You did not provide a backup email</li>
+          </ul>
+        </AlertBody>
+      </Alert>
+    );
+  },
+  args: {
+    statusType: 'error',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'For Alerts with lists, you can leverage `ul` and `li` elements.',
+      },
     },
   },
 };
 
-export const Dismissible: ComponentStory<typeof Alert> = (args) => {
-  return (
-    <Alert {...args}>
-      <AlertIcon icon={Info} />
-      <AlertBody spaceBetween>
-        <Text size="subbody">The latest version of Chroma is 9999.9.9.9</Text>
-        <IconButton aria-label="Dismiss" icon={X} size={0} />
-      </AlertBody>
-    </Alert>
-  );
-};
-Dismissible.args = {
-  fullWidth: true,
+export const ActionsRow: Story = {
+  render: (args) => {
+    return (
+      <BrowserRouter>
+        <Alert {...args}>
+          <AlertIcon icon={CheckCircle} />
+          <AlertBody>
+            <Text size="subbody" weight="bold">
+              Order complete!
+            </Text>
+            <Text size="caption">
+              We will send you your tracking information via email.
+            </Text>
+            <AlertActionsRow>
+              <ButtonLink to="/home" variant="text">
+                View Status
+              </ButtonLink>
+              <Button variant="text">Dismiss</Button>
+            </AlertActionsRow>
+          </AlertBody>
+        </Alert>
+      </BrowserRouter>
+    );
+  },
+  args: {
+    statusType: 'success',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'For Alerts with multiple action buttons, leverage the `AlertActionsRow` component.',
+      },
+    },
+  },
 };
 
-export const LongText: ComponentStory<typeof Alert> = (args) => {
-  return (
-    <Alert {...args}>
-      <AlertIcon icon={Info} />
-      <AlertBody>
-        <Text size="subbody">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
-          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-          aliquip ex ea commodo consequat.
-        </Text>
-      </AlertBody>
-    </Alert>
-  );
+export const RightButton: Story = {
+  render: (args) => {
+    return (
+      <Alert {...args}>
+        <AlertIcon icon={Info} />
+        <AlertBody spaceBetween>
+          <Text size="subbody">The latest version of Chroma is 9999.9.9.9</Text>
+          <Button variant="text">Details</Button>
+        </AlertBody>
+      </Alert>
+    );
+  },
+  args: {
+    fullWidth: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Alerts with a single action button _do not_ need to leverage the `AlertActionsRow`. Instead, they can inline the button in the `AlertBody`.',
+      },
+    },
+  },
+};
+
+export const Dismissible: Story = {
+  render: (args) => {
+    return (
+      <Alert {...args}>
+        <AlertIcon icon={Info} />
+        <AlertBody spaceBetween>
+          <Text size="subbody">The latest version of Chroma is 9999.9.9.9</Text>
+          <IconButton aria-label="Dismiss" icon={X} size={0} />
+        </AlertBody>
+      </Alert>
+    );
+  },
+  args: {
+    fullWidth: true,
+  },
+};
+
+export const LongText: Story = {
+  render: (args) => {
+    return (
+      <Alert {...args}>
+        <AlertIcon icon={Info} />
+        <AlertBody>
+          <Text size="subbody">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+            aliquip ex ea commodo consequat.
+          </Text>
+        </AlertBody>
+      </Alert>
+    );
+  },
 };

--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -1,91 +1,88 @@
-import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, Meta } from '@storybook/react';
 
 import { Avatar } from './Avatar';
 import legoman from '../../../stories/assets/legoman.jpg';
 
-export default {
-  title: 'Components/Avatar',
+const meta: Meta<typeof Avatar> = {
   component: Avatar,
+  args: {
+    name: 'Tony',
+  },
   argTypes: {
     onClick: { action: 'clicked' },
     onError: { action: 'errored', control: false },
   },
-} as ComponentMeta<typeof Avatar>;
-
-const Template: ComponentStory<typeof Avatar> = (args) => <Avatar {...args} />;
-
-export const Default = Template.bind({});
-Default.args = {
-  name: 'Tony',
 };
+export default meta;
 
-export const Name = Template.bind({});
-Name.parameters = {
-  docs: {
-    description: {
-      story:
-        'The Avatar component is used to represent a user. It displays a profile picture, their name initials, or fallback icon.',
-    },
-  },
-};
-Name.args = {
-  name: 'Tony',
-};
+type Story = StoryObj<typeof Avatar>;
 
-export const ProfilePicture = Template.bind({});
-ProfilePicture.args = {
-  name: 'Tony',
-  src: legoman,
-};
-ProfilePicture.parameters = {
-  docs: {
-    description: {
-      story: 'A profile picture can be displayed by providing a `src`.',
+export const Default: Story = {};
+
+export const Name: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The Avatar component is used to represent a user. It displays a profile picture, their name initials, or fallback icon.',
+      },
     },
   },
 };
 
-export const ImageLoadFailure = Template.bind({});
-ImageLoadFailure.args = {
-  name: 'Tony',
-  src: 'https://this-image-does-not-exist.biz/123.jpg',
-};
-ImageLoadFailure.parameters = {
-  docs: {
-    description: {
-      story:
-        'An onError handler can be added to capture errors loading the `src` image. By default, when a `src` fails to load, the avatar will fallback to initials.',
+export const ProfilePicture: Story = {
+  args: {
+    src: legoman,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'A profile picture can be displayed by providing a `src`.',
+      },
     },
   },
 };
 
-export const UseDefaultSrc = Template.bind({});
-UseDefaultSrc.args = {
-  name: 'Tony',
-  src: legoman,
-  UseDefaultSrc: true,
-};
-UseDefaultSrc.parameters = {
-  docs: {
-    description: {
-      story:
-        'This prop is leveraged when the information about the user needs to be "masked".  When this prop is provided, a default image will be used. Although their name is required, it will not be used with this prop.',
+export const ImageLoadFailure: Story = {
+  args: {
+    src: 'https://this-image-does-not-exist.biz/123.jpg',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'An onError handler can be added to capture errors loading the `src` image. By default, when a `src` fails to load, the avatar will fallback to initials.',
+      },
     },
   },
 };
 
-export const Size = Template.bind({});
-Size.args = {
-  name: 'Tony',
-  src: legoman,
-  size: 2,
+export const UseDefaultSrc: Story = {
+  args: {
+    src: legoman,
+    useDefaultSrc: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'This prop is leveraged when the information about the user needs to be "masked".  When this prop is provided, a default image will be used. Although their name is required, it will not be used with this prop.',
+      },
+    },
+  },
 };
-Size.parameters = {
-  docs: {
-    description: {
-      story:
-        'There are size options exposed. Choose one that fits the best for your needs.',
+
+export const Size: Story = {
+  args: {
+    src: legoman,
+    size: 2,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'There are size options exposed. Choose one that fits the best for your needs.',
+      },
     },
   },
 };


### PR DESCRIPTION
# What Was Changed

- Replaced now-defunct CSF 1 & 2 types `ComponentStory` and `ComponentMeta` with `StoryObj` and `Meta` respectively
- Updated all stories to the new single-const format 
- Removed titles, since those are now created from the component name unless you need to override them
- Created Story type and added it to all stories for increased type safety

## Notes for the Team

- I spent a couple cycles trying to simplify the templating for Alert, but because we rely on nested components it got complicated. I've abandoned this for now - there's more work to do that's more important.

# Screenshots

_There should be no visual differences for these components_