### PR TITLE
Update second half of T- Components to Storybook CSF3

### DIFF
--- a/src/components/TextField/TextField.stories.tsx
+++ b/src/components/TextField/TextField.stories.tsx
@@ -1,106 +1,103 @@
 import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, Meta } from '@storybook/react';
 
 import { TextField } from './TextField';
 import { HelpCircle, User } from '@lifeomic/chromicons';
 
-export default {
+const meta: Meta<typeof TextField> = {
   title: 'Form Components/TextField',
   component: TextField,
-  argTypes: {},
-} as ComponentMeta<typeof TextField>;
+  args: {
+    label: 'Text Field',
+  },
+};
+export default meta;
+type Story = StoryObj<typeof TextField>;
 
-const Template: ComponentStory<typeof TextField> = (args) => (
-  <TextField {...args} />
-);
+export const Default: Story = {};
 
-export const Default = Template.bind({});
-Default.args = {
-  label: 'Text Field',
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
 };
 
-export const Disabled = Template.bind({});
-Disabled.args = {
-  label: 'Text Field',
-  disabled: true,
+export const ReadOnly: Story = {
+  args: {
+    readOnly: true,
+  },
 };
 
-export const ReadOnly = Template.bind({});
-ReadOnly.args = {
-  label: 'Text Field',
-  readOnly: true,
+export const Password: Story = {
+  args: {
+    type: 'password',
+  },
 };
 
-export const Password = Template.bind({});
-Password.args = {
-  label: 'Text Field',
-  type: 'password',
+export const Placeholder: Story = {
+  args: {
+    placeholder: 'Required',
+  },
 };
 
-export const Placeholder = Template.bind({});
-Placeholder.args = {
-  label: 'Text Field',
-  placeholder: 'Required',
+export const Error: Story = {
+  args: {
+    hasError: true,
+    errorMessage: 'This is required!',
+  },
 };
 
-export const Error = Template.bind({});
-Error.args = {
-  label: 'Text Field',
-  hasError: true,
-  errorMessage: 'This is required!',
+export const RequiredLabel: Story = {
+  args: {
+    showRequiredLabel: true,
+  },
 };
 
-export const RequiredLabel = Template.bind({});
-RequiredLabel.args = {
-  label: 'Text Field',
-  showRequiredLabel: true,
+export const StartAdornment: Story = {
+  args: {
+    startAdornment: <User aria-hidden />,
+  },
 };
 
-export const StartAdornment = Template.bind({});
-StartAdornment.args = {
-  label: 'Text Field',
-  startAdornment: <User aria-hidden />,
+export const EndAdornment: Story = {
+  args: {
+    endAdornment: <User aria-hidden />,
+  },
 };
 
-export const EndAdornment = Template.bind({});
-EndAdornment.args = {
-  label: 'Text Field',
-  endAdornment: <User aria-hidden />,
+export const HelpMessage: Story = {
+  args: {
+    helpMessage: 'Help Message',
+  },
 };
 
-export const HelpMessage = Template.bind({});
-HelpMessage.args = {
-  label: 'Text Field',
-  helpMessage: 'Help Message',
+export const Tooltip: Story = {
+  args: {
+    icon: HelpCircle,
+    tooltipMessage: 'Tooltip Message',
+  },
 };
 
-export const Tooltip = Template.bind({});
-Tooltip.args = {
-  label: 'Text Field',
-  icon: HelpCircle,
-  tooltipMessage: 'Tooltip Message',
+export const SecondaryLabel: Story = {
+  args: {
+    secondaryLabel: 'Secondary Label',
+  },
 };
 
-export const SecondaryLabel = Template.bind({});
-SecondaryLabel.args = {
-  label: 'Text Field',
-  secondaryLabel: 'Secondary Label',
+export const InverseDark: Story = {
+  parameters: {
+    backgrounds: { default: 'dark' },
+  },
+  args: {
+    color: 'inverse',
+  },
 };
 
-export const InverseDark = Template.bind({});
-InverseDark.parameters = {
-  backgrounds: { default: 'dark' },
-};
-InverseDark.args = {
-  label: 'Text Field',
-  color: 'inverse',
-};
-
-export const InverseBlue = Template.bind({});
-InverseBlue.parameters = {
-  backgrounds: { default: 'blue' },
-};
-InverseBlue.args = {
-  label: 'Text Field',
-  color: 'inverse',
+export const InverseBlue: Story = {
+  parameters: {
+    backgrounds: { default: 'blue' },
+  },
+  args: {
+    color: 'inverse',
+  },
 };

--- a/src/components/Toggle/Toggle.stories.tsx
+++ b/src/components/Toggle/Toggle.stories.tsx
@@ -1,60 +1,58 @@
-import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, Meta } from '@storybook/react';
 
 import { Toggle } from './Toggle';
 
-export default {
+const meta: Meta<typeof Toggle> = {
   title: 'Form Components/Toggle',
   component: Toggle,
-  argTypes: {},
-} as ComponentMeta<typeof Toggle>;
+  args: {
+    label: 'Toggle',
+  },
+};
+export default meta;
+type Story = StoryObj<typeof Toggle>;
 
-const Template: ComponentStory<typeof Toggle> = (args) => <Toggle {...args} />;
+export const Default: Story = {};
 
-export const Default = Template.bind({});
-Default.args = {
-  label: 'Toggle',
+export const Placement: Story = {
+  args: {
+    placement: 'right',
+  },
 };
 
-export const Placement = Template.bind({});
-Placement.args = {
-  label: 'Toggle',
-  placement: 'right',
+export const ShowRequiredLabel: Story = {
+  args: {
+    showRequiredLabel: true,
+  },
 };
 
-export const ShowRequiredLabel = Template.bind({});
-ShowRequiredLabel.args = {
-  label: 'Toggle',
-  showRequiredLabel: true,
+export const Error: Story = {
+  args: {
+    hasError: true,
+    errorMessage: 'Error Message',
+  },
 };
 
-export const Error = Template.bind({});
-Error.args = {
-  label: 'Toggle',
-  hasError: true,
-  errorMessage: 'Error Message',
+export const HelpMessage: Story = {
+  args: {
+    helpMessage: 'Error Message',
+  },
 };
 
-export const HelpMessage = Template.bind({});
-HelpMessage.args = {
-  label: 'Toggle',
-  helpMessage: 'Error Message',
+export const InverseDark: Story = {
+  parameters: {
+    backgrounds: { default: 'dark' },
+  },
+  args: {
+    color: 'inverse',
+  },
 };
 
-export const InverseDark = Template.bind({});
-InverseDark.parameters = {
-  backgrounds: { default: 'dark' },
-};
-InverseDark.args = {
-  label: 'Toggle',
-  color: 'inverse',
-};
-
-export const InverseBlue = Template.bind({});
-InverseBlue.parameters = {
-  backgrounds: { default: 'blue' },
-};
-InverseBlue.args = {
-  label: 'Toggle',
-  color: 'inverse',
+export const InverseBlue: Story = {
+  parameters: {
+    backgrounds: { default: 'blue' },
+  },
+  args: {
+    color: 'inverse',
+  },
 };

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,22 +1,35 @@
 import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryObj, Meta } from '@storybook/react';
 
 import { Tooltip } from './Tooltip';
 import { Button } from '../Button';
+import { IconButton } from '../IconButton';
+import { Info } from '@lifeomic/chromicons';
 
-export default {
-  title: 'Components/Tooltip',
+const meta: Meta<typeof Tooltip> = {
   component: Tooltip,
-  argTypes: {},
-} as ComponentMeta<typeof Tooltip>;
+  args: {
+    title: 'Tooltip',
+    children: <Button>Tooltip on hover</Button>,
+  },
+};
+export default meta;
+type Story = StoryObj<typeof Tooltip>;
 
-const Template: ComponentStory<typeof Tooltip> = (args) => (
-  <Tooltip {...args}>
-    <Button>Tooltip on hover</Button>
-  </Tooltip>
-);
+export const Default: Story = {};
 
-export const Default = Template.bind({});
-Default.args = {
-  title: 'Tooltip',
+export const Children: Story = {
+  args: {
+    children: (
+      <p style={{ width: 'fit-content' }}>Other elements can be children too</p>
+    ),
+    title: 'Like this paragraph',
+  },
+};
+
+export const IconChild: Story = {
+  args: {
+    children: <IconButton aria-label="Info icon tooltip" icon={Info} />,
+    title: 'Icons are a common tooltip paradigm',
+  },
 };


### PR DESCRIPTION
# What Was Changed

## Common to all CSF3 updates
- Replaced now-defunct CSF 1 & 2 types `ComponentStory` and `ComponentMeta` with `StoryObj` and `Meta` respectively
- Updated all stories to the new single-const format 
- Removed titles from ungrouped components whose name is the same as their filename
- Created Story type and added it to all stories for increased type safety

## Unique to this PR
- `Tooltip`
    - Added a couple stories demonstrating different children, since that prop is hard to set in the interactive area with our current setup

# Screenshots

## New `Tooltip` Stories

![Screenshot 2023-09-05 at 11 37 13 AM](https://github.com/lifeomic/chroma-react/assets/5824697/aecd1a0f-3a91-4967-acf0-424351645670)
