### PR TITLE
Update first half of P- Components to Storybook CSF3

### DIFF
--- a/src/components/PageLayout/PageLayout.stories.tsx
+++ b/src/components/PageLayout/PageLayout.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, StoryFn, Meta } from '@storybook/react';
 
 import { PageLayout } from './PageLayout';
 import { MemoryRouter } from 'react-router-dom';
@@ -9,83 +9,92 @@ import {
 } from '../SecondaryNavigation';
 import { Button } from '../Button';
 
-export default {
+const meta: Meta<typeof PageLayout> = {
   title: 'Layout/PageLayout',
+  args: {
+    title: 'Header',
+  },
   component: PageLayout,
-  argTypes: {},
-} as ComponentMeta<typeof PageLayout>;
+};
+export default meta;
+type Story = StoryObj<typeof PageLayout>;
 
-const Template: ComponentStory<typeof PageLayout> = (args) => (
+const Template: StoryFn<typeof PageLayout> = (args) => (
   <PageLayout {...args}>
     <p>Content</p>
   </PageLayout>
 );
 
-export const Default = Template.bind({});
-Default.args = {
-  title: 'Header',
+export const Default: Story = {
+  render: Template,
 };
 
-export const ApplyBackgroundCover = Template.bind({});
-ApplyBackgroundCover.args = {
-  title: 'Header',
-  applyBackgroundCover: true,
+export const ApplyBackgroundCover: Story = {
+  render: Template,
+  args: {
+    applyBackgroundCover: true,
+  },
 };
 
-export const ApplyBackgroundCoverCustom = Template.bind({});
-ApplyBackgroundCoverCustom.args = {
-  title: 'Header',
-  applyBackgroundCover: true,
-  backgroundImage: 'https://via.placeholder.com/150',
+export const ApplyBackgroundCoverCustom: Story = {
+  render: Template,
+  args: {
+    applyBackgroundCover: true,
+    backgroundImage: 'https://via.placeholder.com/150',
+  },
 };
 
-export const Disclaimer = Template.bind({});
-Disclaimer.args = {
-  title: 'Header',
-  disclaimer: (
-    <div
-      style={{
-        display: 'flex',
-        justifyContent: 'center',
-        paddingBottom: '4rem',
-      }}
-    >
-      disclaimer content
-    </div>
-  ),
+export const Disclaimer: Story = {
+  render: Template,
+  args: {
+    disclaimer: (
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+          paddingBottom: '4rem',
+        }}
+      >
+        disclaimer content
+      </div>
+    ),
+  },
 };
 
-export const Sidebar = Template.bind({});
-Sidebar.args = {
-  title: 'Header',
-  sidebar: (
-    <MemoryRouter>
-      <SecondaryNavigation>
-        <SecondaryNavigationItem to="/link-1" label="Link 1" />
-        <SecondaryNavigationItem to="/link-2" label="Link 2" />
-        <SecondaryNavigationItem to="/link-3" label="Link 3" />
-      </SecondaryNavigation>
-    </MemoryRouter>
-  ),
+export const Sidebar: Story = {
+  render: Template,
+  args: {
+    sidebar: (
+      <MemoryRouter>
+        <SecondaryNavigation>
+          <SecondaryNavigationItem to="/link-1" label="Link 1" />
+          <SecondaryNavigationItem to="/link-2" label="Link 2" />
+          <SecondaryNavigationItem to="/link-3" label="Link 3" />
+        </SecondaryNavigation>
+      </MemoryRouter>
+    ),
+  },
 };
 
-export const Tabs = Template.bind({});
-Tabs.args = {
-  title: 'Header',
-  tabs: (
-    <MemoryRouter>
-      <SecondaryNavigation variant="horizontal">
-        <SecondaryNavigationItem to="/link-1" label="Link 1" />
-        <SecondaryNavigationItem to="/link-2" label="Link 2" />
-        <SecondaryNavigationItem to="/link-3" label="Link 3" />
-      </SecondaryNavigation>
-    </MemoryRouter>
-  ),
+export const Tabs: Story = {
+  render: Template,
+  args: {
+    tabs: (
+      <MemoryRouter>
+        <SecondaryNavigation variant="horizontal">
+          <SecondaryNavigationItem to="/link-1" label="Link 1" />
+          <SecondaryNavigationItem to="/link-2" label="Link 2" />
+          <SecondaryNavigationItem to="/link-3" label="Link 3" />
+        </SecondaryNavigation>
+      </MemoryRouter>
+    ),
+  },
 };
 
-export const HeaderActions = Template.bind({});
-HeaderActions.args = {
-  title: 'Header',
-  headerCenter: <p>Centered Content</p>,
-  headerActions: <Button>Edit</Button>,
+export const HeaderActions: Story = {
+  render: Template,
+  args: {
+    headerCenter: <p>Centered Content</p>,
+    headerActions: <Button>Edit</Button>,
+  },
 };

--- a/src/components/Paper/Paper.stories.tsx
+++ b/src/components/Paper/Paper.stories.tsx
@@ -1,15 +1,26 @@
 import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, Meta } from '@storybook/react';
 
 import { Paper } from './Paper';
+import { Box } from '../Box';
+import { Text } from '../Text';
 
-export default {
-  title: 'Components/Paper',
+const meta: Meta<typeof Paper> = {
   component: Paper,
-  argTypes: {},
-} as ComponentMeta<typeof Paper>;
+};
+export default meta;
+type Story = StoryObj<typeof Paper>;
 
-const Template: ComponentStory<typeof Paper> = (args) => <Paper {...args} />;
-
-export const Default = Template.bind({});
-Default.args = {};
+export const Default: Story = {
+  args: {
+    children: (
+      <Box direction="column" gap={1}>
+        <Text size="headline">Content</Text>
+        <Text size="body">
+          This is example content inside a Paper component
+        </Text>
+        <Text size="subbody">Truly astounding content</Text>
+      </Box>
+    ),
+  },
+};

--- a/src/components/Pill/Pill.stories.tsx
+++ b/src/components/Pill/Pill.stories.tsx
@@ -1,17 +1,15 @@
-import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, Meta } from '@storybook/react';
 
 import { Pill } from './Pill';
 
-export default {
-  title: 'Components/Pill',
+const meta: Meta<typeof Pill> = {
   component: Pill,
-  argTypes: {},
-} as ComponentMeta<typeof Pill>;
+};
+export default meta;
+type Story = StoryObj<typeof Pill>;
 
-const Template: ComponentStory<typeof Pill> = (args) => <Pill {...args} />;
-
-export const Default = Template.bind({});
-Default.args = {
-  label: 'Pill',
+export const Default: Story = {
+  args: {
+    label: 'Pill',
+  },
 };

--- a/src/components/Pill/Pill.stories.tsx
+++ b/src/components/Pill/Pill.stories.tsx
@@ -4,12 +4,23 @@ import { Pill } from './Pill';
 
 const meta: Meta<typeof Pill> = {
   component: Pill,
+  args: {
+    label: 'Pill',
+  },
 };
 export default meta;
 type Story = StoryObj<typeof Pill>;
 
-export const Default: Story = {
+export const Default: Story = {};
+
+export const Color: Story = {
   args: {
-    label: 'Pill',
+    color: 'negative',
+  },
+};
+
+export const Variant: Story = {
+  args: {
+    variant: 'highlight',
   },
 };


### PR DESCRIPTION
# What Was Changed

## Common to all CSF3 updates
- Replaced now-defunct CSF 1 & 2 types `ComponentStory` and `ComponentMeta` with `StoryObj` and `Meta` respectively
- Updated all stories to the new single-const format 
- Removed titles from ungrouped components whose name is the same as their filename
- Created Story type and added it to all stories for increased type safety

## Unique to this PR
- Added a couple `Pill` styling stories
- Added content to `Paper` default story

# Screenshots

## `Paper` Story Content

| Before | After |
| --- | --- |
| ![Screenshot 2023-08-29 at 3 43 05 PM](https://github.com/lifeomic/chroma-react/assets/5824697/69dfaac6-2c67-42c2-bda4-bdc94bb6e2f5) | ![Screenshot 2023-08-29 at 3 42 41 PM](https://github.com/lifeomic/chroma-react/assets/5824697/fb5913dd-8c15-420f-a1fe-f6d278df30d1) |

## New `Pill` Stories

![Screenshot 2023-08-29 at 3 37 23 PM](https://github.com/lifeomic/chroma-react/assets/5824697/63c860b5-9efb-4dcc-9c86-5249c06ad2d4)