### PR TITLE
Allow null in description list items

### DIFF
--- a/src/components/DescriptionList/DescriptionList.tsx
+++ b/src/components/DescriptionList/DescriptionList.tsx
@@ -112,6 +112,7 @@ export interface DescriptionListProps {
     | React.ReactElement<DescriptionTermProps>
     | React.ReactElement<DescriptionDetailsProps>
     | React.ReactElement<DescriptionListGroupHeadingProps>
+    | null // allows items to be added programatically and made null if a condition doesn't apply
   >;
   title?: string;
   titleIcon?: React.ComponentType<React.SVGProps<SVGSVGElement>>;


### PR DESCRIPTION
# What Was Changed

- This has come up twice now in `phc-ui` - we want to conditionally add an element to the `<DescriptionList />` `items` array - [conditional description example](https://github.com/lifeomic/phc-ui/pull/3457#discussion_r1333771209) and [conditional divider example](https://github.com/lifeomic/phc-ui/blob/1d9468ae761a10be8e5d54c8cae51f085765fa5f/src/components/pages/ML/components/DescriptionList.tsx#L38)
- So rather than deal with it individually, I think it makes sense to take care of this at the source