### PR TITLE
Update theme to Storybook CSF3

### DIFF
--- a/stories/styles/theme/theme.stories.tsx
+++ b/stories/styles/theme/theme.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentStory } from '@storybook/react';
+import { StoryObj, StoryFn, Meta } from '@storybook/react';
 import * as React from 'react';
 import JSONTree from 'react-json-tree';
 import black from '../../../src/colors/black';
@@ -36,7 +36,7 @@ const paletteOptions = {
   yellow,
 };
 
-export default {
+const meta: Meta<any> = {
   title: 'Styles/Theme',
   parameters: {
     docs: {
@@ -89,10 +89,12 @@ const App: React.FC = () => (
     },
   },
 };
+export default meta;
+type Story = StoryObj<any>;
 
 const palette = createPalette();
 
-export const ThemeStory: ComponentStory<any> = (args) => {
+const TemplateTheme: StoryFn<any> = (args) => {
   console.log('ARGS', args);
   const theme = React.useMemo(
     () =>
@@ -151,9 +153,13 @@ export const ThemeStory: ComponentStory<any> = (args) => {
     </StyledEngineProvider>
   );
 };
-ThemeStory.args = {
-  'Primary Palette': 'blue',
-  'Secondary Palette': 'green',
+
+export const ThemeStory: Story = {
+  render: TemplateTheme,
+  args: {
+    'Primary Palette': 'blue',
+    'Secondary Palette': 'green',
+  },
 };
 
 export const ThemeExplorer = () => <JSONTree data={createTheme()} />;

--- a/stories/styles/theme/theme.stories.tsx
+++ b/stories/styles/theme/theme.stories.tsx
@@ -83,10 +83,8 @@ const App: React.FC = () => (
   },
   argTypes: {
     'Primary Palette': {
-      control: { type: 'radio', options: Object.keys(paletteOptions) },
-    },
-    'Secondary Palette': {
-      control: { type: 'radio', options: Object.keys(paletteOptions) },
+      control: 'select',
+      options: [...Object.keys(paletteOptions)],
     },
   },
 };
@@ -115,10 +113,6 @@ const TemplateTheme: StoryFn<any> = (args) => {
           primary:
             paletteOptions[
               args['Primary Palette'] as keyof typeof paletteOptions
-            ],
-          secondary:
-            paletteOptions[
-              args['Secondary Palette'] as keyof typeof paletteOptions
             ],
         },
       }),
@@ -149,7 +143,6 @@ export const ThemeStory: Story = {
   render: TemplateTheme,
   args: {
     'Primary Palette': 'blue',
-    'Secondary Palette': 'green',
   },
 };
 

--- a/stories/styles/theme/theme.stories.tsx
+++ b/stories/styles/theme/theme.stories.tsx
@@ -20,6 +20,7 @@ import {
   StyledEngineProvider,
   ThemeProvider,
 } from '../../../src/styles';
+import { makeStyles } from '@mui/styles';
 
 const paletteOptions = {
   black,
@@ -94,8 +95,19 @@ type Story = StoryObj<any>;
 
 const palette = createPalette();
 
+const useStyles = makeStyles(() => ({
+  container: {
+    display: 'flex',
+    justifyContent: 'center',
+    padding: '1rem',
+    backgroundColor: palette.common.white,
+  },
+}));
+
 const TemplateTheme: StoryFn<any> = (args) => {
   console.log('ARGS', args);
+  const classes = useStyles({});
+
   const theme = React.useMemo(
     () =>
       createTheme({
@@ -116,36 +128,15 @@ const TemplateTheme: StoryFn<any> = (args) => {
   return (
     <StyledEngineProvider injectFirst>
       <ThemeProvider theme={theme}>
-        <div
-          style={{
-            display: 'flex',
-            justifyContent: 'center',
-            padding: '1rem',
-            backgroundColor: palette.common.white,
-          }}
-        >
+        <div className={classes.container}>
           <Button>Text Button</Button>
           <Button>Text Button</Button>
         </div>
-        <div
-          style={{
-            display: 'flex',
-            justifyContent: 'center',
-            padding: '1rem',
-            backgroundColor: palette.common.white,
-          }}
-        >
+        <div className={classes.container}>
           <Button variant="outlined">Outlined Button</Button>
           <Button variant="outlined">Outlined Button</Button>
         </div>
-        <div
-          style={{
-            display: 'flex',
-            justifyContent: 'center',
-            padding: '1rem',
-            backgroundColor: palette.common.white,
-          }}
-        >
+        <div className={classes.container}>
           <Button variant="contained">Contained Button</Button>
           <Button variant="contained">Contained Button</Button>
         </div>

--- a/stories/styles/theme/theme.stories.tsx
+++ b/stories/styles/theme/theme.stories.tsx
@@ -146,4 +146,27 @@ export const ThemeStory: Story = {
   },
 };
 
-export const ThemeExplorer = () => <JSONTree data={createTheme()} />;
+const explorerTheme = {
+  scheme: 'chalk',
+  author: 'chris kempson (http://chriskempson.com)',
+  base00: '#151515',
+  base01: '#202020',
+  base02: '#303030',
+  base03: '#505050',
+  base04: '#b0b0b0',
+  base05: '#d0d0d0',
+  base06: '#e0e0e0',
+  base07: '#f5f5f5',
+  base08: '#fb9fb1',
+  base09: '#eda987',
+  base0A: '#ddb26f',
+  base0B: '#acc267',
+  base0C: '#12cfc0',
+  base0D: '#6fc2ef',
+  base0E: '#e1a3ee',
+  base0F: '#deaf8f',
+};
+
+export const ThemeExplorer = () => (
+  <JSONTree data={createTheme()} theme={explorerTheme} />
+);


### PR DESCRIPTION
# What Was Changed

## Common to all CSF3 updates
- Replaced now-defunct CSF 1 & 2 types `ComponentStory` and `ComponentMeta` with `StoryObj` and `Meta` respectively
- Updated all stories to the new single-const format 

## Unique to this PR
- condensed some style tags to a class
- Changed Theme Explorer theme to light to match the rest of the content around it
- Nothing in the example made use of the Secondary Palette, so I removed it for now.
    - If there's time in the future, I'd love to study up on our theming and make an example that actually illustrates how our secondary palette works. But for now it's more important to jump on some Patient ML and client work.

# Screenshots

## New `Tooltip` Stories

| Before | After |
| --- | --- |
| ![Screenshot 2023-09-05 at 2 41 30 PM](https://github.com/lifeomic/chroma-react/assets/5824697/4b151e2b-2f9c-4352-8dd5-13b3423ed01a) | ![Screenshot 2023-09-05 at 2 41 06 PM](https://github.com/lifeomic/chroma-react/assets/5824697/288f2ec5-4975-4331-9200-4554f7b28142) |
