### PR TITLE
Update B- Components to Storybook CSF3

### DIFF
--- a/src/components/Box/Box.stories.tsx
+++ b/src/components/Box/Box.stories.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, StoryFn, Meta } from '@storybook/react';
 
 import { Box } from './Box';
 
-export default {
+const meta: Meta<typeof Box> = {
   title: 'Layout/Box',
   component: Box,
-  argTypes: {},
-} as ComponentMeta<typeof Box>;
+};
+export default meta;
+type Story = StoryObj<typeof Box>;
 
-const Template: ComponentStory<typeof Box> = (args) => (
+const Template: StoryFn<typeof Box> = (args) => (
   <Box {...args}>
     <p>p1</p>
     <p>p2</p>
@@ -17,65 +18,75 @@ const Template: ComponentStory<typeof Box> = (args) => (
   </Box>
 );
 
-export const Default = Template.bind({});
+export const Default: Story = {
+  render: Template,
+};
 
-export const Spacing = Template.bind({});
-Spacing.parameters = {
-  docs: {
-    description: {
-      story:
-        'Numbers are multiplied by the default theme spacing for margin, padding, and gap. ' +
-        'Strings are are ' +
-        'used as raw CSS. As well as `margin` and `padding`, the top, bottom, ' +
-        'left, right, x and y versions of each are supported. For a more modern, ' +
-        'straightforward approach to handle spacing between children, use the `gap` prop.',
+export const Spacing: Story = {
+  render: Template,
+  args: {
+    margin: 2,
+    padding: '1px',
+    gap: 2,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Numbers are multiplied by the default theme spacing for margin, padding, and gap. ' +
+          'Strings are are ' +
+          'used as raw CSS. As well as `margin` and `padding`, the top, bottom, ' +
+          'left, right, x and y versions of each are supported. For a more modern, ' +
+          'straightforward approach to handle spacing between children, use the `gap` prop.',
+      },
     },
   },
 };
-Spacing.args = {
-  margin: 2,
-  padding: '1px',
-  gap: 2,
-};
 
-export const Direction = Template.bind({});
-Direction.parameters = {
-  docs: {
-    description: {
-      story:
-        'A direction can be applied. Valid options are `row` (default) or `column`.',
+export const Direction: Story = {
+  render: Template,
+  args: {
+    direction: 'column',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A direction can be applied. Valid options are `row` (default) or `column`.',
+      },
     },
   },
 };
-Direction.args = {
-  direction: 'column',
-};
 
-export const ThemeColor = Template.bind({});
-ThemeColor.parameters = {
-  docs: {
-    description: {
-      story:
-        'Color props take a string dot notation to the theme palette properties, or are passed as raw CSS.',
+export const ThemeColor: Story = {
+  render: Template,
+  args: {
+    color: 'text.contrast',
+    bgColor: 'common.black',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Color props take a string dot notation to the theme palette properties, or are passed as raw CSS.',
+      },
     },
   },
 };
-ThemeColor.args = {
-  color: 'text.contrast',
-  bgColor: 'common.black',
-};
 
-export const borderRadius = Template.bind({});
-borderRadius.parameters = {
-  docs: {
-    description: {
-      story:
-        'Sets the `borderRadius` of a box using `theme.shape.borderRadius`.',
+export const borderRadius: Story = {
+  render: Template,
+  args: {
+    color: 'text.contrast',
+    bgColor: 'common.black',
+    borderRadius: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Sets the `borderRadius` of a box using `theme.shape.borderRadius`.',
+      },
     },
   },
-};
-borderRadius.args = {
-  color: 'text.contrast',
-  bgColor: 'common.black',
-  borderRadius: true,
 };

--- a/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -1,78 +1,49 @@
 import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, Meta } from '@storybook/react';
 import { MemoryRouter } from 'react-router-dom';
 
 import { Breadcrumbs } from './Breadcrumbs';
 
-export default {
-  title: 'Components/Breadcrumbs',
+const meta: Meta<typeof Breadcrumbs> = {
   component: Breadcrumbs,
-  argTypes: {},
+  args: {
+    crumbs: [
+      {
+        text: 'Parent',
+        url: 'root',
+      },
+      {
+        text: 'Child',
+        url: 'root/child',
+      },
+      {
+        text: 'GrandChild',
+        url: 'root/child/grand',
+      },
+    ],
+  },
   decorators: [(story) => <MemoryRouter>{story()}</MemoryRouter>],
-} as ComponentMeta<typeof Breadcrumbs>;
+};
+export default meta;
+type Story = StoryObj<typeof Breadcrumbs>;
 
-const Template: ComponentStory<typeof Breadcrumbs> = (args) => (
-  <Breadcrumbs {...args} />
-);
+export const Default: Story = {};
 
-export const Default = Template.bind({});
-Default.args = {
-  crumbs: [
-    {
-      text: 'Parent',
-      url: 'root',
-    },
-    {
-      text: 'Child',
-      url: 'root/child',
-    },
-    {
-      text: 'GrandChild',
-      url: 'root/child/grand',
-    },
-  ],
+export const InverseDark = {
+  parameters: {
+    backgrounds: { default: 'dark' },
+  },
+  args: {
+    color: 'inverse',
+  },
 };
 
-export const InverseDark = Template.bind({});
-InverseDark.parameters = {
-  backgrounds: { default: 'dark' },
-};
-InverseDark.args = {
-  crumbs: [
-    {
-      text: 'Parent',
-      url: 'root',
-    },
-    {
-      text: 'Child',
-      url: 'root/child',
-    },
-    {
-      text: 'GrandChild',
-      url: 'root/child/grand',
-    },
-  ],
-  color: 'inverse',
-};
+export const InverseBlue = {
+  parameters: {
+    backgrounds: { default: 'blue' },
+  },
 
-export const InverseBlue = Template.bind({});
-InverseBlue.parameters = {
-  backgrounds: { default: 'blue' },
-};
-InverseBlue.args = {
-  crumbs: [
-    {
-      text: 'Parent',
-      url: 'root',
-    },
-    {
-      text: 'Child',
-      url: 'root/child',
-    },
-    {
-      text: 'GrandChild',
-      url: 'root/child/grand',
-    },
-  ],
-  color: 'inverse',
+  args: {
+    color: 'inverse',
+  },
 };

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -1,87 +1,118 @@
 import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, StoryFn, Meta } from '@storybook/react';
 
 import { Button } from './Button';
 import { ChevronDown, Edit } from '@lifeomic/chromicons';
 
-export default {
-  title: 'Components/Button',
+const meta: Meta<typeof Button> = {
   component: Button,
   argTypes: {
     onClick: { action: 'clicked' },
   },
-} as ComponentMeta<typeof Button>;
+};
+export default meta;
+type Story = StoryObj<typeof Button>;
 
-const Template: ComponentStory<typeof Button> = (args) => (
+const Template: StoryFn<typeof Button> = (args) => (
   <Button {...args}>Button</Button>
 );
 
-export const Default = Template.bind({});
+export const Default: Story = {
+  render: Template,
+};
 
-export const Icon = Template.bind({});
-Icon.parameters = {
-  docs: {
-    description: {
-      story:
-        "The Button component takes an `icon` prop. It's recommended to use the [Chromicons](https://lifeomic.github.io/chromicons.com/) icon set.",
+export const Outlined: Story = {
+  render: Template,
+  args: {
+    variant: 'outlined',
+  },
+};
+
+export const TextOnly: Story = {
+  render: Template,
+  args: {
+    variant: 'text',
+  },
+};
+
+export const Disabled: Story = {
+  render: Template,
+  args: {
+    disabled: true,
+  },
+};
+
+export const Icon: Story = {
+  render: Template,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The Button component takes an `icon` prop. It's recommended to use the [Chromicons](https://lifeomic.github.io/chromicons.com/) icon set.",
+      },
+    },
+  },
+  args: {
+    icon: Edit,
+  },
+};
+
+export const TrailingIcon: Story = {
+  render: Template,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The Button component takes an `icon` prop. It's recommended to use the [Chromicons](https://lifeomic.github.io/chromicons.com/) icon set.",
+      },
+    },
+  },
+  args: {
+    trailingIcon: ChevronDown,
+  },
+};
+
+export const Color: Story = {
+  render: Template,
+  args: {
+    color: 'negative',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The button component takes multiple different colors, for different styled ' +
+          'buttons. Typically, the `inverse` color is used when a button needs to be ' +
+          'on a dark-colored background. When the action of the button will have a ' +
+          'negative or positive impact, `negative` or `positive` color are used.',
+      },
     },
   },
 };
-Icon.args = {
-  icon: Edit,
-};
 
-export const TrailingIcon = Template.bind({});
-TrailingIcon.parameters = {
-  docs: {
-    description: {
-      story:
-        "The Button component takes an `icon` prop. It's recommended to use the [Chromicons](https://lifeomic.github.io/chromicons.com/) icon set.",
-    },
+export const FullWidth: Story = {
+  render: Template,
+  args: {
+    fullWidth: true,
   },
 };
-TrailingIcon.args = {
-  trailingIcon: ChevronDown,
-};
 
-export const Color = Template.bind({});
-Color.parameters = {
-  docs: {
-    description: {
-      story:
-        'The button component takes multiple different colors, for different styled ' +
-        'buttons. Typically, the `inverse` color is used when a button needs to be ' +
-        'on a dark-colored background. When the action of the button will have a ' +
-        'negative or positive impact, `negative` or `positive` color are used.',
-    },
+export const InverseDark: Story = {
+  render: Template,
+  parameters: {
+    backgrounds: { default: 'dark' },
+  },
+  args: {
+    color: 'inverse',
   },
 };
-Color.args = {
-  color: 'inverse',
-};
 
-export const FullWidth = Template.bind({});
-FullWidth.args = {
-  fullWidth: true,
-};
-
-export const Disabled = Template.bind({});
-Disabled.args = {
-  disabled: true,
-};
-
-export const InverseDark = Template.bind({});
-InverseDark.parameters = {
-  backgrounds: { default: 'dark' },
-};
-InverseDark.args = {
-  color: 'inverse',
-};
-
-export const InverseBlue = Template.bind({});
-InverseBlue.parameters = {
-  backgrounds: { default: 'blue' },
-};
-InverseBlue.args = {
-  color: 'inverse',
+export const InverseBlue: Story = {
+  render: Template,
+  parameters: {
+    backgrounds: { default: 'blue' },
+  },
+  args: {
+    color: 'inverse',
+  },
 };

--- a/src/components/ButtonFilePicker/ButtonFilePicker.stories.tsx
+++ b/src/components/ButtonFilePicker/ButtonFilePicker.stories.tsx
@@ -1,52 +1,67 @@
 import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, StoryFn, Meta } from '@storybook/react';
 
 import { ButtonFilePicker } from './ButtonFilePicker';
 import { Edit } from '@lifeomic/chromicons';
-
-export default {
-  title: 'Components/ButtonFilePicker',
+const meta: Meta<typeof ButtonFilePicker> = {
   component: ButtonFilePicker,
-  argTypes: {},
-} as ComponentMeta<typeof ButtonFilePicker>;
+};
+export default meta;
+type Story = StoryObj<typeof ButtonFilePicker>;
 
-const Template: ComponentStory<typeof ButtonFilePicker> = (args) => (
+const Template: StoryFn<typeof ButtonFilePicker> = (args) => (
   <ButtonFilePicker {...args}>Button File Picker</ButtonFilePicker>
 );
 
-export const Default = Template.bind({});
-Default.args = {};
+export const Default: Story = {
+  render: Template,
+};
 
-export const Accept = Template.bind({});
-Accept.parameters = {
-  docs: {
-    description: {
-      story:
-        'A CSV list of the type of file extension(s) the file picker should accept.',
+export const Accept: Story = {
+  render: Template,
+  args: {
+    accept: '.jpg,.jpeg',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A CSV list of the type of file extension(s) the file picker should accept.',
+      },
     },
   },
 };
-Accept.args = {
-  accept: '.jpg,.jpeg',
+
+export const Disabled: Story = {
+  render: Template,
+  args: {
+    disabled: true,
+  },
 };
 
-export const Icon = Template.bind({});
-Icon.args = {
-  icon: Edit,
+export const Icon: Story = {
+  render: Template,
+  args: {
+    icon: Edit,
+  },
 };
 
-export const InverseDark = Template.bind({});
-InverseDark.parameters = {
-  backgrounds: { default: 'dark' },
-};
-InverseDark.args = {
-  color: 'inverse',
+export const InverseDark: Story = {
+  render: Template,
+  args: {
+    color: 'inverse',
+  },
+  parameters: {
+    backgrounds: { default: 'dark' },
+  },
 };
 
-export const InverseBlue = Template.bind({});
-InverseBlue.parameters = {
-  backgrounds: { default: 'blue' },
-};
-InverseBlue.args = {
-  color: 'inverse',
+export const InverseBlue: Story = {
+  render: Template,
+  args: {
+    color: 'inverse',
+  },
+  parameters: {
+    backgrounds: { default: 'blue' },
+  },
 };

--- a/src/components/ButtonFloat/ButtonFloat.stories.tsx
+++ b/src/components/ButtonFloat/ButtonFloat.stories.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, StoryFn, Meta } from '@storybook/react';
 
 import { ButtonFloat } from './ButtonFloat';
 import { Edit } from '@lifeomic/chromicons';
 
-export default {
-  title: 'Components/ButtonFloat',
+const meta: Meta<typeof ButtonFloat> = {
   component: ButtonFloat,
   argTypes: {
     disabled: {
@@ -18,66 +17,77 @@ export default {
   },
   decorators: [
     (story) => (
-      <div
-        style={{
-          position: 'fixed',
-          display: 'flex',
-          justifyContent: 'center',
-          alignItems: 'center',
-          top: 0,
-          right: 0,
-          bottom: 0,
-          left: 0,
-        }}
-      >
-        {story()}
+      <div style={{ width: '100%', height: '50px' }}>
+        <div
+          style={{
+            position: 'fixed',
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            top: 0,
+            right: 0,
+            bottom: 0,
+            left: 0,
+          }}
+        >
+          {story()}
+        </div>
       </div>
     ),
   ],
-} as ComponentMeta<typeof ButtonFloat>;
+};
+export default meta;
+type Story = StoryObj<typeof ButtonFloat>;
 
-const Template: ComponentStory<typeof ButtonFloat> = (args) => (
+const Template: StoryFn<typeof ButtonFloat> = (args) => (
   <ButtonFloat {...args}>Button Float</ButtonFloat>
 );
 
-export const Default = Template.bind({});
-Default.args = {};
-
-export const Disabled = Template.bind({});
-Disabled.parameters = {
-  docs: {
-    description: {
-      story:
-        'Like regular buttons, Button Float also takes a prop to disable it.',
-    },
-  },
-};
-Disabled.args = {
-  disabled: true,
+export const Default: Story = {
+  render: Template,
 };
 
-export const Icon = Template.bind({});
-Icon.parameters = {
-  docs: {
-    description: {
-      story:
-        "The Button Float component takes an icon prop. It's recommended to use the [Chromicons](https://lifeomic.github.io/chromicons.com/) icon set.",
+export const Disabled: Story = {
+  render: Template,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Like regular buttons, Button Float also takes a prop to disable it.',
+      },
     },
   },
-};
-Icon.args = {
-  icon: Edit,
+  args: {
+    disabled: true,
+  },
 };
 
-export const TrailingIcon = Template.bind({});
-TrailingIcon.parameters = {
-  docs: {
-    description: {
-      story:
-        "The Button Float component takes a `trailingIcon` prop. This icon will be rendered after the text. It's recommended to use the Chroma icon set.",
+export const Icon: Story = {
+  render: Template,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The Button Float component takes an icon prop. It's recommended to use the [Chromicons](https://lifeomic.github.io/chromicons.com/) icon set.",
+      },
     },
   },
+  args: {
+    icon: Edit,
+  },
 };
-TrailingIcon.args = {
-  trailingIcon: Edit,
+
+export const TrailingIcon: Story = {
+  render: Template,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The Button Float component takes a `trailingIcon` prop. This icon will be rendered after the text. It's recommended to use the Chroma icon set.",
+      },
+    },
+  },
+  args: {
+    trailingIcon: Edit,
+  },
 };

--- a/src/components/ButtonLink/ButtonLink.stories.tsx
+++ b/src/components/ButtonLink/ButtonLink.stories.tsx
@@ -1,102 +1,129 @@
 import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, StoryFn, Meta } from '@storybook/react';
 import { MemoryRouter } from 'react-router-dom';
 
 import { ButtonLink } from './ButtonLink';
 import { Edit } from '@lifeomic/chromicons';
 
-export default {
-  title: 'Components/ButtonLink',
+const meta: Meta<typeof ButtonLink> = {
   component: ButtonLink,
-  argTypes: {},
+  args: {
+    to: '/',
+  },
   decorators: [(story) => <MemoryRouter>{story()}</MemoryRouter>],
-} as ComponentMeta<typeof ButtonLink>;
+};
+export default meta;
+type Story = StoryObj<typeof ButtonLink>;
 
-const Template: ComponentStory<typeof ButtonLink> = (args) => (
+const Template: StoryFn<typeof ButtonLink> = (args) => (
   <ButtonLink {...args}>Button Link</ButtonLink>
 );
 
-export const Default = Template.bind({});
-Default.args = {
-  to: '/',
+export const Default: Story = {
+  render: Template,
 };
 
-export const InternalExternalToHref = Template.bind({});
-InternalExternalToHref.parameters = {
-  docs: {
-    description: {
-      story:
-        '#### Internal href\n' +
-        'The Button Link component requires a "to" prop for the URL it should link to. By ' +
-        'default, the component will generate a typical link.\n' +
-        '#### External href\n' +
-        'By default, the Button Link component will generate an "external" link when the ' +
-        '"to" prop begins with "https".' +
-        '',
+export const InternalExternalToHref: Story = {
+  render: Template,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '#### Internal href\n' +
+          'The Button Link component requires a "to" prop for the URL it should link to. By ' +
+          'default, the component will generate a typical link.\n' +
+          '#### External href\n' +
+          'By default, the Button Link component will generate an "external" link when the ' +
+          '"to" prop begins with "https".' +
+          '',
+      },
     },
   },
-};
-InternalExternalToHref.args = {
-  to: 'https://example.com',
-};
-
-export const TargetSelf = Template.bind({});
-TargetSelf.parameters = {
-  docs: {
-    description: {
-      story:
-        'When an external link is detected, it will auto-add the `target` and `rel` attributes as well. ' +
-        'To provide a link to an external href, but without opening a new tab, provide the "target" prop.',
-    },
+  args: {
+    to: 'https://example.com',
   },
 };
-TargetSelf.args = {
-  to: 'https://example.com',
-  target: '_self',
-};
 
-export const Icon = Template.bind({});
-Icon.parameters = {
-  docs: {
-    description: {
-      story:
-        "The Button Float component takes an icon prop. It's recommended to use the [Chromicons](https://lifeomic.github.io/chromicons.com/) icon set.",
+export const TargetSelf: Story = {
+  render: Template,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'When an external link is detected, it will auto-add the `target` and `rel` attributes as well. ' +
+          'To provide a link to an external href, but without opening a new tab, provide the "target" prop.',
+      },
     },
   },
-};
-Icon.args = {
-  to: 'https://example.com',
-  icon: Edit,
-};
-
-export const TrailingIcon = Template.bind({});
-TrailingIcon.parameters = {
-  docs: {
-    description: {
-      story:
-        "The Button Float component takes a `trailingIcon` prop. This icon will be rendered after the text. It's recommended to use the Chroma icon set.",
-    },
+  args: {
+    to: 'https://example.com',
+    target: '_self',
   },
 };
-TrailingIcon.args = {
-  to: 'https://example.com',
-  trailingIcon: Edit,
+
+export const Disabled: Story = {
+  render: Template,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The Button Float component takes an icon prop. It's recommended to use the [Chromicons](https://lifeomic.github.io/chromicons.com/) icon set.",
+      },
+    },
+  },
+  args: {
+    disabled: true,
+  },
 };
 
-export const InverseDark = Template.bind({});
-InverseDark.parameters = {
-  backgrounds: { default: 'dark' },
-};
-InverseDark.args = {
-  to: '/',
-  color: 'inverse',
+export const Icon: Story = {
+  render: Template,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The Button Float component takes an icon prop. It's recommended to use the [Chromicons](https://lifeomic.github.io/chromicons.com/) icon set.",
+      },
+    },
+  },
+  args: {
+    to: 'https://example.com',
+    icon: Edit,
+  },
 };
 
-export const InverseBlue = Template.bind({});
-InverseBlue.parameters = {
-  backgrounds: { default: 'blue' },
+export const TrailingIcon: Story = {
+  render: Template,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The Button Float component takes a `trailingIcon` prop. This icon will be rendered after the text. It's recommended to use the Chroma icon set.",
+      },
+    },
+  },
+  args: {
+    to: 'https://example.com',
+    trailingIcon: Edit,
+  },
 };
-InverseBlue.args = {
-  to: '/',
-  color: 'inverse',
+
+export const InverseDark: Story = {
+  render: Template,
+  parameters: {
+    backgrounds: { default: 'dark' },
+  },
+  args: {
+    color: 'inverse',
+  },
+};
+
+export const InverseBlue: Story = {
+  render: Template,
+  parameters: {
+    backgrounds: { default: 'blue' },
+  },
+  args: {
+    color: 'inverse',
+  },
 };

--- a/src/components/ButtonUnstyled/ButtonUnstyled.stories.tsx
+++ b/src/components/ButtonUnstyled/ButtonUnstyled.stories.tsx
@@ -1,19 +1,21 @@
 import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, StoryFn, Meta } from '@storybook/react';
 
 import { ButtonUnstyled } from './ButtonUnstyled';
 
-export default {
-  title: 'Components/ButtonUnstyled',
+const meta: Meta<typeof ButtonUnstyled> = {
   component: ButtonUnstyled,
   argTypes: {
     onClick: { action: 'clicked' },
   },
-} as ComponentMeta<typeof ButtonUnstyled>;
+};
+export default meta;
+type Story = StoryObj<typeof ButtonUnstyled>;
 
-const Template: ComponentStory<typeof ButtonUnstyled> = (args) => (
+const Template: StoryFn<typeof ButtonUnstyled> = (args) => (
   <ButtonUnstyled {...args}>Button Unstyled</ButtonUnstyled>
 );
 
-export const Default = Template.bind({});
-Default.args = {};
+export const Default: Story = {
+  render: Template,
+};


### PR DESCRIPTION
# What Was Changed

- Replaced now-defunct CSF 1 & 2 types `ComponentStory` and `ComponentMeta` with `StoryObj` and `Meta` respectively
- Updated all stories to the new single-const format 
- Removed titles, since those are now created from the component name unless you need to override them
    - except for `Box`, which is organized into the Layout group
- Created Story type and added it to all stories for increased type safety
-  Added Stories for Outlined and Text variants on `Button` so we have examples of those properties on at least one button component
- Increased height on `ButtonFloat` stories wrapper so it doesn't get cut off by outer window

# Screenshots

## New Button Stories

![Screenshot 2023-08-22 at 4 21 18 PM](https://github.com/lifeomic/chroma-react/assets/5824697/dad3b13d-72e0-47c4-9de6-4f15656348fb)

## ButtonFloat Height Fix

| Before | After |
| --- | --- |
| ![Screenshot 2023-08-22 at 4 22 03 PM](https://github.com/lifeomic/chroma-react/assets/5824697/030e029a-6e97-4f5e-bd38-6bab6f35645d) | ![Screenshot 2023-08-22 at 4 21 48 PM](https://github.com/lifeomic/chroma-react/assets/5824697/30800bce-a9b3-4b11-abcd-d70bce3e93c2) |


