### PR TITLE
feat: Add Slideover title icon

### DIFF
--- a/src/components/SlideOver/Actions.tsx
+++ b/src/components/SlideOver/Actions.tsx
@@ -10,10 +10,6 @@ export const useStyles = makeStyles(
   (theme) => ({
     root: {
       borderTop: `1px solid ${theme.palette.divider}`,
-      paddingBottom: theme.spacing(1),
-      paddingLeft: theme.spacing(2),
-      paddingRight: theme.spacing(2),
-      paddingTop: theme.spacing(1),
     },
   }),
   { name: ActionsStylesKey }
@@ -30,7 +26,12 @@ export const Actions: React.FC<ActionsProps> = ({
 }) => {
   const classes = useStyles({});
   return (
-    <Box className={clsx(classes.root, className)} {...rootProps}>
+    <Box
+      className={clsx(classes.root, className)}
+      gap={1}
+      padding={2}
+      {...rootProps}
+    >
       {children}
     </Box>
   );

--- a/src/components/SlideOver/Header.test.tsx
+++ b/src/components/SlideOver/Header.test.tsx
@@ -2,6 +2,10 @@ import * as React from 'react';
 import { renderWithTheme } from '../../testUtils/renderWithTheme';
 import { Header, HeaderProps } from './index';
 import { fireEvent } from '@testing-library/dom';
+import {
+  IconComponent,
+  testId as iconComponentTestId,
+} from '../../testUtils/IconComponent';
 
 const testId = 'Header';
 
@@ -67,4 +71,22 @@ test('it renders the provided children', async () => {
 
   const children = await findByTestId(testId);
   expect(children).toBeInTheDocument();
+});
+
+test('it renders title and title icon', async () => {
+  const { findByTestId } = renderWithTheme(
+    <Header
+      {...getBaseProps()}
+      data-testid={testId}
+      title="SlideOverTitle"
+      titleIcon={IconComponent}
+      onClose={() => {}}
+    />
+  );
+
+  const title = await findByTestId(testId);
+  expect(title).toBeInTheDocument();
+  const titleIcon = await findByTestId(iconComponentTestId);
+  expect(titleIcon).toBeInTheDocument();
+  expect(titleIcon).toHaveClass('ChromaSlideOverHeader-titleIcon');
 });

--- a/src/components/SlideOver/Header.tsx
+++ b/src/components/SlideOver/Header.tsx
@@ -5,18 +5,22 @@ import { Text } from '../Text';
 import { X } from '@lifeomic/chromicons';
 import * as React from 'react';
 import clsx from 'clsx';
+import { Box } from '../Box';
 
 export const HeaderStylesKey = 'ChromaSlideOverHeader';
 
 export const useStyles = makeStyles(
   (theme) => ({
     root: {
-      alignItems: 'center',
-      display: 'flex',
-      flexDirection: 'row',
-      justifyContent: 'space-between',
       backgroundColor: theme.palette.black[50],
-      padding: theme.spacing(2),
+    },
+    titleIcon: {
+      color: theme.palette.text.hint,
+      height: theme.pxToRem(22),
+      width: theme.pxToRem(22),
+    },
+    button: {
+      marginRight: theme.pxToRem(-10),
     },
   }),
   { name: HeaderStylesKey }
@@ -29,6 +33,7 @@ export interface HeaderProps {
   children?: React.ReactNode;
   onClose: () => any;
   title?: string;
+  titleIcon?: React.ComponentType<React.SVGProps<SVGSVGElement>>;
   classes?: {
     root?: string;
     text?: string;
@@ -42,31 +47,40 @@ export const Header: React.FC<HeaderProps> = ({
   className,
   onClose,
   title,
+  titleIcon: TitleIcon,
   ...rootProps
 }) => {
   const classes = useStyles({});
   return (
-    <div
+    <Box
+      align="center"
+      justify="space-between"
+      padding={2}
       className={clsx(classes.root, additionalClasses?.root, className)}
       {...rootProps}
     >
       {children}
       {title && (
-        <Text
-          className={clsx(additionalClasses?.text)}
-          size="body"
-          weight="bold"
-        >
-          {title}
-        </Text>
+        <Box align="center" gap={1}>
+          {!!TitleIcon && (
+            <TitleIcon role="img" aria-hidden className={classes.titleIcon} />
+          )}
+          <Text
+            className={clsx(additionalClasses?.text)}
+            size="body"
+            weight="bold"
+          >
+            {title}
+          </Text>
+        </Box>
       )}
       <IconButton
-        className={additionalClasses?.button}
+        className={clsx(classes.button, additionalClasses?.button)}
         aria-label="Close panel"
         icon={X}
         onClick={onClose}
         size={0}
       />
-    </div>
+    </Box>
   );
 };

--- a/src/components/SlideOver/SlideOver.stories.tsx
+++ b/src/components/SlideOver/SlideOver.stories.tsx
@@ -8,6 +8,7 @@ import { Text } from '../Text';
 import { Body } from './Body';
 import { Actions } from './Actions';
 import { Button } from '../Button';
+import { Settings } from '@lifeomic/chromicons';
 
 export default {
   title: 'Components/SlideOver',
@@ -25,6 +26,19 @@ Default.args = {
   children: (
     <>
       <Header title="Panel Title" onClose={() => {}} />
+      <Body>
+        <Text>Content</Text>
+      </Body>
+    </>
+  ),
+  isOpen: true,
+};
+
+export const HeaderWithIcon = Template.bind({});
+HeaderWithIcon.args = {
+  children: (
+    <>
+      <Header title="Panel Title" titleIcon={Settings} onClose={() => {}} />
       <Body>
         <Text>Content</Text>
       </Body>


### PR DESCRIPTION
### Changes

- Add `titleIcon` prop to `<Header`
- Move close icon to the right by 10px
- Add padding around actions footer
- Add spacing between actions
- Update tests

BEFORE | AFTER | &nbsp;
-- | -- | --
<img width="449" alt="Screenshot 2023-08-23 at 1 55 25 PM" src="https://github.com/lifeomic/chroma-react/assets/485903/b7948643-188c-44fd-a510-a19c18f19253"> | <img width="449" alt="Screenshot 2023-08-23 at 1 46 35 PM" src="https://github.com/lifeomic/chroma-react/assets/485903/08d6999b-ab67-41ad-9395-4b4e6fa2ca56"> | Nudge close icon to the right
<img width="449" alt="Screenshot 2023-08-23 at 1 55 31 PM" src="https://github.com/lifeomic/chroma-react/assets/485903/1086afba-698b-4c41-9ab9-a01466e0e09a"> | <img width="449" alt="Screenshot 2023-08-23 at 1 46 25 PM" src="https://github.com/lifeomic/chroma-react/assets/485903/31d0b7bd-d720-491a-9acc-3274c92d4146"> | Nudge close icon to the right
<img width="449" alt="Screenshot 2023-08-23 at 1 55 39 PM" src="https://github.com/lifeomic/chroma-react/assets/485903/51b6ba1f-3cbc-4751-b3aa-58b9b3992cc9"> | <img width="449" alt="Screenshot 2023-08-23 at 1 46 35 PM" src="https://github.com/lifeomic/chroma-react/assets/485903/bcd1e9d3-414d-4c8d-b221-565070275dca"> | Nudge close icon; Add padding to footer; Add space between buttons
N/A | <img width="449" alt="Screenshot 2023-08-23 at 1 46 29 PM" src="https://github.com/lifeomic/chroma-react/assets/485903/f10794d4-ba0e-4fd4-84de-a8553f3b2143"> | Add `titleIcon`

