### PR TITLE
Update NumberFormat Components to Storybook CSF3

### DIFF
--- a/src/components/NumberFormat/PercentFormatField.stories.tsx
+++ b/src/components/NumberFormat/PercentFormatField.stories.tsx
@@ -1,6 +1,8 @@
+import React from 'react';
 import { StoryObj, Meta } from '@storybook/react';
 
 import { PercentFormatField } from './UnitNumberFormatField';
+import { Apple, HelpCircle, TrendingUp } from '@lifeomic/chromicons';
 
 const meta: Meta<typeof PercentFormatField> = {
   title: 'Form Components/NumberFormat/PercentFormatField',
@@ -30,6 +32,36 @@ export const Min: Story = {
 export const Max: Story = {
   args: {
     max: 70,
+  },
+};
+
+export const Adornments: Story = {
+  args: {
+    startAdornment: <Apple />,
+    endAdornment: <TrendingUp />,
+  },
+};
+
+export const TooltipMessage: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Icon and Tooltip Message must be used at the same time for either of them to render.',
+      },
+    },
+  },
+  args: {
+    icon: HelpCircle,
+    tooltipMessage: 'Tooltip Message',
+  },
+};
+
+export const RequiredAndError: Story = {
+  args: {
+    hasError: true,
+    showRequiredLabel: true,
+    errorMessage: 'This is required',
   },
 };
 

--- a/src/components/NumberFormat/PercentFormatField.stories.tsx
+++ b/src/components/NumberFormat/PercentFormatField.stories.tsx
@@ -1,59 +1,52 @@
-import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, Meta } from '@storybook/react';
 
 import { PercentFormatField } from './UnitNumberFormatField';
 
-export default {
+const meta: Meta<typeof PercentFormatField> = {
   title: 'Form Components/NumberFormat/PercentFormatField',
   component: PercentFormatField,
+  args: {
+    label: 'Percent Format Field',
+    value: 50,
+  },
   argTypes: {
     color: {
       control: 'radio',
       options: ['default', 'inverse'],
     },
   },
-} as ComponentMeta<typeof PercentFormatField>;
+};
+export default meta;
+type Story = StoryObj<typeof PercentFormatField>;
 
-const Template: ComponentStory<typeof PercentFormatField> = (args) => (
-  <PercentFormatField {...args} />
-);
+export const Default: Story = {};
 
-export const Default = Template.bind({});
-Default.args = {
-  label: 'Percent Format Field',
-  value: 50,
+export const Min: Story = {
+  args: {
+    min: 20,
+  },
 };
 
-export const Min = Template.bind({});
-Min.args = {
-  label: 'Percent Format Field',
-  value: 50,
-  min: 20,
+export const Max: Story = {
+  args: {
+    max: 70,
+  },
 };
 
-export const Max = Template.bind({});
-Max.args = {
-  label: 'Percent Format Field',
-  value: 50,
-  max: 70,
+export const InverseDark: Story = {
+  parameters: {
+    backgrounds: { default: 'dark' },
+  },
+  args: {
+    color: 'inverse',
+  },
 };
 
-export const InverseDark = Template.bind({});
-InverseDark.parameters = {
-  backgrounds: { default: 'dark' },
-};
-InverseDark.args = {
-  label: 'Percent Format Field',
-  value: 50,
-  color: 'inverse',
-};
-
-export const InverseBlue = Template.bind({});
-InverseBlue.parameters = {
-  backgrounds: { default: 'blue' },
-};
-InverseBlue.args = {
-  label: 'Percent Format Field',
-  value: 50,
-  color: 'inverse',
+export const InverseBlue: Story = {
+  parameters: {
+    backgrounds: { default: 'blue' },
+  },
+  args: {
+    color: 'inverse',
+  },
 };

--- a/src/components/NumberFormat/PhoneNumberFormatField.stories.tsx
+++ b/src/components/NumberFormat/PhoneNumberFormatField.stories.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, Meta } from '@storybook/react';
 
 import { PhoneNumberFormatField } from './PhoneNumberFormatField';
 
-export default {
+const meta: Meta<typeof PhoneNumberFormatField> = {
   title: 'Form Components/NumberFormat/PhoneNumberFormatField',
   component: PhoneNumberFormatField,
   argTypes: {
@@ -12,38 +11,39 @@ export default {
       options: ['default', 'inverse'],
     },
   },
-} as ComponentMeta<typeof PhoneNumberFormatField>;
+};
+export default meta;
+type Story = StoryObj<typeof PhoneNumberFormatField>;
 
-const Template: ComponentStory<typeof PhoneNumberFormatField> = (args) => (
-  <PhoneNumberFormatField {...args} />
-);
+export const Default: Story = {};
 
-export const Default = Template.bind({});
-Default.args = {};
-
-export const Placeholder = Template.bind({});
-Placeholder.args = {
-  placeholder: 'placeholder',
+export const Placeholder: Story = {
+  args: {
+    placeholder: 'placeholder',
+  },
 };
 
-export const Error = Template.bind({});
-Error.args = {
-  hasError: true,
-  errorMessage: 'This is required',
+export const Error: Story = {
+  args: {
+    hasError: true,
+    errorMessage: 'This is required',
+  },
 };
 
-export const InverseDark = Template.bind({});
-InverseDark.parameters = {
-  backgrounds: { default: 'dark' },
-};
-InverseDark.args = {
-  color: 'inverse',
+export const InverseDark: Story = {
+  parameters: {
+    backgrounds: { default: 'dark' },
+  },
+  args: {
+    color: 'inverse',
+  },
 };
 
-export const InverseBlue = Template.bind({});
-InverseBlue.parameters = {
-  backgrounds: { default: 'blue' },
-};
-InverseBlue.args = {
-  color: 'inverse',
+export const InverseBlue: Story = {
+  parameters: {
+    backgrounds: { default: 'blue' },
+  },
+  args: {
+    color: 'inverse',
+  },
 };

--- a/src/components/NumberFormat/PhoneNumberFormatField.stories.tsx
+++ b/src/components/NumberFormat/PhoneNumberFormatField.stories.tsx
@@ -23,9 +23,10 @@ export const Placeholder: Story = {
   },
 };
 
-export const Error: Story = {
+export const RequiredAndError: Story = {
   args: {
     hasError: true,
+    showRequiredLabel: true,
     errorMessage: 'This is required',
   },
 };

--- a/src/components/NumberFormat/PriceFormatField.stories.tsx
+++ b/src/components/NumberFormat/PriceFormatField.stories.tsx
@@ -1,6 +1,8 @@
+import React from 'react';
 import { StoryObj, Meta } from '@storybook/react';
 
 import { PriceFormatField } from './UnitNumberFormatField';
+import { Apple, HelpCircle, TrendingUp } from '@lifeomic/chromicons';
 
 const meta: Meta<typeof PriceFormatField> = {
   title: 'Form Components/NumberFormat/PriceFormatField',
@@ -30,6 +32,36 @@ export const Min: Story = {
 export const Max: Story = {
   args: {
     max: 70,
+  },
+};
+
+export const Adornments: Story = {
+  args: {
+    startAdornment: <Apple />,
+    endAdornment: <TrendingUp />,
+  },
+};
+
+export const TooltipMessage: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Icon and Tooltip Message must be used at the same time for either of them to render.',
+      },
+    },
+  },
+  args: {
+    icon: HelpCircle,
+    tooltipMessage: 'Tooltip Message',
+  },
+};
+
+export const RequiredAndError: Story = {
+  args: {
+    hasError: true,
+    showRequiredLabel: true,
+    errorMessage: 'This is required',
   },
 };
 

--- a/src/components/NumberFormat/PriceFormatField.stories.tsx
+++ b/src/components/NumberFormat/PriceFormatField.stories.tsx
@@ -1,59 +1,52 @@
-import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, Meta } from '@storybook/react';
 
 import { PriceFormatField } from './UnitNumberFormatField';
 
-export default {
+const meta: Meta<typeof PriceFormatField> = {
   title: 'Form Components/NumberFormat/PriceFormatField',
   component: PriceFormatField,
+  args: {
+    label: 'Price Format Field',
+    value: 50,
+  },
   argTypes: {
     color: {
       control: 'radio',
       options: ['default', 'inverse'],
     },
   },
-} as ComponentMeta<typeof PriceFormatField>;
+};
+export default meta;
+type Story = StoryObj<typeof PriceFormatField>;
 
-const Template: ComponentStory<typeof PriceFormatField> = (args) => (
-  <PriceFormatField {...args} />
-);
+export const Default: Story = {};
 
-export const Default = Template.bind({});
-Default.args = {
-  label: 'Price Format Field',
-  value: 50,
+export const Min: Story = {
+  args: {
+    min: 20,
+  },
 };
 
-export const Min = Template.bind({});
-Min.args = {
-  label: 'Price Format Field',
-  value: 50,
-  min: 20,
+export const Max: Story = {
+  args: {
+    max: 70,
+  },
 };
 
-export const Max = Template.bind({});
-Max.args = {
-  label: 'Price Format Field',
-  value: 50,
-  max: 70,
+export const InverseDark: Story = {
+  parameters: {
+    backgrounds: { default: 'dark' },
+  },
+  args: {
+    color: 'inverse',
+  },
 };
 
-export const InverseDark = Template.bind({});
-InverseDark.parameters = {
-  backgrounds: { default: 'dark' },
-};
-InverseDark.args = {
-  label: 'Price Format Field',
-  value: 50,
-  color: 'inverse',
-};
-
-export const InverseBlue = Template.bind({});
-InverseBlue.parameters = {
-  backgrounds: { default: 'blue' },
-};
-InverseBlue.args = {
-  label: 'Price Format Field',
-  value: 50,
-  color: 'inverse',
+export const InverseBlue: Story = {
+  parameters: {
+    backgrounds: { default: 'blue' },
+  },
+  args: {
+    color: 'inverse',
+  },
 };

--- a/src/components/NumberFormat/UnitNumberFormatField.stories.tsx
+++ b/src/components/NumberFormat/UnitNumberFormatField.stories.tsx
@@ -1,80 +1,65 @@
-import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, Meta } from '@storybook/react';
 
 import { UnitNumberFormatField } from './UnitNumberFormatField';
 
-export default {
+const meta: Meta<typeof UnitNumberFormatField> = {
   title: 'Form Components/NumberFormat/UnitNumberFormatField',
   component: UnitNumberFormatField,
+  args: {
+    label: 'Unit Number Format Field',
+    value: 50,
+    units: 'units',
+  },
   argTypes: {
     color: {
       control: 'radio',
       options: ['default', 'inverse'],
     },
   },
-} as ComponentMeta<typeof UnitNumberFormatField>;
+};
+export default meta;
+type Story = StoryObj<typeof UnitNumberFormatField>;
 
-const Template: ComponentStory<typeof UnitNumberFormatField> = (args) => (
-  <UnitNumberFormatField {...args} />
-);
+export const Default: Story = {};
 
-export const Default = Template.bind({});
-Default.args = {
-  label: 'Unit Number Format Field',
-  value: 50,
-  units: 'units',
+export const Min: Story = {
+  args: {
+    min: 20,
+  },
 };
 
-export const Min = Template.bind({});
-Min.args = {
-  label: 'Unit Number Format Field',
-  value: 50,
-  units: 'units',
-  min: 20,
+export const Max: Story = {
+  args: {
+    max: 70,
+  },
 };
 
-export const Max = Template.bind({});
-Max.args = {
-  label: 'Unit Number Format Field',
-  value: 50,
-  units: 'units',
-  max: 70,
+export const DecimalScale: Story = {
+  args: {
+    decimalScale: 2,
+  },
 };
 
-export const DecimalScale = Template.bind({});
-DecimalScale.args = {
-  label: 'Unit Number Format Field',
-  value: 50,
-  units: 'units',
-  decimalScale: 2,
+export const PrefixUnits: Story = {
+  args: {
+    prefixUnits: true,
+  },
 };
 
-export const PrefixUnits = Template.bind({});
-PrefixUnits.args = {
-  label: 'Unit Number Format Field',
-  value: 50,
-  units: 'units',
-  prefixUnits: true,
+export const InverseDark: Story = {
+  parameters: {
+    backgrounds: { default: 'dark' },
+  },
+  args: {
+    color: 'inverse',
+  },
 };
 
-export const InverseDark = Template.bind({});
-InverseDark.parameters = {
-  backgrounds: { default: 'dark' },
-};
-InverseDark.args = {
-  label: 'Unit Number Format Field',
-  value: 50,
-  units: 'units',
-  color: 'inverse',
-};
-
-export const InverseBlue = Template.bind({});
-InverseBlue.parameters = {
-  backgrounds: { default: 'blue' },
-};
-InverseBlue.args = {
-  label: 'Unit Number Format Field',
-  value: 50,
-  units: 'units',
-  color: 'inverse',
+export const InverseBlue: Story = {
+  parameters: {
+    backgrounds: { default: 'blue' },
+  },
+  args: {
+    color: 'inverse',
+  },
 };

--- a/src/components/NumberFormat/UnitNumberFormatField.stories.tsx
+++ b/src/components/NumberFormat/UnitNumberFormatField.stories.tsx
@@ -1,6 +1,8 @@
+import React from 'react';
 import { StoryObj, Meta } from '@storybook/react';
 
 import { UnitNumberFormatField } from './UnitNumberFormatField';
+import { Apple, HelpCircle, TrendingUp } from '@lifeomic/chromicons';
 
 const meta: Meta<typeof UnitNumberFormatField> = {
   title: 'Form Components/NumberFormat/UnitNumberFormatField',
@@ -43,6 +45,36 @@ export const DecimalScale: Story = {
 export const PrefixUnits: Story = {
   args: {
     prefixUnits: true,
+  },
+};
+
+export const Adornments: Story = {
+  args: {
+    startAdornment: <Apple />,
+    endAdornment: <TrendingUp />,
+  },
+};
+
+export const TooltipMessage: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Icon and Tooltip Message must be used at the same time for either of them to render.',
+      },
+    },
+  },
+  args: {
+    icon: HelpCircle,
+    tooltipMessage: 'Tooltip Message',
+  },
+};
+
+export const RequiredAndError: Story = {
+  args: {
+    hasError: true,
+    showRequiredLabel: true,
+    errorMessage: 'This is required',
   },
 };
 


### PR DESCRIPTION
# What Was Changed

## Common to all CSF3 updates
- Replaced now-defunct CSF 1 & 2 types `ComponentStory` and `ComponentMeta` with `StoryObj` and `Meta` respectively
- Updated all stories to the new single-const format 
- Created Story type and added it to all stories for increased type safety

## Unique to this PR
- `PhoneNumberFormatField`
    - Added `showRequiredLabel: true` to all components' error story, since it made semantic sense with the error story we were telling
- All components except `PhoneNumberFormatField`
    - Because `PhoneNumberFormatField` does not have many props the other three do, it did not receive these stories
    - Added
         - Required story, same as `PhoneNumberFormatField`
         - Adornments
         - Tooltip Message / Icon
     - You might notice I didn't add a story for every single prop. My heuristic is if the property involves a React Node/Icon or is potentially confusing for a user to play with in the top sandbox, then I'll add a story and maybe a doc explanation if needed. If it's just a string someone can input, then I'll skip it. My goal is to balance completeness of stories with getting all stories updated reasonably quickly. I also hope this thinking can help future developers and future components.

# Screenshots

## Updated `PhoneNumberFormatField` Required Story

| Before | After |
| --- | --- |
| ![Screenshot 2023-08-29 at 2 49 45 PM](https://github.com/lifeomic/chroma-react/assets/5824697/41596ee9-60de-4330-9f33-07f2489fbe28) | ![Screenshot 2023-08-29 at 2 48 36 PM](https://github.com/lifeomic/chroma-react/assets/5824697/117b334c-cc10-4cc6-8829-e04d944f6460) |

## New `PercentFormatField` Stories

![Screenshot 2023-08-29 at 2 48 26 PM](https://github.com/lifeomic/chroma-react/assets/5824697/56a7dbb8-44bc-4934-96f3-533c86551f40)

## New `PriceFormatField` Stories

![Screenshot 2023-08-29 at 2 48 49 PM](https://github.com/lifeomic/chroma-react/assets/5824697/a12fa188-3ad9-4503-91ac-5a51424cc73f)

## New `UnitNumberFormatField` Stories

![Screenshot 2023-08-29 at 2 49 07 PM](https://github.com/lifeomic/chroma-react/assets/5824697/aa61affd-9f57-486a-97b2-feaad5631f8e)




