### PR TITLE
Update second batch of S- Components to Storybook CSF3

### DIFF
--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -1,19 +1,22 @@
 import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, StoryFn, Meta } from '@storybook/react';
 
 import { Select } from './Select';
 import { SelectOption } from './SelectOption';
 import { ChevronRight, Edit } from '@lifeomic/chromicons';
 import { GroupHeading } from './GroupHeading';
 
-export default {
+const meta: Meta<typeof Select> = {
   title: 'Form Components/Select',
   component: Select,
-  argTypes: {},
-  subcomponents: { SelectOption, GroupHeading },
-} as ComponentMeta<typeof Select>;
+  args: {
+    label: 'Select',
+  },
+};
+export default meta;
+type Story = StoryObj<typeof Select>;
 
-const Template: ComponentStory<typeof Select> = (args) => {
+const Template: StoryFn<typeof Select> = (args) => {
   const [selected, setSelected] = React.useState<string>('');
 
   return (
@@ -52,82 +55,91 @@ const Template: ComponentStory<typeof Select> = (args) => {
   );
 };
 
-export const Default = Template.bind({});
-Default.args = {
-  label: 'Select',
+export const Default: Story = {
+  render: Template,
 };
 
-export const Placeholder = Template.bind({});
-Placeholder.args = {
-  label: 'Select',
-  placeholder: 'Placeholder',
-};
-
-export const SecondaryLabel = Template.bind({});
-SecondaryLabel.args = {
-  label: 'Select',
-  secondaryLabel: 'Secondary Label',
-};
-
-export const HelpMessage = Template.bind({});
-HelpMessage.args = {
-  label: 'Select',
-  helpMessage: 'Help Message',
-};
-
-export const Error = Template.bind({});
-Error.args = {
-  label: 'Select',
-  errorMessage: 'Error Message',
-  hasError: true,
-};
-
-export const Disabled = Template.bind({});
-Disabled.args = {
-  label: 'Select',
-  disabled: true,
-};
-
-export const FullWidth = Template.bind({});
-FullWidth.args = {
-  label: 'Select',
-  fullWidth: true,
-};
-
-export const Tooltip = Template.bind({});
-Tooltip.args = {
-  label: 'Select',
-  icon: Edit,
-  tooltipMessage: 'Tooltip Message',
-};
-
-export const SecondaryAction = Template.bind({});
-SecondaryAction.args = {
-  label: 'Select',
-  secondaryAction: {
-    args: 'https://lifeomic.com/',
-    action: (args: string) => {
-      alert(`You can do something with arg "${args}"`);
-    },
-    label: 'Do something',
-    icon: ChevronRight,
+export const Placeholder: Story = {
+  render: Template,
+  args: {
+    placeholder: 'Placeholder',
   },
 };
 
-export const InverseDark = Template.bind({});
-InverseDark.parameters = {
-  backgrounds: { default: 'dark' },
-};
-InverseDark.args = {
-  label: 'Select',
-  color: 'inverse',
+export const SecondaryLabel: Story = {
+  render: Template,
+  args: {
+    secondaryLabel: 'Secondary Label',
+  },
 };
 
-export const InverseBlue = Template.bind({});
-InverseBlue.parameters = {
-  backgrounds: { default: 'blue' },
+export const HelpMessage: Story = {
+  render: Template,
+  args: {
+    helpMessage: 'Help Message',
+  },
 };
-InverseBlue.args = {
-  label: 'Select',
-  color: 'inverse',
+
+export const Error: Story = {
+  render: Template,
+  args: {
+    errorMessage: 'Error Message',
+    hasError: true,
+  },
+};
+
+export const Disabled: Story = {
+  render: Template,
+  args: {
+    disabled: true,
+  },
+};
+
+export const FullWidth: Story = {
+  render: Template,
+  args: {
+    fullWidth: true,
+  },
+};
+
+export const Tooltip: Story = {
+  render: Template,
+  args: {
+    icon: Edit,
+    tooltipMessage: 'Tooltip Message',
+  },
+};
+
+export const SecondaryAction: Story = {
+  render: Template,
+  args: {
+    secondaryAction: {
+      args: 'https://lifeomic.com/',
+      action: (args: string) => {
+        alert(`You can do something with arg "${args}"`);
+      },
+      label: 'Do something',
+      icon: ChevronRight,
+    },
+  },
+};
+
+export const InverseDark: Story = {
+  render: Template,
+  parameters: {
+    backgrounds: { default: 'dark' },
+  },
+  args: {
+    color: 'inverse',
+  },
+};
+
+export const InverseBlue: Story = {
+  render: Template,
+  parameters: {
+    backgrounds: { default: 'blue' },
+  },
+  args: {
+    color: 'inverse',
+  },
 };

--- a/src/components/Skeleton/Skeleton.stories.tsx
+++ b/src/components/Skeleton/Skeleton.stories.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, Meta } from '@storybook/react';
 
 import { Skeleton } from './Skeleton';
 
-export default {
-  title: 'Components/Skeleton',
+const meta: Meta<typeof Skeleton> = {
   component: Skeleton,
-  argTypes: {},
+  args: {
+    height: 30,
+    width: 300,
+  },
   decorators: [
     (story) => (
       <div
@@ -21,14 +23,8 @@ export default {
       </div>
     ),
   ],
-} as ComponentMeta<typeof Skeleton>;
-
-const Template: ComponentStory<typeof Skeleton> = (args) => (
-  <Skeleton {...args} />
-);
-
-export const Default = Template.bind({});
-Default.args = {
-  height: 100,
-  width: 100,
 };
+export default meta;
+type Story = StoryObj<typeof Skeleton>;
+
+export const Default: Story = {};

--- a/src/components/SlideOver/SlideOver.stories.tsx
+++ b/src/components/SlideOver/SlideOver.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, StoryFn, Meta } from '@storybook/react';
 
 import { SlideOver } from './SlideOver';
 import { Header } from './Header';
@@ -10,72 +10,93 @@ import { Actions } from './Actions';
 import { Button } from '../Button';
 import { Settings } from '@lifeomic/chromicons';
 
-export default {
-  title: 'Components/SlideOver',
+const meta: Meta<typeof SlideOver> = {
   component: SlideOver,
-  argTypes: {},
-  subcomponents: { Header, Body, Actions },
-} as ComponentMeta<typeof SlideOver>;
+  decorators: [
+    (story: Function) => <div style={{ height: '200px' }}>{story()}</div>,
+  ],
+};
+export default meta;
+type Story = StoryObj<typeof SlideOver>;
 
-const Template: ComponentStory<typeof SlideOver> = (args) => (
-  <SlideOver {...args} />
-);
+const Template: StoryFn<typeof SlideOver> = (args) => {
+  const [isOpen, setIsOpen] = React.useState(false);
 
-export const Default = Template.bind({});
-Default.args = {
-  children: (
+  return (
     <>
-      <Header title="Panel Title" onClose={() => {}} />
-      <Body>
-        <Text>Content</Text>
-      </Body>
+      <Button
+        onClick={() => {
+          setIsOpen(!isOpen);
+        }}
+      >
+        Toggle SlideOver
+      </Button>
+      <SlideOver {...args} isOpen={isOpen}>
+        {args.children}
+      </SlideOver>
     </>
-  ),
-  isOpen: true,
+  );
 };
 
-export const HeaderWithIcon = Template.bind({});
-HeaderWithIcon.args = {
-  children: (
-    <>
-      <Header title="Panel Title" titleIcon={Settings} onClose={() => {}} />
-      <Body>
-        <Text>Content</Text>
-      </Body>
-    </>
-  ),
-  isOpen: true,
+export const Default: Story = {
+  render: Template,
+  args: {
+    children: (
+      <>
+        <Header title="Panel Title" onClose={() => {}} />
+        <Body>
+          <Text>Content</Text>
+        </Body>
+      </>
+    ),
+  },
 };
 
-export const CustomHeader = Template.bind({});
-CustomHeader.args = {
-  children: (
-    <>
-      <Header onClose={() => {}}>
-        <Avatar name="Chroma" />
-        <Text>Custom Header</Text>
-      </Header>
-      <Body>
-        <Text>Content</Text>
-      </Body>
-    </>
-  ),
-  isOpen: true,
+export const HeaderWithIcon: Story = {
+  render: Template,
+  args: {
+    children: (
+      <>
+        <Header title="Panel Title" titleIcon={Settings} onClose={() => {}} />
+        <Body>
+          <Text>Content</Text>
+        </Body>
+      </>
+    ),
+  },
 };
 
-export const PanelActions = Template.bind({});
-PanelActions.args = {
-  children: (
-    <>
-      <Header title="Panel Title" onClose={() => {}} />
-      <Body>
-        <Text>Content</Text>
-      </Body>
-      <Actions justify="flex-end">
-        <Button variant="text">Cancel</Button>
-        <Button>Save</Button>
-      </Actions>
-    </>
-  ),
-  isOpen: true,
+export const CustomHeader: Story = {
+  render: Template,
+  args: {
+    children: (
+      <>
+        <Header onClose={() => {}}>
+          <Avatar name="Chroma" />
+          <Text>Custom Header</Text>
+        </Header>
+        <Body>
+          <Text>Content</Text>
+        </Body>
+      </>
+    ),
+  },
+};
+
+export const PanelActions: Story = {
+  render: Template,
+  args: {
+    children: (
+      <>
+        <Header title="Panel Title" onClose={() => {}} />
+        <Body>
+          <Text>Content</Text>
+        </Body>
+        <Actions justify="flex-end">
+          <Button variant="text">Cancel</Button>
+          <Button>Save</Button>
+        </Actions>
+      </>
+    ),
+  },
 };


### PR DESCRIPTION
# What Was Changed

## Common to all CSF3 updates
- Replaced now-defunct CSF 1 & 2 types `ComponentStory` and `ComponentMeta` with `StoryObj` and `Meta` respectively
- Updated all stories to the new single-const format 
- Removed titles from ungrouped components whose name is the same as their filename
- Created Story type and added it to all stories for increased type safety

## Unique to this PR
- `Select`
    - _nothing should have changed visually_
    - There could be some properties that could use new or modified stories, but I want to get the first round done before diving into this
- `Skeleton`
    - I modified the `Skeleton`'s size so it looks more like it might when loading a block of text on a page
- `SlideOver`
    - The page was unable to scroll with open `SlideOver`s in the stories
    - This is now fixed by starting with all `SlideOver`s closed and having a button to toggle their open status
    - Also increased the stories' height so you can see the whole `SlideOver`

# Screenshots

## Skeleton Size Mod

| Before | After |
| --- | --- |
| ![Screenshot 2023-08-31 at 1 08 32 PM](https://github.com/lifeomic/chroma-react/assets/5824697/b5844c61-8294-4163-8b5d-2cf4dac01c38) | ![Screenshot 2023-08-31 at 1 05 08 PM](https://github.com/lifeomic/chroma-react/assets/5824697/b145efbf-444d-4e76-b17b-937fd2d0a0f6) |


## SlideOver Changes

| Before | After |
| --- | --- |
| https://github.com/lifeomic/chroma-react/assets/5824697/8b19e4db-34cf-4638-9a37-b1500a553202 | https://github.com/lifeomic/chroma-react/assets/5824697/822e0310-409a-4531-b4d6-ff2f2f35854d |





