### PR TITLE
Update R- Components to Storybook CSF3

### DIFF
--- a/src/components/Radio/Radio.stories.tsx
+++ b/src/components/Radio/Radio.stories.tsx
@@ -1,6 +1,7 @@
 import { StoryObj, Meta } from '@storybook/react';
 
 import { Radio } from './Radio';
+import { Apple } from '@lifeomic/chromicons';
 
 const meta: Meta<typeof Radio> = {
   title: 'Form Components/Radio/Radio',
@@ -13,3 +14,36 @@ export default meta;
 type Story = StoryObj<typeof Radio>;
 
 export const Default: Story = {};
+
+export const Icon: Story = {
+  args: {
+    label: 'Apples',
+    icon: Apple,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'See a list of available icons in our [Chromicons](https://lifeomic.github.io/chromicons.com/) icon set.',
+      },
+    },
+  },
+};
+
+export const InverseDark: Story = {
+  parameters: {
+    backgrounds: { default: 'dark' },
+  },
+  args: {
+    color: 'inverse',
+  },
+};
+
+export const InverseBlue: Story = {
+  parameters: {
+    backgrounds: { default: 'blue' },
+  },
+  args: {
+    color: 'inverse',
+  },
+};

--- a/src/components/Radio/Radio.stories.tsx
+++ b/src/components/Radio/Radio.stories.tsx
@@ -1,17 +1,15 @@
-import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, Meta } from '@storybook/react';
 
 import { Radio } from './Radio';
 
-export default {
+const meta: Meta<typeof Radio> = {
   title: 'Form Components/Radio/Radio',
   component: Radio,
-  argTypes: {},
-} as ComponentMeta<typeof Radio>;
-
-const Template: ComponentStory<typeof Radio> = (args) => <Radio {...args} />;
-
-export const Default = Template.bind({});
-Default.args = {
-  label: 'Radio',
+  args: {
+    label: 'Radio',
+  },
 };
+export default meta;
+type Story = StoryObj<typeof Radio>;
+
+export const Default: Story = {};

--- a/src/components/Radio/RadioGroup.stories.tsx
+++ b/src/components/Radio/RadioGroup.stories.tsx
@@ -1,25 +1,29 @@
 import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryFn, Meta, StoryObj } from '@storybook/react';
 
 import { RadioGroup } from './RadioGroup';
 import { Radio } from './Radio';
 
-export default {
+const meta: Meta<typeof RadioGroup> = {
   title: 'Form Components/Radio/RadioGroup',
   component: RadioGroup,
+  args: {
+    title: 'Radio Group',
+  },
   argTypes: {
     onChange: { action: 'clicked' },
   },
-} as ComponentMeta<typeof RadioGroup>;
+};
+export default meta;
+type Story = StoryObj<typeof RadioGroup>;
 
-const Template: ComponentStory<typeof RadioGroup> = (args) => (
+const Template: StoryFn<typeof RadioGroup> = (args) => (
   <RadioGroup {...args}>
     <Radio value="opt1" label="Option 1" />
     <Radio value="opt2" label="Option 2" />
   </RadioGroup>
 );
 
-export const Default = Template.bind({});
-Default.args = {
-  title: 'Radio Group',
+export const Default: Story = {
+  render: Template,
 };

--- a/src/components/Radio/RadioGroup.stories.tsx
+++ b/src/components/Radio/RadioGroup.stories.tsx
@@ -27,3 +27,23 @@ const Template: StoryFn<typeof RadioGroup> = (args) => (
 export const Default: Story = {
   render: Template,
 };
+
+export const InverseDark: Story = {
+  render: Template,
+  parameters: {
+    backgrounds: { default: 'dark' },
+  },
+  args: {
+    color: 'inverse',
+  },
+};
+
+export const InverseBlue: Story = {
+  render: Template,
+  parameters: {
+    backgrounds: { default: 'blue' },
+  },
+  args: {
+    color: 'inverse',
+  },
+};

--- a/src/components/Radio/RadioGroupMinimal.stories.tsx
+++ b/src/components/Radio/RadioGroupMinimal.stories.tsx
@@ -27,3 +27,23 @@ const Template: StoryFn<typeof RadioGroupMinimal> = (args) => (
 export const Default: Story = {
   render: Template,
 };
+
+export const InverseDark: Story = {
+  render: Template,
+  parameters: {
+    backgrounds: { default: 'dark' },
+  },
+  args: {
+    color: 'inverse',
+  },
+};
+
+export const InverseBlue: Story = {
+  render: Template,
+  parameters: {
+    backgrounds: { default: 'blue' },
+  },
+  args: {
+    color: 'inverse',
+  },
+};

--- a/src/components/Radio/RadioGroupMinimal.stories.tsx
+++ b/src/components/Radio/RadioGroupMinimal.stories.tsx
@@ -1,25 +1,29 @@
 import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryFn, Meta, StoryObj } from '@storybook/react';
 
 import { RadioGroupMinimal } from './RadioGroupMinimal';
 import { Radio } from './Radio';
 
-export default {
+const meta: Meta<typeof RadioGroupMinimal> = {
   title: 'Form Components/Radio/RadioGroupMinimal',
   component: RadioGroupMinimal,
   argTypes: {
     onChange: { action: 'clicked' },
   },
-} as ComponentMeta<typeof RadioGroupMinimal>;
+  args: {
+    title: 'Radio Group Minimal',
+  },
+};
+export default meta;
+type Story = StoryObj<typeof RadioGroupMinimal>;
 
-const Template: ComponentStory<typeof RadioGroupMinimal> = (args) => (
+const Template: StoryFn<typeof RadioGroupMinimal> = (args) => (
   <RadioGroupMinimal {...args}>
     <Radio value="opt1" label="Option 1" />
     <Radio value="opt2" label="Option 2" />
   </RadioGroupMinimal>
 );
 
-export const Default = Template.bind({});
-Default.args = {
-  title: 'Radio Group Minimal',
+export const Default: Story = {
+  render: Template,
 };


### PR DESCRIPTION
# What Was Changed

## Common to all CSF3 updates
- Replaced now-defunct CSF 1 & 2 types `ComponentStory` and `ComponentMeta` with `StoryObj` and `Meta` respectively
- Updated all stories to the new single-const format 
- Created Story type and added it to all stories for increased type safety

## Unique to this PR
- Added color inverse stories to all components
- Added Icon story to `Radio`
- Noticed `Radio` has `hasError` and `errorMessage` props from extending `BaseFormElement`, but does not implement them. We'll need to take care of this (or omit the props if people aren't using them anywhere) in a future PR

# Screenshots

## New `Radio` Stories

![Screenshot 2023-08-30 at 1 56 48 PM](https://github.com/lifeomic/chroma-react/assets/5824697/9eb758c8-cbd9-4e63-b549-d54f58fb49b2)

## New `RadioGroup` Stories

![Screenshot 2023-08-30 at 1 56 54 PM](https://github.com/lifeomic/chroma-react/assets/5824697/cd417b20-20c3-484b-a060-d224409de826)

## New `RadioGroupMinimal` Stories

![Screenshot 2023-08-30 at 1 57 02 PM](https://github.com/lifeomic/chroma-react/assets/5824697/4ba22590-17af-4c65-bc5f-879705d6d381)


