### PR TITLE
Update second half of P- Components to Storybook CSF3

### DIFF
--- a/src/components/Popover/Popover.stories.tsx
+++ b/src/components/Popover/Popover.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, Meta } from '@storybook/react';
 
 import { Popover, PopoverRenderProps } from './Popover';
 import { Button } from '../Button';
@@ -8,74 +8,93 @@ import { PopoverList } from './PopoverList';
 import { PopoverItem } from './PopoverItem';
 import { Edit, Trash } from '@lifeomic/chromicons';
 
-export default {
-  title: 'Components/Popover',
+const meta: Meta<typeof Popover> = {
   component: Popover,
-  argTypes: {},
-} as ComponentMeta<typeof Popover>;
-
-const Template: ComponentStory<typeof Popover> = (args) => (
-  <Popover {...args}>
-    <p>Popover inner content</p>
-  </Popover>
-);
-
-export const Default = Template.bind({});
-Default.args = {
-  'aria-label': 'Popover',
-  anchorElement: <Button style={{ marginRight: '1rem' }}>Open Popover</Button>,
+  args: {
+    'aria-label': 'Popover',
+    anchorElement: (
+      <Button style={{ marginRight: '1rem' }}>Open Popover</Button>
+    ),
+    children: <p style={{ paddingLeft: '1rem' }}>Popover inner content</p>,
+  },
+  decorators: [(story) => <div style={{ height: '150px' }}>{story()}</div>],
 };
+export default meta;
+type Story = StoryObj<typeof Popover>;
 
-export const Portal = Template.bind({});
-Portal.args = {
-  'aria-label': 'Popover',
-  anchorElement: <Button style={{ marginRight: '1rem' }}>Open Popover</Button>,
-  usePortal: true,
-};
+export const Default: Story = {};
 
-export const Actions: ComponentStory<typeof Popover> = (args) => (
-  <Popover {...args}>
-    {({ popover }: PopoverRenderProps) => (
-      <>
-        <p>Popover inner content</p>
-        <PopoverActions justify="center">
-          <Button onClick={() => popover.hide()}>Sign Out</Button>
-        </PopoverActions>
-      </>
-    )}
-  </Popover>
-);
-Actions.args = {
-  'aria-label': 'Popover',
-  anchorElement: <Button style={{ marginRight: '1rem' }}>Open Popover</Button>,
-};
-
-export const List: ComponentStory<typeof Popover> = (args) => (
-  <Popover {...args}>
-    <>
-      <PopoverList>
-        <PopoverItem icon={Edit} text="Edit" />
-        <PopoverItem icon={Trash} text="Delete" />
-        <PopoverItem>Your custom content here!</PopoverItem>
-      </PopoverList>
-      <PopoverActions justify="center">
-        <Button>Sign Out</Button>
-      </PopoverActions>
-    </>
-  </Popover>
-);
-List.parameters = {
-  docs: {
-    description: {
-      story:
-        'It is **highly** recommended that the `<Menu>` component be used instead; ' +
-        'however, there may be existing use cases where a popover needs a list of items. ' +
-        'This path is not 100% out-of-the-box accessible -- it works with a screen ' +
-        'reader; however, keyboard support is not available with this just yet.',
-    },
+export const Title: Story = {
+  args: {
+    title: 'Title',
   },
 };
-List.args = {
-  'aria-label': 'Popover',
-  anchorElement: <Button style={{ marginRight: '1rem' }}>Open Popover</Button>,
+
+export const Portal: Story = {
+  args: {
+    usePortal: true,
+  },
+};
+
+export const Placement: Story = {
+  args: {
+    placement: 'right',
+  },
+};
+
+export const Gutter: Story = {
+  args: {
+    gutter: 50,
+  },
+};
+
+export const UnstableOffset: Story = {
+  args: {
+    unstable_offset: [200, 50],
+  },
+};
+
+export const Actions: Story = {
+  render: (args) => (
+    <Popover {...args}>
+      {({ popover }: PopoverRenderProps) => (
+        <>
+          <p style={{ paddingLeft: '1rem' }}>Popover inner content</p>
+          <PopoverActions justify="center">
+            <Button onClick={() => popover.hide()}>Sign Out</Button>
+          </PopoverActions>
+        </>
+      )}
+    </Popover>
+  ),
+};
+
+export const List: Story = {
+  args: {
+    children: (
+      <>
+        <PopoverList>
+          <PopoverItem icon={Edit} text="Edit" />
+          <PopoverItem icon={Trash} text="Delete" />
+          <PopoverItem>Your custom content here!</PopoverItem>
+        </PopoverList>
+        <PopoverActions justify="center">
+          <Button>Sign Out</Button>
+        </PopoverActions>
+      </>
+    ),
+    usePortal: true,
+    placement: 'right-start',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'It is **highly** recommended that the `<Menu>` component be used instead; ' +
+          'however, there may be existing use cases where a popover needs a list of items. ' +
+          'This path is not 100% out-of-the-box accessible -- it works with a screen ' +
+          'reader; however, keyboard support is not available with this just yet.',
+      },
+    },
+  },
 };

--- a/src/components/PrimaryNavigation/PrimaryNavigation.stories.tsx
+++ b/src/components/PrimaryNavigation/PrimaryNavigation.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, Meta } from '@storybook/react';
 
 import { PrimaryNavigation } from './PrimaryNavigation';
 import { PrimaryNavigationItem } from './PrimaryNavigationItem';
@@ -14,10 +14,8 @@ import { PrimaryNavigationSubItem } from './PrimaryNavigationSubItem';
 (LayoutManagerContext.Provider as any).displayName =
   'LayoutManagerContext.Provider';
 
-export default {
-  title: 'Components/PrimaryNavigation',
+const meta: Meta<typeof PrimaryNavigation> = {
   component: PrimaryNavigation,
-  argTypes: {},
   decorators: [
     (story) => {
       const [isSidebarCollapsed, setIsSidebarCollapsed] = React.useState(false);
@@ -37,113 +35,117 @@ export default {
     },
     (story) => <MemoryRouter>{story()}</MemoryRouter>,
   ],
-} as ComponentMeta<typeof PrimaryNavigation>;
-
-export const Default: ComponentStory<typeof PrimaryNavigation> = (args) => {
-  return (
-    <PrimaryNavigation {...args}>
-      <PrimaryNavigationItem to="/edit" icon={<Edit />} label="Nav Item" />
-      <PrimaryNavigationItem
-        to="/right"
-        icon={<ArrowRight />}
-        label="Nav Item 2"
-        betaLabelText="Beta"
-      />
-    </PrimaryNavigation>
-  );
 };
-Default.args = {
-  header: (
-    <div
-      style={{
-        color: 'white',
-        display: 'flex',
-        justifyContent: 'center',
-        width: '100%',
-        border: '1px dashed white',
-      }}
-    >
-      <Text color="inverse">Optional Header Section</Text>
-    </div>
-  ),
-  footer: (
-    <div
-      style={{
-        display: 'flex',
-        justifyContent: 'center',
-        color: 'white',
-        width: '100%',
-        border: '1px dashed white',
-      }}
-    >
-      <Text color="inverse">Optional Footer Section</Text>
-    </div>
-  ),
-  headerMin: <b>MIN</b>,
-};
+export default meta;
+type Story = StoryObj<typeof PrimaryNavigation>;
 
-export const PrimaryNavigationSubrouting: ComponentStory<typeof PrimaryNavigation> = (
-  args
-) => {
-  return (
-    <PrimaryNavigation {...args}>
-      <PrimaryNavigationItem to="/edit" icon={<Edit />} label="Nav Item" />
-      <PrimaryNavigationItem
-        to="/left"
-        icon={<ArrowLeft />}
-        label="Nav Item 2"
-        betaLabelText="Beta"
-      />
-      <PrimaryNavigationExpansionItem
-        icon={<Subjects />}
-        label="Base Route"
-        to="/base"
-        rootParentPath="/base"
+export const Default: Story = {
+  render: (args) => {
+    return (
+      <PrimaryNavigation {...args}>
+        <PrimaryNavigationItem to="/edit" icon={<Edit />} label="Nav Item" />
+        <PrimaryNavigationItem
+          to="/right"
+          icon={<ArrowRight />}
+          label="Nav Item 2"
+          betaLabelText="Beta"
+        />
+      </PrimaryNavigation>
+    );
+  },
+  args: {
+    header: (
+      <div
+        style={{
+          color: 'white',
+          display: 'flex',
+          justifyContent: 'center',
+          width: '100%',
+          border: '1px dashed white',
+        }}
       >
-        <PrimaryNavigationSubItem label="Child Route1" to="/base/c1" />
-        <PrimaryNavigationSubItem label="Child Route2" to="/base/c2" />
-      </PrimaryNavigationExpansionItem>
-    </PrimaryNavigation>
-  );
-};
-PrimaryNavigationSubrouting.parameters = {
-  docs: {
-    description: {
-      story:
-        'Combining PrimaryNavigationExpansionItem and PrimaryNavigationSubItem allows for ' +
-        'consumers to create an expansion-panel-esque component in their navigation bar. ' +
-        'The current pattern is that clicking the root path will navigate users to the ' +
-        'root/dashboard view. Child routes navigation items are then rendered below. ' +
-        'Navigating away from the "rootParentPath" closes the expansion-panel route item.',
-    },
+        <Text color="inverse">Optional Header Section</Text>
+      </div>
+    ),
+    footer: (
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+          color: 'white',
+          width: '100%',
+          border: '1px dashed white',
+        }}
+      >
+        <Text color="inverse">Optional Footer Section</Text>
+      </div>
+    ),
+    headerMin: <b>MIN</b>,
   },
 };
-PrimaryNavigationSubrouting.args = {
-  header: (
-    <div
-      style={{
-        color: 'white',
-        display: 'flex',
-        justifyContent: 'center',
-        width: '100%',
-        border: '1px dashed white',
-      }}
-    >
-      <Text color="inverse">Optional Header Section</Text>
-    </div>
-  ),
-  footer: (
-    <div
-      style={{
-        display: 'flex',
-        justifyContent: 'center',
-        color: 'white',
-        width: '100%',
-        border: '1px dashed white',
-      }}
-    >
-      <Text color="inverse">Optional Footer Section</Text>
-    </div>
-  ),
-  headerMin: <b>MIN</b>,
+
+export const PrimaryNavigationSubrouting: Story = {
+  render: (args) => {
+    return (
+      <PrimaryNavigation {...args}>
+        <PrimaryNavigationItem to="/edit" icon={<Edit />} label="Nav Item" />
+        <PrimaryNavigationItem
+          to="/left"
+          icon={<ArrowLeft />}
+          label="Nav Item 2"
+          betaLabelText="Beta"
+        />
+        <PrimaryNavigationExpansionItem
+          icon={<Subjects />}
+          label="Base Route"
+          to="/base"
+          rootParentPath="/base"
+        >
+          <PrimaryNavigationSubItem label="Child Route1" to="/base/c1" />
+          <PrimaryNavigationSubItem label="Child Route2" to="/base/c2" />
+        </PrimaryNavigationExpansionItem>
+      </PrimaryNavigation>
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Combining PrimaryNavigationExpansionItem and PrimaryNavigationSubItem allows for ' +
+          'consumers to create an expansion-panel-esque component in their navigation bar. ' +
+          'The current pattern is that clicking the root path will navigate users to the ' +
+          'root/dashboard view. Child routes navigation items are then rendered below. ' +
+          'Navigating away from the "rootParentPath" closes the expansion-panel route item.',
+      },
+    },
+  },
+  args: {
+    header: (
+      <div
+        style={{
+          color: 'white',
+          display: 'flex',
+          justifyContent: 'center',
+          width: '100%',
+          border: '1px dashed white',
+        }}
+      >
+        <Text color="inverse">Optional Header Section</Text>
+      </div>
+    ),
+    footer: (
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+          color: 'white',
+          width: '100%',
+          border: '1px dashed white',
+        }}
+      >
+        <Text color="inverse">Optional Footer Section</Text>
+      </div>
+    ),
+    headerMin: <b>MIN</b>,
+  },
 };


### PR DESCRIPTION
# What Was Changed

## Common to all CSF3 updates
- Replaced now-defunct CSF 1 & 2 types `ComponentStory` and `ComponentMeta` with `StoryObj` and `Meta` respectively
- Updated all stories to the new single-const format 
- Removed titles from ungrouped components whose name is the same as their filename
- Created Story type and added it to all stories for increased type safety

## Unique to this PR
- Added several `Popover` styling stories
- Increased height of `Popover` Stories
    - made the tallest menu Popover a portal so it didn't have to be quite so tall
- Added some padding to the content

# Screenshots

## Increased `Popover` Height

| Before | After |
| --- | --- |
| ![Screenshot 2023-08-29 at 4 26 13 PM](https://github.com/lifeomic/chroma-react/assets/5824697/624c986c-8a35-495b-8a54-332d8a2b2474) | ![Screenshot 2023-08-29 at 4 23 40 PM](https://github.com/lifeomic/chroma-react/assets/5824697/6a4bebd1-210d-4748-9267-a0bfddb90bb5) |

## Added Padding Left

| Before | After |
| --- | --- |
| ![Screenshot 2023-08-29 at 4 26 24 PM](https://github.com/lifeomic/chroma-react/assets/5824697/984712c0-a741-4b85-af09-b7765c401d7a) | ![Screenshot 2023-08-29 at 5 05 47 PM](https://github.com/lifeomic/chroma-react/assets/5824697/8445c512-40a4-48c7-b9cd-8705d19f5456) |

## New `Popover` Stories

![Screenshot 2023-08-29 at 4 23 46 PM](https://github.com/lifeomic/chroma-react/assets/5824697/8aebd2dc-7bac-4a25-bd14-f1f49706ae28)
![Screenshot 2023-08-29 at 4 23 52 PM](https://github.com/lifeomic/chroma-react/assets/5824697/12eda09b-a9d1-4de1-9cd7-58969aea8b42)
![Screenshot 2023-08-29 at 4 23 56 PM](https://github.com/lifeomic/chroma-react/assets/5824697/dc940465-33e5-48f3-a2a6-85753b289e17)
![Screenshot 2023-08-29 at 4 24 02 PM](https://github.com/lifeomic/chroma-react/assets/5824697/5aeb591e-160d-4ee5-bcf3-c3454689b6aa)
