### PR TITLE
Update first half of T- Components to Storybook CSF3

### DIFF
--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -1,33 +1,30 @@
 import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, Meta } from '@storybook/react';
 
 import { Tabs } from './Tabs';
 import { TabList } from './TabList';
 import { Tab } from './Tab';
 import { TabPanel } from './TabPanel';
 
-export default {
-  title: 'Components/Tabs',
+const meta: Meta<typeof Tabs> = {
   component: Tabs,
-  argTypes: {},
-  subcomponents: { Tab, TabList, TabPanel },
-} as ComponentMeta<typeof Tabs>;
-
-const Template: ComponentStory<typeof Tabs> = (args) => <Tabs {...args} />;
-
-export const Default = Template.bind({});
-Default.args = {
-  children: (
-    <>
-      <TabList aria-label="My Tabs">
-        <Tab stopId="tab1">Tab 1 Pill</Tab>
-        <Tab stopId="tab2">Tab 2 Pill</Tab>
-        <Tab stopId="tab3" disabled>
-          Tab 3 Pill
-        </Tab>
-      </TabList>
-      <TabPanel>Tab 2 selected</TabPanel>
-      <TabPanel>Tab 1 selected</TabPanel>
-    </>
-  ),
+  args: {
+    children: (
+      <>
+        <TabList aria-label="My Tabs">
+          <Tab stopId="tab1">Tab 1 Pill</Tab>
+          <Tab stopId="tab2">Tab 2 Pill</Tab>
+          <Tab stopId="tab3" disabled>
+            Tab 3 Pill
+          </Tab>
+        </TabList>
+        <TabPanel>Tab 2 selected</TabPanel>
+        <TabPanel>Tab 1 selected</TabPanel>
+      </>
+    ),
+  },
 };
+export default meta;
+type Story = StoryObj<typeof Tabs>;
+
+export const Default: Story = {};

--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StoryObj, Meta } from '@storybook/react';
+import { StoryObj, StoryFn, Meta } from '@storybook/react';
 
 import { Tabs } from './Tabs';
 import { TabList } from './TabList';
@@ -8,6 +8,11 @@ import { TabPanel } from './TabPanel';
 
 const meta: Meta<typeof Tabs> = {
   component: Tabs,
+};
+export default meta;
+type Story = StoryObj<typeof Tabs>;
+
+export const Default: Story = {
   args: {
     children: (
       <>
@@ -18,13 +23,79 @@ const meta: Meta<typeof Tabs> = {
             Tab 3 Pill
           </Tab>
         </TabList>
-        <TabPanel>Tab 2 selected</TabPanel>
-        <TabPanel>Tab 1 selected</TabPanel>
+        <TabPanel stopId="tab1">Tab 1 selected</TabPanel>
+        <TabPanel stopId="tab2">Tab 2 selected</TabPanel>
       </>
     ),
   },
 };
-export default meta;
-type Story = StoryObj<typeof Tabs>;
 
-export const Default: Story = {};
+const TemplateManual: StoryFn<typeof Tabs> = (args) => {
+  const [activeTab, setActiveTab] = React.useState('tab1');
+  const [content, setContent] = React.useState(
+    'No side effect has been called yet...'
+  );
+
+  return (
+    <>
+      <Tabs {...args} selectedTabId={activeTab}>
+        <TabList aria-label="My Tabs">
+          <Tab
+            stopId="tab1"
+            onClick={() => {
+              setActiveTab('tab1');
+              setContent('Some side effect from tab 1');
+            }}
+          >
+            Tab 1 Pill
+          </Tab>
+          <Tab
+            stopId="tab2"
+            onClick={() => {
+              setActiveTab('tab2');
+              setContent('Some side effect from tab 2');
+            }}
+          >
+            Tab 2 Pill
+          </Tab>
+          <Tab
+            stopId="tab3"
+            onClick={() => {
+              setActiveTab('tab3');
+              setContent('Some side effect from tab 3');
+            }}
+          >
+            Tab 3 Pill
+          </Tab>
+        </TabList>
+        <TabPanel stopId="tab1">
+          <p>Tab 1 content</p>
+        </TabPanel>
+        <TabPanel stopId="tab2">
+          <p>Tab 2 content</p>
+        </TabPanel>
+        <TabPanel stopId="tab3">
+          <p>Tab 3 content</p>
+        </TabPanel>
+      </Tabs>
+      <div style={{ backgroundColor: 'whitesmoke', padding: '1rem' }}>
+        <p>{content}</p>
+      </div>
+    </>
+  );
+};
+
+export const ManualControl: Story = {
+  render: TemplateManual,
+  args: {
+    manualControl: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Manual control allows you to run side effects by handling tab change manually with an onClick() on each tab',
+      },
+    },
+  },
+};

--- a/src/components/Text/Text.stories.tsx
+++ b/src/components/Text/Text.stories.tsx
@@ -1,35 +1,32 @@
-import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, Meta } from '@storybook/react';
 
 import { Text } from './Text';
 
-export default {
-  title: 'Components/Text',
+const meta: Meta<typeof Text> = {
   component: Text,
-  argTypes: {},
-} as ComponentMeta<typeof Text>;
+  args: {
+    children: 'Text',
+  },
+};
+export default meta;
+type Story = StoryObj<typeof Text>;
 
-const Template: ComponentStory<typeof Text> = (args) => <Text {...args} />;
+export const Default: Story = {};
 
-export const Default = Template.bind({});
-Default.args = {
-  children: 'Text',
+export const InverseDark: Story = {
+  parameters: {
+    backgrounds: { default: 'dark' },
+  },
+  args: {
+    color: 'inverse',
+  },
 };
 
-export const InverseDark = Template.bind({});
-InverseDark.parameters = {
-  backgrounds: { default: 'dark' },
-};
-InverseDark.args = {
-  children: 'Text',
-  color: 'inverse',
-};
-
-export const InverseBlue = Template.bind({});
-InverseBlue.parameters = {
-  backgrounds: { default: 'blue' },
-};
-InverseBlue.args = {
-  children: 'Text',
-  color: 'inverse',
+export const InverseBlue: Story = {
+  parameters: {
+    backgrounds: { default: 'blue' },
+  },
+  args: {
+    color: 'inverse',
+  },
 };

--- a/src/components/TextArea/TextArea.stories.tsx
+++ b/src/components/TextArea/TextArea.stories.tsx
@@ -1,81 +1,79 @@
-import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, Meta } from '@storybook/react';
 
 import { TextArea } from './TextArea';
 import { HelpCircle } from '@lifeomic/chromicons';
 
-export default {
+const meta: Meta<typeof TextArea> = {
   title: 'Form Components/TextArea',
   component: TextArea,
-  argTypes: {},
-} as ComponentMeta<typeof TextArea>;
+  args: {
+    label: 'TextArea',
+  },
+};
+export default meta;
+type Story = StoryObj<typeof TextArea>;
 
-const Template: ComponentStory<typeof TextArea> = (args) => (
-  <TextArea {...args} />
-);
+export const Default: Story = {};
 
-export const Default = Template.bind({});
-Default.args = {
-  label: 'TextArea',
+export const NoLabel: Story = {
+  args: {
+    label: '',
+    'aria-label': 'TextArea',
+  },
 };
 
-export const NoLabel = Template.bind({});
-NoLabel.args = {
-  'aria-label': 'TextArea',
+export const SecondaryLabel: Story = {
+  args: {
+    secondaryLabel: 'Secondary Label',
+  },
 };
 
-export const SecondaryLabel = Template.bind({});
-SecondaryLabel.args = {
-  label: 'TextArea',
-  secondaryLabel: 'Secondary Label',
+export const HelpMessage: Story = {
+  args: {
+    helpMessage: 'Help Message',
+  },
 };
 
-export const HelpMessage = Template.bind({});
-HelpMessage.args = {
-  label: 'TextArea',
-  helpMessage: 'Help Message',
+export const Tooltip: Story = {
+  args: {
+    icon: HelpCircle,
+    tooltipMessage: 'Here is descriptive text',
+  },
 };
 
-export const Tooltip = Template.bind({});
-Tooltip.args = {
-  label: 'TextArea',
-  icon: HelpCircle,
-  tooltipMessage: 'Here is descriptive text',
+export const Required: Story = {
+  args: {
+    showRequiredLabel: true,
+  },
 };
 
-export const Required = Template.bind({});
-Required.args = {
-  label: 'TextArea',
-  showRequiredLabel: true,
+export const Error: Story = {
+  args: {
+    hasError: true,
+    errorMessage: 'This is required',
+  },
 };
 
-export const Error = Template.bind({});
-Error.args = {
-  label: 'TextArea',
-  hasError: true,
-  errorMessage: 'This is required',
+export const ReadOnly: Story = {
+  args: {
+    readOnly: true,
+  },
 };
 
-export const ReadOnly = Template.bind({});
-ReadOnly.args = {
-  label: 'TextArea',
-  readOnly: true,
+export const InverseDark: Story = {
+  parameters: {
+    backgrounds: { default: 'dark' },
+  },
+  args: {
+    color: 'inverse',
+  },
 };
 
-export const InverseDark = Template.bind({});
-InverseDark.parameters = {
-  backgrounds: { default: 'dark' },
-};
-InverseDark.args = {
-  label: 'TextArea',
-  color: 'inverse',
-};
-
-export const InverseBlue = Template.bind({});
-InverseBlue.parameters = {
-  backgrounds: { default: 'blue' },
-};
-InverseBlue.args = {
-  label: 'TextArea',
-  color: 'inverse',
+export const InverseBlue: Story = {
+  parameters: {
+    backgrounds: { default: 'blue' },
+  },
+  args: {
+    color: 'inverse',
+  },
 };


### PR DESCRIPTION
# What Was Changed

## Common to all CSF3 updates
- Replaced now-defunct CSF 1 & 2 types `ComponentStory` and `ComponentMeta` with `StoryObj` and `Meta` respectively
- Updated all stories to the new single-const format 
- Removed titles from ungrouped components whose name is the same as their filename
- Created Story type and added it to all stories for increased type safety

## Unique to this PR
- `Tabs`
    - Added a story for `manualControl`, which was unable to be demonstrated by adjusting the props
    - It's a halfway solution that could be improved
        - the `onClick()` functions are obfuscated in Storybook, so a completely new Chrōma user without reference to usage of Tabs in phc-ui, for example, may not quite be able to figure out how to set this up.
        - the proper way to do `manualControl` within a story involves the Storybook `Actions` and/or `State` add-ons.
        - I spent some time looking into these and decided it could wait until later because it was going to be a big change and take some time.
- _the other two components should look and behave the same as before_

# Screenshots

## New `Tabs` Manual Control Story

https://github.com/lifeomic/chroma-react/assets/5824697/a7a3c3c0-8c0c-4e08-b360-587dc9a464b1

| In-Browser | In VS Code |
| --- | --- |
|  ![Screenshot 2023-09-01 at 1 16 54 PM](https://github.com/lifeomic/chroma-react/assets/5824697/40ae2cf7-db86-4e0a-bd4e-25290d8f7e4a) | <img width="451" alt="Screenshot 2023-09-01 at 1 17 08 PM" src="https://github.com/lifeomic/chroma-react/assets/5824697/4932735d-6cc6-4568-830f-a7f8c7fbfb40"> |
