### PR TITLE
feat: Add secondary header to `<ExpansionPanel`

### DIFF
--- a/src/components/ExpansionPanel/ExpansionPanel.stories.tsx
+++ b/src/components/ExpansionPanel/ExpansionPanel.stories.tsx
@@ -3,6 +3,7 @@ import { StoryObj, StoryFn, Meta } from '@storybook/react';
 
 import { ExpansionPanel } from './ExpansionPanel';
 import { Check, ArrowRight } from '@lifeomic/chromicons';
+import { Button } from '../Button';
 
 const meta: Meta<typeof ExpansionPanel> = {
   title: 'Components/ExpansionPanel',
@@ -44,6 +45,23 @@ export const TruncatedTitle: Story = {
     docs: {
       description: {
         story: `The title can be set to truncate with an ellipsis if it is too long for the expansion panel.`,
+      },
+    },
+  },
+};
+
+export const SecondaryHeader: Story = {
+  render: Template,
+  args: {
+    title:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit ex ea commodo consequat.',
+    secondaryHeaderChildren: <Button variant="text">Button</Button>,
+    truncateTitle: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: `Secondary content or actions can be placed in the expansion panel header.`,
       },
     },
   },

--- a/src/components/ExpansionPanel/ExpansionPanel.stories.tsx
+++ b/src/components/ExpansionPanel/ExpansionPanel.stories.tsx
@@ -54,8 +54,9 @@ export const SecondaryHeader: Story = {
   render: Template,
   args: {
     title:
-      'Lorem ipsum dolor sit amet, consectetur adipiscing elit ex ea commodo consequat.',
-    secondaryHeaderChildren: <Button variant="text">Button</Button>,
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
+    leadingIcon: ArrowRight,
+    secondaryHeader: <Button variant="text">Secondary Button</Button>,
     truncateTitle: true,
   },
   parameters: {

--- a/src/components/ExpansionPanel/ExpansionPanel.tsx
+++ b/src/components/ExpansionPanel/ExpansionPanel.tsx
@@ -38,7 +38,7 @@ export const useStyles = makeStyles(
       outline: 'none',
       overflow: 'hidden',
       paddingLeft: theme.spacing(2),
-      paddingRight: theme.spacing(2),
+      paddingRight: 0,
       paddingTop: theme.spacing(1.25),
       paddingBottom: theme.spacing(1.25),
       position: 'relative',

--- a/src/components/ExpansionPanel/ExpansionPanel.tsx
+++ b/src/components/ExpansionPanel/ExpansionPanel.tsx
@@ -5,6 +5,8 @@ import { makeStyles } from '../../styles';
 import { GetClasses } from '../../typeUtils';
 import { generateUniqueId } from '../_private/UniqueId';
 import { Text } from '../Text';
+import { Box } from '../Box';
+import { IconButton } from '../IconButton';
 
 export const ExpansionPanelStylesKey = 'ChromaExpansionPanel';
 
@@ -17,9 +19,17 @@ export const useStyles = makeStyles(
     rootOpen: {
       maxHeight: 'inherit',
     },
-    button: {
-      width: '100%',
+    header: {
       background: theme.palette.common.white,
+      position: 'relative',
+      zIndex: 2,
+    },
+    headerShadow: {
+      boxShadow: theme.boxShadows.table,
+    },
+    button: {
+      background: theme.palette.common.white,
+      width: '100%',
       display: 'flex',
       justifyContent: 'space-between',
       alignItems: 'center',
@@ -39,9 +49,6 @@ export const useStyles = makeStyles(
         color: theme.palette.black.main,
         transform: 'translate3d(2px, 0, 0)',
       },
-    },
-    buttonShadow: {
-      boxShadow: theme.boxShadows.table,
     },
     leadingIcon: {
       marginRight: theme.spacing(1),
@@ -63,10 +70,16 @@ export const useStyles = makeStyles(
       overflow: 'hidden',
       textOverflow: 'ellipsis',
     },
-    icon: {
+    iconButton: {
       transition: 'transform 0.25s ease',
       color: theme.palette.primary.main,
       minWidth: theme.pxToRem(18),
+      paddingRight: theme.spacing(2),
+      paddingLeft: theme.spacing(2),
+      '& > svg': {
+        maxHeight: theme.pxToRem(18),
+        maxWidth: theme.pxToRem(18),
+      },
     },
     rotate: {
       transform: 'rotate(45deg)',
@@ -110,6 +123,8 @@ export interface ExpansionPanelProps
   leadingIconClassName?: string;
   title: string;
   leadingIcon?: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+  secondaryHeaderClassName?: string;
+  secondaryHeaderChildren?: React.ReactNode;
   truncateTitle?: boolean;
   onToggle?: (isExpanded: boolean) => void;
   isOpen?: boolean;
@@ -150,6 +165,8 @@ export const ExpansionPanel = React.forwardRef<
       contentDirection = 'column',
       title,
       leadingIcon: LeadingIcon,
+      secondaryHeaderClassName,
+      secondaryHeaderChildren,
       truncateTitle = false,
       ...rootProps
     },
@@ -206,39 +223,51 @@ export const ExpansionPanel = React.forwardRef<
         ref={ref}
         {...rootProps}
       >
-        <button
-          aria-expanded={isExpanded}
-          aria-owns={ariaId}
-          className={clsx(classes.button, isExpanded && classes.buttonShadow)}
-          onClick={handleClick}
-          tabIndex={0}
+        <Box
+          align="center"
+          className={clsx(classes.header, isExpanded && classes.headerShadow)}
         >
-          <div className={classes.titleContainer}>
-            {LeadingIcon && (
-              <LeadingIcon
-                role="img"
-                aria-hidden
-                className={clsx(classes.leadingIcon, leadingIconClassName)}
-                width={18}
-                height={18}
-              />
-            )}
-            <Text
-              className={clsx(classes.title, truncateTitle && classes.truncate)}
-              size="subbody"
-              weight="bold"
-            >
-              {title}
-            </Text>
-          </div>
-
-          <Plus
-            className={clsx(classes.icon, isExpanded && classes.rotate)}
-            aria-hidden="true"
-            width={18}
-            height={18}
+          <button
+            aria-expanded={isExpanded}
+            aria-owns={ariaId}
+            className={classes.button}
+            onClick={handleClick}
+            tabIndex={0}
+          >
+            <div className={classes.titleContainer}>
+              {LeadingIcon && (
+                <LeadingIcon
+                  role="img"
+                  aria-hidden
+                  className={clsx(classes.leadingIcon, leadingIconClassName)}
+                  width={18}
+                  height={18}
+                />
+              )}
+              <Text
+                className={clsx(
+                  classes.title,
+                  truncateTitle && classes.truncate
+                )}
+                size="subbody"
+                weight="bold"
+              >
+                {title}
+              </Text>
+            </div>
+          </button>
+          <Box
+            className={clsx(classes.secondaryHeader, secondaryHeaderClassName)}
+          >
+            {secondaryHeaderChildren}
+          </Box>
+          <IconButton
+            aria-label="Expand/collapse"
+            icon={Plus}
+            className={clsx(classes.iconButton, isExpanded && classes.rotate)}
+            onClick={handleClick}
           />
-        </button>
+        </Box>
         <div
           aria-hidden={!isExpanded}
           id={ariaId}

--- a/src/components/ExpansionPanel/ExpansionPanel.tsx
+++ b/src/components/ExpansionPanel/ExpansionPanel.tsx
@@ -28,20 +28,21 @@ export const useStyles = makeStyles(
       boxShadow: theme.boxShadows.table,
     },
     button: {
-      background: theme.palette.common.white,
-      width: '100%',
-      display: 'flex',
-      justifyContent: 'space-between',
       alignItems: 'center',
-      position: 'relative',
-      textAlign: 'left',
+      background: theme.palette.common.white,
       border: 'none',
+      cursor: 'pointer',
+      display: 'flex',
+      flex: 1,
+      justifyContent: 'space-between',
       outline: 'none',
+      overflow: 'hidden',
       paddingLeft: theme.spacing(2),
       paddingRight: theme.spacing(2),
       paddingTop: theme.spacing(1.25),
       paddingBottom: theme.spacing(1.25),
-      cursor: 'pointer',
+      position: 'relative',
+      textAlign: 'left',
       '&:focus': {
         outline: 'none',
       },
@@ -50,15 +51,11 @@ export const useStyles = makeStyles(
         transform: 'translate3d(2px, 0, 0)',
       },
     },
-    leadingIcon: {
-      marginRight: theme.spacing(1),
-      minWidth: theme.pxToRem(18),
-    },
     titleContainer: {
       alignItems: 'center',
       display: 'flex',
-      maxWidth: `calc(100% - ${theme.pxToRem(34)})`, // 34 = icon width of 18px + 16px padding
-      flexGrow: 1,
+      flex: 1,
+      minWidth: 0,
     },
     title: {
       color: theme.palette.text.secondary,
@@ -69,6 +66,10 @@ export const useStyles = makeStyles(
       whiteSpace: 'nowrap',
       overflow: 'hidden',
       textOverflow: 'ellipsis',
+    },
+    leadingIcon: {
+      marginRight: theme.spacing(1),
+      minWidth: theme.pxToRem(18),
     },
     iconButton: {
       transition: 'transform 0.25s ease',
@@ -124,7 +125,7 @@ export interface ExpansionPanelProps
   title: string;
   leadingIcon?: React.ComponentType<React.SVGProps<SVGSVGElement>>;
   secondaryHeaderClassName?: string;
-  secondaryHeaderChildren?: React.ReactNode;
+  secondaryHeader?: React.ReactNode;
   truncateTitle?: boolean;
   onToggle?: (isExpanded: boolean) => void;
   isOpen?: boolean;
@@ -166,7 +167,7 @@ export const ExpansionPanel = React.forwardRef<
       title,
       leadingIcon: LeadingIcon,
       secondaryHeaderClassName,
-      secondaryHeaderChildren,
+      secondaryHeader,
       truncateTitle = false,
       ...rootProps
     },
@@ -230,7 +231,7 @@ export const ExpansionPanel = React.forwardRef<
           <button
             aria-expanded={isExpanded}
             aria-owns={ariaId}
-            className={classes.button}
+            className={clsx(classes.button)}
             onClick={handleClick}
             tabIndex={0}
           >
@@ -256,10 +257,8 @@ export const ExpansionPanel = React.forwardRef<
               </Text>
             </div>
           </button>
-          <Box
-            className={clsx(classes.secondaryHeader, secondaryHeaderClassName)}
-          >
-            {secondaryHeaderChildren}
+          <Box className={secondaryHeaderClassName} align="center" gap={1}>
+            {secondaryHeader}
           </Box>
           <IconButton
             aria-label="Expand/collapse"


### PR DESCRIPTION
We have a use case where we want to add secondary actions (or content) to the expansion panel header. This required some refactoring of the button element, which included adding an `<IconButton` so that we could allot some space for content to go between the clickable title and plus icon.

![expansion-panel-secondary-header](https://github.com/lifeomic/chroma-react/assets/485903/6a8a371e-61bc-4140-b774-336b5b8309d5)
