### PR TITLE
Update D- Components to Storybook CSF3

### DIFF
--- a/src/components/DayPicker/DayPicker.stories.tsx
+++ b/src/components/DayPicker/DayPicker.stories.tsx
@@ -1,120 +1,120 @@
 import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, Meta } from '@storybook/react';
 
 import { DayPicker } from './DayPicker';
 
-export default {
+const meta: Meta<typeof DayPicker> = {
   title: 'Form Components/DayPicker',
   component: DayPicker,
-  argTypes: {},
-} as ComponentMeta<typeof DayPicker>;
-
-const Template: ComponentStory<typeof DayPicker> = (args) => (
-  <DayPicker {...args} />
-);
-
-export const Default = Template.bind({});
-Default.args = {
-  label: 'Day Picker',
+  args: {
+    label: 'Day Picker',
+  },
+  decorators: [
+    (story) => <div style={{ width: '460px', height: '350px' }}>{story()}</div>,
+  ],
 };
+export default meta;
+type Story = StoryObj<typeof DayPicker>;
 
-export const ValueAndOnDayChange = Template.bind({});
-ValueAndOnDayChange.parameters = {
-  docs: {
-    description: {
-      story: `\`DayPicker\` is a controlled component, and uses the \`value\` and \`onDayChange\` props
-to facilitate input.
+export const Default: Story = {};
 
-If \`value\` is set to \`undefined\`, the provided \`placeholder\` message will be shown.
+export const ValueAndOnDayChange: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: `\`DayPicker\` is a controlled component, and uses the \`value\` and \`onDayChange\` props
+  to facilitate input.
 
-\`onDayChange\` is called in two scenarios:
+  If \`value\` is set to \`undefined\`, the provided \`placeholder\` message will be shown.
 
-- a date was selected in the calendar UI
-- if manual input is enabled (via \`parseDate\`), and the input is updated to a valid date string.`,
+  \`onDayChange\` is called in two scenarios:
+
+  - a date was selected in the calendar UI
+  - if manual input is enabled (via \`parseDate\`), and the input is updated to a valid date string.`,
+      },
     },
   },
-};
-ValueAndOnDayChange.args = {
-  label: 'Day Picker',
-  value: new Date(),
-};
-
-export const FormatDate = Template.bind({});
-FormatDate.parameters = {
-  docs: {
-    description: {
-      story: `Custom text formats can be supported via the \`formatDate\` prop`,
-    },
+  args: {
+    value: new Date(),
   },
 };
-FormatDate.args = {
-  label: 'Day Picker',
-  value: new Date(),
-  formatDate: (date: Date) => date.toISOString().slice(0, 10),
-};
 
-export const ManualInput = Template.bind({});
-ManualInput.parameters = {
-  docs: {
-    description: {
-      story: `By default, \`DayPicker\` does not allow for manual input into the text field.
-
-Providing the \`parseDate\` prop will enable this behavior.
-
-You can use the \`onTextChange\` prop to visually handle malformed strings, e.g. via an error message.`,
+export const FormatDate: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: `Custom text formats can be supported via the \`formatDate\` prop`,
+      },
     },
   },
-};
-ManualInput.args = {
-  label: 'Day Picker',
-  value: new Date(),
-  formatDate: (date: Date) => date.toISOString().slice(0, 10),
-  parseDate: (_text: string) => new Date(),
-  onTextChange: (_text: string) => {},
+  args: {
+    value: new Date(),
+    formatDate: (date: Date) => date.toISOString().slice(0, 10),
+  },
 };
 
-export const MinDate = Template.bind({});
-MinDate.args = {
-  label: 'Day Picker',
-  value: new Date(),
-  minDate: new Date(),
+export const ManualInput: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: `By default, \`DayPicker\` does not allow for manual input into the text field.
+
+  Providing the \`parseDate\` prop will enable this behavior.
+
+  You can use the \`onTextChange\` prop to visually handle malformed strings, e.g. via an error message.`,
+      },
+    },
+  },
+  args: {
+    value: new Date(),
+    formatDate: (date: Date) => date.toISOString().slice(0, 10),
+    parseDate: (_text: string) => new Date(),
+    onTextChange: (_text: string) => {},
+  },
 };
 
-export const MaxDate = Template.bind({});
-MaxDate.args = {
-  label: 'Day Picker',
-  value: new Date(),
-  maxDate: new Date(),
+export const MinDate: Story = {
+  args: {
+    value: new Date(),
+    minDate: new Date(),
+  },
 };
 
-export const DisableDay = Template.bind({});
-DisableDay.args = {
-  label: 'Day Picker',
-  value: new Date(),
-  disableDay: (date: Date) => date.getDate() % 2 === 0,
+export const MaxDate: Story = {
+  args: {
+    value: new Date(),
+    maxDate: new Date(),
+  },
 };
 
-export const AnchorPosition = Template.bind({});
-AnchorPosition.args = {
-  label: 'Day Picker',
-  value: new Date(),
-  anchorPosition: 'top-right',
+export const DisableDay: Story = {
+  args: {
+    value: new Date(),
+    disableDay: (date: Date) => date.getDate() % 2 === 0,
+  },
 };
 
-export const InverseDark = Template.bind({});
-InverseDark.parameters = {
-  backgrounds: { default: 'dark' },
-};
-InverseDark.args = {
-  label: 'Day Picker',
-  color: 'inverse',
+export const AnchorPosition: Story = {
+  args: {
+    value: new Date(),
+    anchorPosition: 'bottom-right',
+  },
 };
 
-export const InverseBlue = Template.bind({});
-InverseBlue.parameters = {
-  backgrounds: { default: 'blue' },
+export const InverseDark: Story = {
+  parameters: {
+    backgrounds: { default: 'dark' },
+  },
+  args: {
+    color: 'inverse',
+  },
 };
-InverseBlue.args = {
-  label: 'Day Picker',
-  color: 'inverse',
+
+export const InverseBlue: Story = {
+  parameters: {
+    backgrounds: { default: 'blue' },
+  },
+  args: {
+    color: 'inverse',
+  },
 };

--- a/src/components/Divider/Divider.stories.tsx
+++ b/src/components/Divider/Divider.stories.tsx
@@ -1,33 +1,40 @@
 import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, Meta } from '@storybook/react';
 
 import { Divider } from './Divider';
 
-export default {
+const meta: Meta<typeof Divider> = {
   title: 'Layout/Divider',
   component: Divider,
-  argTypes: {},
-} as ComponentMeta<typeof Divider>;
-
-const Template: ComponentStory<typeof Divider> = (args) => (
-  <Divider {...args} />
-);
-
-export const Default = Template.bind({});
-Default.args = {};
-
-export const InverseDark = Template.bind({});
-InverseDark.parameters = {
-  backgrounds: { default: 'dark' },
 };
-InverseDark.args = {
-  color: 'inverse',
+export default meta;
+type Story = StoryObj<typeof Divider>;
+
+export const Default: Story = {};
+
+export const InverseDark: Story = {
+  parameters: {
+    backgrounds: { default: 'dark' },
+  },
+  args: {
+    color: 'inverse',
+  },
 };
 
-export const InverseBlue = Template.bind({});
-InverseBlue.parameters = {
-  backgrounds: { default: 'blue' },
+export const InverseBlue: Story = {
+  parameters: {
+    backgrounds: { default: 'blue' },
+  },
+  args: {
+    color: 'inverse',
+  },
 };
-InverseBlue.args = {
-  color: 'inverse',
+
+export const Direction: Story = {
+  args: {
+    direction: 'row',
+  },
+  decorators: [
+    (story: Function) => <div style={{ height: '50px' }}>{story()}</div>,
+  ],
 };

--- a/src/components/DotLoader/DotLoader.stories.tsx
+++ b/src/components/DotLoader/DotLoader.stories.tsx
@@ -1,17 +1,36 @@
 import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, StoryFn, Meta } from '@storybook/react';
+import { makeStyles } from '../../styles';
 
 import { DotLoader } from './DotLoader';
 
-export default {
+const useStyles = makeStyles(() => ({
+  styledLoader: {
+    fill: 'black',
+  },
+}));
+
+const meta: Meta<typeof DotLoader> = {
   title: 'Components/DotLoader',
   component: DotLoader,
   argTypes: {},
-} as ComponentMeta<typeof DotLoader>;
+} as Meta<typeof DotLoader>;
+export default meta;
+type Story = StoryObj<typeof DotLoader>;
 
-const Template: ComponentStory<typeof DotLoader> = (args) => (
-  <DotLoader {...args} />
-);
+const Template: StoryFn<typeof DotLoader> = (args) => {
+  const classes = useStyles({});
+  return <DotLoader {...args} dotStyle={classes.styledLoader} />;
+};
 
-export const Default = Template.bind({});
-Default.args = {};
+export const Default: Story = {};
+
+export const Small: Story = {
+  args: {
+    size: 1,
+  },
+};
+
+export const Styled: Story = {
+  render: Template,
+};


### PR DESCRIPTION
# What Was Changed

- Replaced now-defunct CSF 1 & 2 types `ComponentStory` and `ComponentMeta` with `StoryObj` and `Meta` respectively
- Updated all stories to the new single-const format 
- Removed titles from ungrouped components whose name is the same as their filename
- Created Story type and added it to all stories for increased type safety
-  Added Stories for `DotLoader` small and styled args, as well as `Divider` row arg
- Increased height on `DayPicker` stories wrapper so it doesn't get cut off by outer window - in the future, we could look into making the `DayPicker` calendar popup float above its parent content like `Select` and `ComboBox`
- _`DescriptionList` Components will be the next PR, to try to keep this one to a reasonable size_

# Screenshots

## New Divider Story

![Screenshot 2023-08-23 at 11 13 50 AM](https://github.com/lifeomic/chroma-react/assets/5824697/e61f1749-3cd5-40e8-b61a-899e88ea4a91)

## New DotLoader Stories

![Screenshot 2023-08-23 at 11 14 03 AM](https://github.com/lifeomic/chroma-react/assets/5824697/b066f7dc-3d7d-4c74-9aad-67b320774238)

## DayPicker Height Fix

| Before | After |
| --- | --- |
| ![Screenshot 2023-08-23 at 11 21 19 AM](https://github.com/lifeomic/chroma-react/assets/5824697/59c5d0ee-0f5e-4d64-a69b-c116039bdc9f) | ![Screenshot 2023-08-23 at 11 14 38 AM](https://github.com/lifeomic/chroma-react/assets/5824697/e48f4066-b43c-42ec-bf1f-51250e57485d) |




