### PR TITLE
Update IconButton Components to Storybook CSF3 

### DIFF
--- a/src/components/IconButton/IconButton.stories.tsx
+++ b/src/components/IconButton/IconButton.stories.tsx
@@ -1,12 +1,14 @@
-import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, Meta } from '@storybook/react';
 
 import { IconButton } from './IconButton';
 import { Edit } from '@lifeomic/chromicons';
 
-export default {
-  title: 'Components/IconButton',
+const meta: Meta<typeof IconButton> = {
   component: IconButton,
+  args: {
+    'aria-label': 'Edit',
+    icon: Edit,
+  },
   argTypes: {
     disabled: {
       description: '`boolean`',
@@ -17,41 +19,32 @@ export default {
     },
     onClick: { action: 'clicked' },
   },
-} as ComponentMeta<typeof IconButton>;
+};
+export default meta;
+type Story = StoryObj<typeof IconButton>;
 
-const Template: ComponentStory<typeof IconButton> = (args) => (
-  <IconButton {...args} />
-);
+export const Default: Story = {};
 
-export const Default = Template.bind({});
-Default.args = {
-  'aria-label': 'Edit',
-  icon: Edit,
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
 };
 
-export const Disabled = Template.bind({});
-Disabled.args = {
-  'aria-label': 'Edit',
-  icon: Edit,
-  disabled: true,
+export const InverseDark: Story = {
+  parameters: {
+    backgrounds: { default: 'dark' },
+  },
+  args: {
+    color: 'inverse',
+  },
 };
 
-export const InverseDark = Template.bind({});
-InverseDark.parameters = {
-  backgrounds: { default: 'dark' },
-};
-InverseDark.args = {
-  'aria-label': 'Edit',
-  icon: Edit,
-  color: 'inverse',
-};
-
-export const InverseBlue = Template.bind({});
-InverseBlue.parameters = {
-  backgrounds: { default: 'blue' },
-};
-InverseBlue.args = {
-  'aria-label': 'Edit',
-  icon: Edit,
-  color: 'inverse',
+export const InverseBlue: Story = {
+  parameters: {
+    backgrounds: { default: 'blue' },
+  },
+  args: {
+    color: 'inverse',
+  },
 };

--- a/src/components/IconButton/IconButton.stories.tsx
+++ b/src/components/IconButton/IconButton.stories.tsx
@@ -1,7 +1,7 @@
 import { StoryObj, Meta } from '@storybook/react';
 
 import { IconButton } from './IconButton';
-import { Edit } from '@lifeomic/chromicons';
+import { Edit, Settings } from '@lifeomic/chromicons';
 
 const meta: Meta<typeof IconButton> = {
   component: IconButton,
@@ -24,6 +24,32 @@ export default meta;
 type Story = StoryObj<typeof IconButton>;
 
 export const Default: Story = {};
+
+export const Icon: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'For a list of available icons, see our <a href="https://lifeomic.github.io/chromicons.com/">Chrōmicons catalog</a>.',
+      },
+    },
+  },
+  args: {
+    icon: Settings,
+  },
+};
+
+export const Size: Story = {
+  args: {
+    size: 0,
+  },
+};
+
+export const Color: Story = {
+  args: {
+    color: 'negative',
+  },
+};
 
 export const Disabled: Story = {
   args: {

--- a/src/components/IconButtonFloat/IconButtonFloat.stories.tsx
+++ b/src/components/IconButtonFloat/IconButtonFloat.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { StoryObj, Meta } from '@storybook/react';
 
 import { IconButtonFloat } from './IconButtonFloat';
-import { Edit } from '@lifeomic/chromicons';
+import { Edit, Settings } from '@lifeomic/chromicons';
 
 const meta: Meta<typeof IconButtonFloat> = {
   component: IconButtonFloat,
@@ -22,19 +22,21 @@ const meta: Meta<typeof IconButtonFloat> = {
   },
   decorators: [
     (story) => (
-      <div
-        style={{
-          position: 'fixed',
-          display: 'flex',
-          justifyContent: 'center',
-          alignItems: 'center',
-          top: 0,
-          right: 0,
-          bottom: 0,
-          left: 0,
-        }}
-      >
-        {story()}
+      <div style={{ height: '50px' }}>
+        <div
+          style={{
+            position: 'fixed',
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            top: 0,
+            right: 0,
+            bottom: 0,
+            left: 0,
+          }}
+        >
+          {story()}
+        </div>
       </div>
     ),
   ],
@@ -43,6 +45,32 @@ export default meta;
 type Story = StoryObj<typeof IconButtonFloat>;
 
 export const Default: Story = {};
+
+export const Icon: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'For a list of available icons, see our <a href="https://lifeomic.github.io/chromicons.com/">Chrōmicons catalog</a>.',
+      },
+    },
+  },
+  args: {
+    icon: Settings,
+  },
+};
+
+export const Size: Story = {
+  args: {
+    size: 0,
+  },
+};
+
+export const Justify: Story = {
+  args: {
+    justify: 'left',
+  },
+};
 
 export const Disabled: Story = {
   args: {

--- a/src/components/IconButtonFloat/IconButtonFloat.stories.tsx
+++ b/src/components/IconButtonFloat/IconButtonFloat.stories.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, Meta } from '@storybook/react';
 
 import { IconButtonFloat } from './IconButtonFloat';
 import { Edit } from '@lifeomic/chromicons';
 
-export default {
-  title: 'Components/IconButtonFloat',
+const meta: Meta<typeof IconButtonFloat> = {
   component: IconButtonFloat,
+  args: {
+    'aria-label': 'Edit',
+    icon: Edit,
+  },
   argTypes: {
     disabled: {
       description: '`boolean`',
@@ -35,21 +38,14 @@ export default {
       </div>
     ),
   ],
-} as ComponentMeta<typeof IconButtonFloat>;
-
-const Template: ComponentStory<typeof IconButtonFloat> = (args) => (
-  <IconButtonFloat {...args} />
-);
-
-export const Default = Template.bind({});
-Default.args = {
-  'aria-label': 'Edit',
-  icon: Edit,
 };
+export default meta;
+type Story = StoryObj<typeof IconButtonFloat>;
 
-export const Disabled = Template.bind({});
-Disabled.args = {
-  'aria-label': 'Edit',
-  icon: Edit,
-  disabled: true,
+export const Default: Story = {};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
 };

--- a/src/components/IconButtonLink/IconButtonLink.stories.tsx
+++ b/src/components/IconButtonLink/IconButtonLink.stories.tsx
@@ -1,13 +1,17 @@
 import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, Meta } from '@storybook/react';
 
 import { IconButtonLink } from './IconButtonLink';
 import { Edit } from '@lifeomic/chromicons';
 import { MemoryRouter } from 'react-router-dom';
 
-export default {
-  title: 'Components/IconButtonLink',
+const meta: Meta<typeof IconButtonLink> = {
   component: IconButtonLink,
+  args: {
+    'aria-label': 'IconButtonLink',
+    icon: Edit,
+    to: '/',
+  },
   argTypes: {
     disabled: {
       description: '`boolean`',
@@ -19,88 +23,71 @@ export default {
     onClick: { action: 'clicked' },
   },
   decorators: [(story) => <MemoryRouter>{story()}</MemoryRouter>],
-} as ComponentMeta<typeof IconButtonLink>;
-
-const Template: ComponentStory<typeof IconButtonLink> = (args) => (
-  <IconButtonLink {...args} />
-);
-
-export const Default = Template.bind({});
-Default.args = {
-  'aria-label': 'IconButtonLink',
-  icon: Edit,
-  to: '/',
 };
+export default meta;
+type Story = StoryObj<typeof IconButtonLink>;
 
-export const InternalLink = Template.bind({});
-InternalLink.parameters = {
-  docs: {
-    description: {
-      story:
-        'The Icon Button Link component requires a "to" prop for the URL it should link ' +
-        'to. By default, the component will generate a typical link.',
+export const Default: Story = {};
+
+export const InternalLink: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The Icon Button Link component requires a "to" prop for the URL it should link ' +
+          'to. By default, the component will generate a typical link.',
+      },
     },
   },
 };
-InternalLink.args = {
-  'aria-label': 'IconButtonLink',
-  icon: Edit,
-  to: '/',
-};
 
-export const ExternalLink = Template.bind({});
-ExternalLink.parameters = {
-  docs: {
-    description: {
-      story:
-        'By default, the Icon Button Link component will generate an "external" link when ' +
-        'the "to" prop begins with "https".\n\n' +
-        'When an external link is detected, it will auto-add the `target` and `rel` ' +
-        'attributes as well.',
+export const ExternalLink: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'By default, the Icon Button Link component will generate an "external" link when ' +
+          'the "to" prop begins with "https".\n\n' +
+          'When an external link is detected, it will auto-add the `target` and `rel` ' +
+          'attributes as well.',
+      },
     },
   },
-};
-ExternalLink.args = {
-  'aria-label': 'IconButtonLink',
-  icon: Edit,
-  to: 'https://www.lifeomic.com',
-};
-
-export const ExternalLinkSameTab = Template.bind({});
-ExternalLinkSameTab.parameters = {
-  docs: {
-    description: {
-      story:
-        'To provide a link to an external href, but without opening a new tab, provide ' +
-        'the "target" prop.',
-    },
+  args: {
+    to: 'https://www.lifeomic.com',
   },
 };
-ExternalLinkSameTab.args = {
-  'aria-label': 'IconButtonLink',
-  icon: Edit,
-  to: 'https://www.lifeomic.com',
-  target: '_self',
+
+export const ExternalLinkSameTab: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'To provide a link to an external href, but without opening a new tab, provide ' +
+          'the "target" prop.',
+      },
+    },
+  },
+  args: {
+    to: 'https://www.lifeomic.com',
+    target: '_self',
+  },
 };
 
-export const InverseDark = Template.bind({});
-InverseDark.parameters = {
-  backgrounds: { default: 'dark' },
-};
-InverseDark.args = {
-  'aria-label': 'IconButtonLink',
-  icon: Edit,
-  to: '/',
-  color: 'inverse',
+export const InverseDark: Story = {
+  parameters: {
+    backgrounds: { default: 'dark' },
+  },
+  args: {
+    color: 'inverse',
+  },
 };
 
-export const InverseBlue = Template.bind({});
-InverseBlue.parameters = {
-  backgrounds: { default: 'blue' },
-};
-InverseBlue.args = {
-  'aria-label': 'IconButtonLink',
-  icon: Edit,
-  to: '/',
-  color: 'inverse',
+export const InverseBlue: Story = {
+  parameters: {
+    backgrounds: { default: 'blue' },
+  },
+  args: {
+    color: 'inverse',
+  },
 };

--- a/src/components/IconButtonLink/IconButtonLink.stories.tsx
+++ b/src/components/IconButtonLink/IconButtonLink.stories.tsx
@@ -13,13 +13,6 @@ const meta: Meta<typeof IconButtonLink> = {
     to: '/',
   },
   argTypes: {
-    disabled: {
-      description: '`boolean`',
-      table: {
-        defaultValue: { summary: false },
-      },
-      control: { type: 'boolean' },
-    },
     onClick: { action: 'clicked' },
   },
   decorators: [(story) => <MemoryRouter>{story()}</MemoryRouter>],

--- a/src/components/IconButtonLink/IconButtonLink.stories.tsx
+++ b/src/components/IconButtonLink/IconButtonLink.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { StoryObj, Meta } from '@storybook/react';
 
 import { IconButtonLink } from './IconButtonLink';
-import { Edit } from '@lifeomic/chromicons';
+import { Edit, Settings } from '@lifeomic/chromicons';
 import { MemoryRouter } from 'react-router-dom';
 
 const meta: Meta<typeof IconButtonLink> = {
@@ -21,6 +21,20 @@ export default meta;
 type Story = StoryObj<typeof IconButtonLink>;
 
 export const Default: Story = {};
+
+export const Icon: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'For a list of available icons, see our <a href="https://lifeomic.github.io/chromicons.com/">Chrōmicons catalog</a>.',
+      },
+    },
+  },
+  args: {
+    icon: Settings,
+  },
+};
 
 export const InternalLink: Story = {
   parameters: {
@@ -64,6 +78,18 @@ export const ExternalLinkSameTab: Story = {
   args: {
     to: 'https://www.lifeomic.com',
     target: '_self',
+  },
+};
+
+export const Size: Story = {
+  args: {
+    size: 0,
+  },
+};
+
+export const Color: Story = {
+  args: {
+    color: 'negative',
   },
 };
 


### PR DESCRIPTION
# What Was Changed

## Common to all CSF3 updates
- Replaced now-defunct CSF 1 & 2 types `ComponentStory` and `ComponentMeta` with `StoryObj` and `Meta` respectively
- Updated all stories to the new single-const format 
- Removed titles from ungrouped components whose name is the same as their filename
- Created Story type and added it to all stories for increased type safety

## Unique to this PR
- Added icon (with link to Chrōmicons) and size stories to all three components.
- Added color stories to the non-floating components
- Added justify story to the `IconButtonFloat` and increased the view heights in the docs so it doesn't get cut off
- Removed `disabled` argType from `IconButtonLink` because it uses HTMLAnchor props and does not have a `disabled` prop

# Screenshots

## New `IconButton` Stories

![Screenshot 2023-08-24 at 1 02 02 PM](https://github.com/lifeomic/chroma-react/assets/5824697/4669453f-d914-451b-ae06-6bec88be9010)

## New `IconButtonFloat` Stories

![Screenshot 2023-08-24 at 1 02 16 PM](https://github.com/lifeomic/chroma-react/assets/5824697/8db8234b-7d75-4655-9756-0092e6aad1ab)

## New `IconButtonLink` Stories

`IconButtonLink` Stories are the same as `IconButton` but not in an order that's simply to screenshot 😅 




