### PR TITLE
Adjust `<ExpansionPanel` icons' min-widths to fix Safari display bug

### DIFF
--- a/src/components/ExpansionPanel/ExpansionPanel.tsx
+++ b/src/components/ExpansionPanel/ExpansionPanel.tsx
@@ -45,7 +45,7 @@ export const useStyles = makeStyles(
     },
     leadingIcon: {
       marginRight: theme.spacing(1),
-      minWidth: 'fit-content',
+      minWidth: theme.pxToRem(18),
     },
     titleContainer: {
       alignItems: 'center',
@@ -66,7 +66,7 @@ export const useStyles = makeStyles(
     icon: {
       transition: 'transform 0.25s ease',
       color: theme.palette.primary.main,
-      minWidth: 'fit-content',
+      minWidth: theme.pxToRem(18),
     },
     rotate: {
       transform: 'rotate(45deg)',


### PR DESCRIPTION
BEFORE | AFTER | &nbsp;
-- | -- | --
<img width="1054" alt="Screenshot 2023-10-09 at 10 21 42 AM" src="https://github.com/lifeomic/chroma-react/assets/485903/2dc4abe4-4a56-4d40-83cb-c62501b761b7"> | <img width="1054" alt="Screenshot 2023-10-09 at 10 21 56 AM" src="https://github.com/lifeomic/chroma-react/assets/485903/2e735525-add9-49ab-b9cc-74488d076f77"> | Safari
<img width="1060" alt="Screenshot 2023-10-09 at 10 22 25 AM" src="https://github.com/lifeomic/chroma-react/assets/485903/2afcd028-9892-4113-9746-db64ad394378"> | <img width="1062" alt="Screenshot 2023-10-09 at 10 22 42 AM" src="https://github.com/lifeomic/chroma-react/assets/485903/1636c679-241f-4b8c-b8ac-eb65ed26c133"> | Chrome (no visual changes)
<img width="1058" alt="Screenshot 2023-10-09 at 10 24 38 AM" src="https://github.com/lifeomic/chroma-react/assets/485903/ee941bff-af27-4602-ab3e-99fa8286bafe"> | <img width="1058" alt="Screenshot 2023-10-09 at 10 24 42 AM" src="https://github.com/lifeomic/chroma-react/assets/485903/b9ab5563-ca55-4c0f-9056-77bba950331a"> | Firefox (no visual changes)

