### PR TITLE
Update third batch of S- Components to Storybook CSF3

### DIFF
--- a/src/components/Slider/Slider.stories.tsx
+++ b/src/components/Slider/Slider.stories.tsx
@@ -1,88 +1,83 @@
-import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, Meta } from '@storybook/react';
 
 import { Slider } from './Slider';
 
-export default {
-  title: 'Components/Slider',
+const meta: Meta<typeof Slider> = {
   component: Slider,
-  argTypes: {},
-} as ComponentMeta<typeof Slider>;
+  args: {
+    label: 'Slider',
+  },
+};
+export default meta;
+type Story = StoryObj<typeof Slider>;
 
-const Template: ComponentStory<typeof Slider> = (args) => <Slider {...args} />;
+export const Default: Story = {};
 
-export const Default = Template.bind({});
-Default.args = {
-  label: 'Slider',
+export const LabelPlacement: Story = {
+  args: {
+    labelPlacement: 'bottom',
+  },
 };
 
-export const LabelPlacement = Template.bind({});
-LabelPlacement.args = {
-  label: 'Slider',
-  labelPlacement: 'bottom',
+export const HelpMessage: Story = {
+  args: {
+    helpMessage: 'Help Message',
+  },
 };
 
-export const HelpMessage = Template.bind({});
-HelpMessage.args = {
-  label: 'Slider',
-  helpMessage: 'Help Message',
+export const Value: Story = {
+  args: {
+    value: 40,
+  },
 };
 
-export const Value = Template.bind({});
-Value.args = {
-  label: 'Slider',
-  value: 40,
+export const ShowValue: Story = {
+  args: {
+    value: 40,
+    showValue: true,
+  },
 };
 
-export const ShowValue = Template.bind({});
-ShowValue.args = {
-  label: 'Slider',
-  value: 40,
-  showValue: true,
+export const FormatValue: Story = {
+  args: {
+    value: 40,
+    formatValue: (value: number | undefined) => `${value} cm`,
+  },
 };
 
-export const FormatValue = Template.bind({});
-FormatValue.args = {
-  label: 'Slider',
-  value: 40,
-  formatValue: (value: number | undefined) => `${value} cm`,
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
 };
 
-export const Disabled = Template.bind({});
-Disabled.args = {
-  label: 'Slider',
-  disabled: true,
+export const Error: Story = {
+  args: {
+    hasError: true,
+    errorMessage: 'Error Message',
+  },
 };
 
-export const Error = Template.bind({});
-Error.args = {
-  label: 'Slider',
-  hasError: true,
-  errorMessage: 'Error Message',
+export const InverseDark: Story = {
+  parameters: {
+    backgrounds: { default: 'dark' },
+  },
+  args: {
+    value: 40,
+    color: 'inverse',
+    helpMessage: 'Help Message',
+    showValue: true,
+  },
 };
 
-export const InverseDark = Template.bind({});
-InverseDark.parameters = {
-  backgrounds: { default: 'dark' },
-};
-InverseDark.args = {
-  label: 'Slider',
-  value: 40,
-  color: 'inverse',
-  helpMessage: 'Help Message',
-  showValue: true,
-  formatValue: (value: number | undefined) => `${value} cm`,
-};
-
-export const InverseBlue = Template.bind({});
-InverseBlue.parameters = {
-  backgrounds: { default: 'blue' },
-};
-InverseBlue.args = {
-  label: 'Slider',
-  value: 40,
-  color: 'inverse',
-  helpMessage: 'Help Message',
-  showValue: true,
-  formatValue: (value: number | undefined) => `${value} cm`,
+export const InverseBlue: Story = {
+  parameters: {
+    backgrounds: { default: 'blue' },
+  },
+  args: {
+    value: 40,
+    color: 'inverse',
+    helpMessage: 'Help Message',
+    showValue: true,
+  },
 };

--- a/src/components/SmallTile/SmallTile.stories.tsx
+++ b/src/components/SmallTile/SmallTile.stories.tsx
@@ -1,30 +1,26 @@
 import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, Meta } from '@storybook/react';
 
 import { SmallTile } from './SmallTile';
 import { SmallTileContent } from './SmallTileContent';
 import { SmallTileFooter } from './SmallTileFooter';
 
-export default {
-  title: 'Components/SmallTile',
+const meta: Meta<typeof SmallTile> = {
   component: SmallTile,
-  argTypes: {},
+  args: {
+    children: (
+      <>
+        <SmallTileContent text="Title Text" />
+        <SmallTileFooter text="Footer Text" />
+      </>
+    ),
+  },
   subcomponents: {
     SmallTileContent,
     SmallTileFooter,
   },
-} as ComponentMeta<typeof SmallTile>;
-
-const Template: ComponentStory<typeof SmallTile> = (args) => (
-  <SmallTile {...args} />
-);
-
-export const Default = Template.bind({});
-Default.args = {
-  children: (
-    <>
-      <SmallTileContent text="Title Text" />
-      <SmallTileFooter text="Footer Text" />
-    </>
-  ),
 };
+export default meta;
+type Story = StoryObj<typeof SmallTile>;
+
+export const Default: Story = {};

--- a/src/components/Snackbar/Snackbar.stories.tsx
+++ b/src/components/Snackbar/Snackbar.stories.tsx
@@ -1,26 +1,22 @@
 import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, Meta } from '@storybook/react';
 
 import { Snackbar } from './Snackbar';
 import { Button } from '../Button';
 
-export default {
-  title: 'Components/Snackbar',
+const meta: Meta<typeof Snackbar> = {
   component: Snackbar,
-  argTypes: {},
-} as ComponentMeta<typeof Snackbar>;
-
-const Template: ComponentStory<typeof Snackbar> = (args) => (
-  <Snackbar {...args} />
-);
-
-export const Default = Template.bind({});
-Default.args = {
-  isOpen: true,
-  children: (
-    <>
-      <span>This is child text with a call to action</span>
-      <Button style={{ marginLeft: 8 }}>Button</Button>
-    </>
-  ),
+  args: {
+    isOpen: true,
+    children: (
+      <>
+        <span>This is child text with a call to action</span>
+        <Button style={{ marginLeft: 8 }}>Button</Button>
+      </>
+    ),
+  },
 };
+export default meta;
+type Story = StoryObj<typeof Snackbar>;
+
+export const Default: Story = {};

--- a/src/components/Snackbar/Snackbar.stories.tsx
+++ b/src/components/Snackbar/Snackbar.stories.tsx
@@ -3,6 +3,7 @@ import { StoryObj, Meta } from '@storybook/react';
 
 import { Snackbar } from './Snackbar';
 import { Button } from '../Button';
+import { AlertTriangle } from '@lifeomic/chromicons';
 
 const meta: Meta<typeof Snackbar> = {
   component: Snackbar,
@@ -15,8 +16,35 @@ const meta: Meta<typeof Snackbar> = {
       </>
     ),
   },
+  decorators: [
+    (story: Function) => (
+      <div
+        style={{
+          height: '100px',
+        }}
+      >
+        {story()}
+      </div>
+    ),
+  ],
 };
 export default meta;
 type Story = StoryObj<typeof Snackbar>;
 
 export const Default: Story = {};
+export const Icon: Story = {
+  args: {
+    icon: AlertTriangle,
+    statusType: 'error',
+    role: 'alert',
+    allowDismiss: true,
+    children: (
+      <>
+        <span>Warning</span>
+        <Button style={{ marginLeft: 8 }} color="negative">
+          Button
+        </Button>
+      </>
+    ),
+  },
+};


### PR DESCRIPTION
# What Was Changed

## Common to all CSF3 updates
- Replaced now-defunct CSF 1 & 2 types `ComponentStory` and `ComponentMeta` with `StoryObj` and `Meta` respectively
- Updated all stories to the new single-const format 
- Removed titles from ungrouped components whose name is the same as their filename
- Created Story type and added it to all stories for increased type safety

## Unique to this PR
- `Snackbar`
    - Added a story to cover Icon as well as the warning styling
    - Increased Story height so we can see whole component
    - Snackbar doesn't appear to implement its title prop
- _Nothing should have changed visually with the other two components_
- `Slider` could potentially use more stories. I think this and former components in a similar position merit a discussion about which stories to make and which to rely on the live prop manipulation feature for

# Screenshots

## `Snackbar` Changes

| Before | After |
| --- | --- |
| ![Screenshot 2023-08-31 at 1 44 45 PM](https://github.com/lifeomic/chroma-react/assets/5824697/e1b0b023-ea7b-4110-be24-2fdad37386db) | ![Screenshot 2023-08-31 at 1 44 08 PM](https://github.com/lifeomic/chroma-react/assets/5824697/ddcc3f51-4d34-44f1-889c-195f9e3b7065) |


