### PR TITLE
fix: Adjust layout of `<SlideOver` children and add text overflow for panel title

### DIFF
--- a/src/components/SlideOver/Header.tsx
+++ b/src/components/SlideOver/Header.tsx
@@ -16,8 +16,19 @@ export const useStyles = makeStyles(
     },
     titleIcon: {
       color: theme.palette.text.hint,
+      minHeight: theme.pxToRem(22),
+      minWidth: theme.pxToRem(22),
       height: theme.pxToRem(22),
       width: theme.pxToRem(22),
+    },
+    overflow: {
+      flex: 1,
+      overflow: 'hidden',
+    },
+    text: {
+      textOverflow: 'ellipsis',
+      overflow: 'hidden',
+      whiteSpace: 'nowrap',
     },
     button: {
       marginRight: theme.pxToRem(-10),
@@ -54,19 +65,19 @@ export const Header: React.FC<HeaderProps> = ({
   return (
     <Box
       align="center"
+      gap={1}
       justify="space-between"
       padding={2}
       className={clsx(classes.root, additionalClasses?.root, className)}
       {...rootProps}
     >
-      {children}
       {title && (
-        <Box align="center" gap={1}>
+        <Box align="center" gap={1} className={classes.overflow}>
           {!!TitleIcon && (
             <TitleIcon role="img" aria-hidden className={classes.titleIcon} />
           )}
           <Text
-            className={clsx(additionalClasses?.text)}
+            className={clsx(classes.text, additionalClasses?.text)}
             size="body"
             weight="bold"
           >
@@ -74,13 +85,18 @@ export const Header: React.FC<HeaderProps> = ({
           </Text>
         </Box>
       )}
-      <IconButton
-        className={clsx(classes.button, additionalClasses?.button)}
-        aria-label="Close panel"
-        icon={X}
-        onClick={onClose}
-        size={0}
-      />
+      <Box align="center" gap={1}>
+        <Box justify="flex-end" align="center" gap={1}>
+          {children}
+        </Box>
+        <IconButton
+          className={clsx(classes.button, additionalClasses?.button)}
+          aria-label="Close panel"
+          icon={X}
+          onClick={onClose}
+          size={0}
+        />
+      </Box>
     </Box>
   );
 };


### PR DESCRIPTION
This PR adjusts the layout for children of `<Header` in `<SlideOver` and also adds text overflow ellipsis for the panel title.

### Changes

- Adjust layout for `<Header` children
- Add min-height and -width so `titleIcon` does not shrink

BEFORE | AFTER
-- | --
<img width="449" alt="Screenshot 2023-08-28 at 10 45 18 AM" src="https://github.com/lifeomic/chroma-react/assets/485903/083663ab-1741-43db-814c-49077da6d69a"> | <img width="449" alt="Screenshot 2023-08-28 at 10 44 20 AM" src="https://github.com/lifeomic/chroma-react/assets/485903/bfc539a0-6d0c-4de4-bd73-f2818fd3358a">
