### PR TITLE
Update fourth round of S- Components to Storybook CSF3

### DIFF
--- a/src/components/SpinButton/SpinButton.stories.tsx
+++ b/src/components/SpinButton/SpinButton.stories.tsx
@@ -1,26 +1,23 @@
-import React, { useState } from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import React from 'react';
+import { StoryObj, StoryFn, Meta } from '@storybook/react';
 
 import { SpinButton } from './SpinButton';
 import { Box } from '../Box';
 import { TextField } from '../TextField';
 
-export default {
-  title: 'Components/SpinButton',
+const meta: Meta<typeof SpinButton> = {
   component: SpinButton,
   argTypes: {
     onClick: { action: 'clicked' },
   },
-} as ComponentMeta<typeof SpinButton>;
+};
+export default meta;
+type Story = StoryObj<typeof SpinButton>;
 
-const Template: ComponentStory<typeof SpinButton> = (args) => (
-  <SpinButton {...args}></SpinButton>
-);
+export const Default: Story = {};
 
-export const Default = Template.bind({});
-
-export const KeyboardSupport = () => {
-  const [valueNow, setValueNow] = useState(0);
+export const KeyboardSupport: StoryFn<typeof SpinButton> = () => {
+  const [valueNow, setValueNow] = React.useState(0);
   return (
     <Box style={{ overflow: 'auto', width: '80%' }} direction="row">
       <TextField

--- a/src/components/Stepper/Stepper.stories.tsx
+++ b/src/components/Stepper/Stepper.stories.tsx
@@ -1,18 +1,67 @@
 import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryFn, Meta, StoryObj } from '@storybook/react';
 
 import { Stepper } from './Stepper';
 import { Step } from './Step';
 import { Activity, Flag, User, Zap } from '@lifeomic/chromicons';
 
-export default {
-  title: 'Components/Stepper',
+const meta: Meta<typeof Stepper> = {
   component: Stepper,
-  argTypes: {},
-  subcomponents: { Step },
-} as ComponentMeta<typeof Stepper>;
+  argTypes: {
+    height: {
+      control: { type: 'number' },
+    },
+    width: {
+      control: { type: 'number' },
+    },
+    margin: {
+      control: { type: 'number' },
+    },
+    marginTop: {
+      control: { type: 'number' },
+    },
+    marginBottom: {
+      control: { type: 'number' },
+    },
+    marginLeft: {
+      control: { type: 'number' },
+    },
+    marginRight: {
+      control: { type: 'number' },
+    },
+    marginX: {
+      control: { type: 'number' },
+    },
+    marginY: {
+      control: { type: 'number' },
+    },
+    padding: {
+      control: { type: 'number' },
+    },
+    paddingTop: {
+      control: { type: 'number' },
+    },
+    paddingBottom: {
+      control: { type: 'number' },
+    },
+    paddingLeft: {
+      control: { type: 'number' },
+    },
+    paddingRight: {
+      control: { type: 'number' },
+    },
+    paddingX: {
+      control: { type: 'number' },
+    },
+    paddingY: {
+      control: { type: 'number' },
+    },
+  },
+};
+export default meta;
+type Story = StoryObj<typeof Stepper>;
 
-const Template: ComponentStory<typeof Stepper> = (args) => (
+const Template: StoryFn<typeof Stepper> = (args) => (
   <Stepper {...args}>
     <Step icon={Zap} subTitle="950" title="Registered" />
     <Step icon={Activity} subTitle="900" title="Consented" />
@@ -25,7 +74,9 @@ const Template: ComponentStory<typeof Stepper> = (args) => (
   </Stepper>
 );
 
-export const Default = Template.bind({});
-Default.args = {
-  activeStep: 1,
+export const Default: Story = {
+  render: Template,
+  args: {
+    activeStep: 1,
+  },
 };


### PR DESCRIPTION
# What Was Changed

## Common to all CSF3 updates
- Replaced now-defunct CSF 1 & 2 types `ComponentStory` and `ComponentMeta` with `StoryObj` and `Meta` respectively
- Updated all stories to the new single-const format 
- Removed titles from ungrouped components whose name is the same as their filename
- Created Story type and added it to all stories for increased type safety

## Unique to this PR
- `Stepper`
    - Added number controls so you can test out setting all the new props @dexterca just added
    - Decided not to make stories because you can check these out by modifying the props - considering going back and doing this for our other components, and will likely call a quick Chroma meeting for this

# Screenshots

## `Stepper` Number controls

_Side note: I have no idea why marginBottom is rendering apart from all the other margin props. It's written right under MarginTop in all places in Stepper.tsx_

![Screenshot 2023-08-31 at 4 38 17 PM](https://github.com/lifeomic/chroma-react/assets/5824697/1fc469af-5f52-4eef-ae79-54982cc0c562)




