### PR TITLE
Update E- to H- Components to Storybook CSF3

### DIFF
--- a/src/components/ExpansionPanel/ExpansionPanel.stories.tsx
+++ b/src/components/ExpansionPanel/ExpansionPanel.stories.tsx
@@ -1,45 +1,50 @@
 import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, StoryFn, Meta } from '@storybook/react';
 
 import { ExpansionPanel } from './ExpansionPanel';
 import { Check, ArrowRight } from '@lifeomic/chromicons';
 
-export default {
+const meta: Meta<typeof ExpansionPanel> = {
   title: 'Components/ExpansionPanel',
   component: ExpansionPanel,
-  argTypes: {},
-} as ComponentMeta<typeof ExpansionPanel>;
+  args: {
+    title: 'Expansion Panel',
+  },
+};
+export default meta;
+type Story = StoryObj<typeof ExpansionPanel>;
 
-const Template: ComponentStory<typeof ExpansionPanel> = (args) => (
+const Template: StoryFn<typeof ExpansionPanel> = (args) => (
   <ExpansionPanel {...args}>
     <p>Content inside of panel</p>
     <p>More content inside of panel</p>
   </ExpansionPanel>
 );
 
-export const Default = Template.bind({});
-Default.args = {
-  title: 'Expansion Panel',
+export const Default: Story = {
+  render: Template,
 };
 
-export const Icon = Template.bind({});
-Icon.args = {
-  title: 'Expansion Panel',
-  leadingIcon: Check,
+export const Icon: Story = {
+  render: Template,
+  args: {
+    leadingIcon: Check,
+  },
 };
 
-export const TruncatedTitle = Template.bind({});
-TruncatedTitle.args = {
-  title:
-    'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
-  leadingIcon: ArrowRight,
-  truncateTitle: true,
-};
-
-TruncatedTitle.parameters = {
-  docs: {
-    description: {
-      story: `The title can be set to truncate with an ellipsis if it is too long for the expansion panel.`,
+export const TruncatedTitle: Story = {
+  render: Template,
+  args: {
+    title:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
+    leadingIcon: ArrowRight,
+    truncateTitle: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: `The title can be set to truncate with an ellipsis if it is too long for the expansion panel.`,
+      },
     },
   },
 };

--- a/src/components/FormBox/FormBox.stories.tsx
+++ b/src/components/FormBox/FormBox.stories.tsx
@@ -1,22 +1,25 @@
 import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, StoryFn, Meta } from '@storybook/react';
 
 import { FormBox } from './FormBox';
 import { TextField } from '../TextField';
 import { TextArea } from '../TextArea';
 
-export default {
+const meta: Meta<typeof FormBox> = {
   title: 'Form Components/FormBox',
   component: FormBox,
   argTypes: {},
-} as ComponentMeta<typeof FormBox>;
+};
+export default meta;
+type Story = StoryObj<typeof FormBox>;
 
-const Template: ComponentStory<typeof FormBox> = (args) => (
+const Template: StoryFn<typeof FormBox> = (args) => (
   <FormBox {...args}>
     <TextField label="Text Field" />
     <TextArea label="Text Area" />
   </FormBox>
 );
 
-export const Default = Template.bind({});
-Default.args = {};
+export const Default: Story = {
+  render: Template,
+};

--- a/src/components/Header/Header.stories.tsx
+++ b/src/components/Header/Header.stories.tsx
@@ -1,26 +1,29 @@
 import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, Meta } from '@storybook/react';
 
 import { Header } from './Header';
 import { Logo } from '../../assets/Logo';
 import { Button } from '../Button';
 import { Avatar } from '../Avatar';
 
-export default {
+const meta: Meta<typeof Header> = {
   title: 'Components/Header',
   component: Header,
-  argTypes: {},
-} as ComponentMeta<typeof Header>;
+};
+export default meta;
+type Story = StoryObj<typeof Header>;
 
-const Template: ComponentStory<typeof Header> = (args) => <Header {...args} />;
+export const Default: Story = {
+  args: {
+    left: <Button variant="text">Header</Button>,
+  },
+};
 
-export const Default = Template.bind({});
-Default.args = {};
-
-export const Full = Template.bind({});
-Full.args = {
-  centerLogo: true,
-  logo: <Logo />,
-  left: <Button variant="text">Account 1</Button>,
-  right: <Avatar size={0} name="Chroma" />,
+export const Full: Story = {
+  args: {
+    centerLogo: true,
+    logo: <Logo />,
+    left: <Button variant="text">Account 1</Button>,
+    right: <Avatar size={0} name="Chroma" />,
+  },
 };


### PR DESCRIPTION
# What Was Changed

## Common to all CSF3 updates
- Replaced now-defunct CSF 1 & 2 types `ComponentStory` and `ComponentMeta` with `StoryObj` and `Meta` respectively
- Updated all stories to the new single-const format 
- Removed titles from ungrouped components whose name is the same as their filename
- Created Story type and added it to all stories for increased type safety

## Unique to this PR
- Added title to left in Default `Header` so it doesn't look empty

# Screenshots

## Header Default

| Before | After |
| --- | --- |
| ![Screenshot 2023-08-23 at 5 20 03 PM](https://github.com/lifeomic/chroma-react/assets/5824697/181029ee-08ed-44b7-99fe-56d60c397a7d) | ![Screenshot 2023-08-23 at 5 17 46 PM](https://github.com/lifeomic/chroma-react/assets/5824697/c6bbb6e7-eb73-4d28-a333-1482791160fa) |




