### PR TITLE
Update L- Components to Storybook CSF3

### DIFF
--- a/src/components/LayoutManager/LayoutManager.stories.tsx
+++ b/src/components/LayoutManager/LayoutManager.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, StoryFn, Meta } from '@storybook/react';
 
 import { LayoutManager } from './LayoutManager';
 import { MemoryRouter } from 'react-router-dom';
@@ -17,14 +17,15 @@ import { Logo } from '../../assets/Logo';
 import { Insights } from '../../assets/Insights';
 import { Subjects } from '../../assets/Subjects';
 
-export default {
+const meta: Meta<typeof LayoutManager> = {
   title: 'Layout/LayoutManager',
   component: LayoutManager,
-  argTypes: {},
   decorators: [(story) => <MemoryRouter>{story()}</MemoryRouter>],
-} as ComponentMeta<typeof LayoutManager>;
+};
+export default meta;
+type Story = StoryObj<typeof LayoutManager>;
 
-export const Default: ComponentStory<typeof LayoutManager> = (args) => (
+const Template: StoryFn<typeof LayoutManager> = (args) => (
   <LayoutManager
     {...args}
     header={<Header logo={<Logo />} />}
@@ -61,6 +62,12 @@ export const Default: ComponentStory<typeof LayoutManager> = (args) => (
       </PrimaryNavigation>
     }
   >
-    <p>Main Content</p>
+    <div style={{ padding: '1rem' }}>
+      <p>Main Content</p>
+    </div>
   </LayoutManager>
 );
+
+export const Default: Story = {
+  render: Template,
+};

--- a/src/components/LinearProgress/LinearProgress.stories.tsx
+++ b/src/components/LinearProgress/LinearProgress.stories.tsx
@@ -1,27 +1,23 @@
-import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, Meta } from '@storybook/react';
 
 import { LinearProgress } from './LinearProgress';
 
-export default {
-  title: 'Components/LinearProgress',
+const meta: Meta<typeof LinearProgress> = {
   component: LinearProgress,
-  argTypes: {},
-} as ComponentMeta<typeof LinearProgress>;
+};
+export default meta;
+type Story = StoryObj<typeof LinearProgress>;
 
-const Template: ComponentStory<typeof LinearProgress> = (args) => (
-  <LinearProgress {...args} />
-);
+export const Default: Story = {};
 
-export const Default = Template.bind({});
-Default.args = {};
-
-export const Indeterminate = Template.bind({});
-Indeterminate.args = {
-  variant: 'indeterminate',
+export const Indeterminate: Story = {
+  args: {
+    variant: 'indeterminate',
+  },
 };
 
-export const Value = Template.bind({});
-Value.args = {
-  value: 50,
+export const Value: Story = {
+  args: {
+    value: 50,
+  },
 };

--- a/src/components/Link/Link.stories.tsx
+++ b/src/components/Link/Link.stories.tsx
@@ -1,45 +1,42 @@
 import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, Meta } from '@storybook/react';
 
 import { Link } from './Link';
 import { MemoryRouter } from 'react-router-dom';
 
-export default {
-  title: 'Components/Link',
+const meta: Meta<typeof Link> = {
   component: Link,
-  argTypes: {},
+  args: {
+    to: '/',
+    children: 'Link',
+  },
   decorators: [(story) => <MemoryRouter>{story()}</MemoryRouter>],
-} as ComponentMeta<typeof Link>;
+};
+export default meta;
+type Story = StoryObj<typeof Link>;
 
-const Template: ComponentStory<typeof Link> = (args) => (
-  <Link {...args}>Link</Link>
-);
+export const Default: Story = {};
 
-export const Default = Template.bind({});
-Default.args = {
-  to: '/',
+export const NewTab: Story = {
+  args: {
+    newTab: true,
+  },
 };
 
-export const NewTab = Template.bind({});
-NewTab.args = {
-  to: '/',
-  newTab: true,
+export const InverseDark: Story = {
+  parameters: {
+    backgrounds: { default: 'dark' },
+  },
+  args: {
+    color: 'inverse',
+  },
 };
 
-export const InverseDark = Template.bind({});
-InverseDark.parameters = {
-  backgrounds: { default: 'dark' },
-};
-InverseDark.args = {
-  to: '/',
-  color: 'inverse',
-};
-
-export const InverseBlue = Template.bind({});
-InverseBlue.parameters = {
-  backgrounds: { default: 'blue' },
-};
-InverseBlue.args = {
-  to: '/',
-  color: 'inverse',
+export const InverseBlue: Story = {
+  parameters: {
+    backgrounds: { default: 'blue' },
+  },
+  args: {
+    color: 'inverse',
+  },
 };

--- a/src/components/Link/Link.stories.tsx
+++ b/src/components/Link/Link.stories.tsx
@@ -23,6 +23,12 @@ export const NewTab: Story = {
   },
 };
 
+export const Color: Story = {
+  args: {
+    color: 'negative',
+  },
+};
+
 export const InverseDark: Story = {
   parameters: {
     backgrounds: { default: 'dark' },


### PR DESCRIPTION
# What Was Changed

## Common to all CSF3 updates
- Replaced now-defunct CSF 1 & 2 types `ComponentStory` and `ComponentMeta` with `StoryObj` and `Meta` respectively
- Updated all stories to the new single-const format 
- Removed titles from ungrouped components whose name is the same as their filename
- Created Story type and added it to all stories for increased type safety

## Unique to this PR
- Added a little padding to 'Main Content' in `LayoutManager`
- Added color story to `Link`

# Screenshots

## Layout Manager Padding

| Before | After |
| --- | --- |
| ![Screenshot 2023-08-24 at 4 58 31 PM](https://github.com/lifeomic/chroma-react/assets/5824697/458da968-3df6-4c80-bafc-d1740787cdad) | ![Screenshot 2023-08-24 at 4 48 57 PM](https://github.com/lifeomic/chroma-react/assets/5824697/e8adbd5e-b1ae-46ba-ac59-e1ea9f57281a) |

## New `Link` Story

![Screenshot 2023-08-24 at 4 53 40 PM](https://github.com/lifeomic/chroma-react/assets/5824697/c40663b0-14a5-4c7d-bcca-0b728b41ae6f)


