### PR TITLE
Update I- to K- Components to Storybook CSF3

### DIFF
--- a/src/components/IconTile/IconTile.stories.tsx
+++ b/src/components/IconTile/IconTile.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, StoryFn, Meta } from '@storybook/react';
 
 import { IconTile } from './IconTile';
 import { IconTileHero } from './IconTileHero';
@@ -8,20 +8,23 @@ import { IconTileContent } from './IconTileContent';
 import { Edit2 } from '@lifeomic/chromicons';
 import sampleBackground from '../../../stories/assets/sampleBackground.svg';
 
-export default {
-  title: 'Components/IconTile',
+const meta: Meta<typeof IconTile> = {
   component: IconTile,
   argTypes: {
     onClick: { action: 'clicked' },
   },
-} as ComponentMeta<typeof IconTile>;
+};
+export default meta;
+type Story = StoryObj<typeof IconTile>;
 
-export const Default: ComponentStory<typeof IconTile> = (args) => {
-  return (
-    <IconTile {...args}>
-      <IconTileHero backgroundUrl={sampleBackground} />
-      <IconTileBadge icon={Edit2} />
-      <IconTileContent text="Text" caption="caption" />
-    </IconTile>
-  );
+const Template: StoryFn<typeof IconTile> = (args) => (
+  <IconTile {...args}>
+    <IconTileHero backgroundUrl={sampleBackground} />
+    <IconTileBadge icon={Edit2} />
+    <IconTileContent text="Text" caption="caption" />
+  </IconTile>
+);
+
+export const Default: Story = {
+  render: Template,
 };

--- a/src/components/InfiniteScroll/InfiniteScroll.stories.tsx
+++ b/src/components/InfiniteScroll/InfiniteScroll.stories.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, StoryFn, Meta } from '@storybook/react';
 
 import { InfiniteScroll } from './InfiniteScroll';
 
-export default {
-  title: 'Components/InfiniteScroll',
+const meta: Meta<typeof InfiniteScroll> = {
   component: InfiniteScroll,
-  argTypes: {},
   decorators: [
     (story) => (
       <div
@@ -28,11 +26,13 @@ export default {
       </div>
     ),
   ],
-} as ComponentMeta<typeof InfiniteScroll>;
+};
+export default meta;
+type Story = StoryObj<typeof InfiniteScroll>;
 
-let i = 0;
-const getPage = () => new Array(30).fill(null).map(() => i++);
-const Template: ComponentStory<typeof InfiniteScroll> = (args) => {
+const Template: StoryFn<typeof InfiniteScroll> = (args) => {
+  let i = 0;
+  const getPage = () => new Array(30).fill(null).map(() => i++);
   const [items, setItems] = React.useState(getPage());
   const [loading, setLoading] = React.useState(false);
 
@@ -52,8 +52,10 @@ const Template: ComponentStory<typeof InfiniteScroll> = (args) => {
   );
 };
 
-export const Default = Template.bind({});
-Default.args = {
-  scrollContainer: 'parent',
-  hasNextPage: true,
+export const Default: Story = {
+  render: Template,
+  args: {
+    scrollContainer: 'parent',
+    hasNextPage: true,
+  },
 };

--- a/src/components/KeymapHelp/KeymapHelp.stories.tsx
+++ b/src/components/KeymapHelp/KeymapHelp.stories.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, Meta } from '@storybook/react';
 
 import { KeymapHelp } from './KeymapHelp';
 
-export default {
-  title: 'Components/KeymapHelp',
+const meta: Meta<typeof KeymapHelp> = {
   component: KeymapHelp,
-  argTypes: {},
   decorators: [
     (story) => (
       <div
@@ -20,21 +18,19 @@ export default {
       </div>
     ),
   ],
-} as ComponentMeta<typeof KeymapHelp>;
+};
+export default meta;
+type Story = StoryObj<typeof KeymapHelp>;
 
-const Template: ComponentStory<typeof KeymapHelp> = (args) => (
-  <KeymapHelp {...args} />
-);
+export const Default: Story = {};
 
-export const Default = Template.bind({});
-Default.args = {};
-
-export const AdditionalKeys = Template.bind({});
-AdditionalKeys.args = {
-  keyMapDocs: [
-    {
-      sequences: ['ctrl', 'alt', 'delete'],
-      description: 'Bring up the help menu',
-    },
-  ],
+export const AdditionalKeys: Story = {
+  args: {
+    keyMapDocs: [
+      {
+        sequences: ['ctrl', 'alt', 'delete'],
+        description: 'Bring up the help menu',
+      },
+    ],
+  },
 };


### PR DESCRIPTION
# What Was Changed

## Common to all CSF3 updates
- Replaced now-defunct CSF 1 & 2 types `ComponentStory` and `ComponentMeta` with `StoryObj` and `Meta` respectively
- Updated all stories to the new single-const format 
- Removed titles from ungrouped components whose name is the same as their filename
- Created Story type and added it to all stories for increased type safety

## Unique to this PR
- KeymapHelp cites a GitHub Issue from 2019 that is not officially closed. I see there were some posts in 2020-21 that have a workaround which received a complaint of performance issues.
- If someone thinks we need to try this workaround I can apply it in another PR. Skipping for now in order to get through updating all the components in a timely manner. 

# Screenshots

_Nothing should have changed visually_



