### PR TITLE
feat: upgrade framer-motion

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "clsx": "^1.1.0",
     "deepmerge": "^4.2.2",
     "focus-visible": "^5.1.0",
-    "framer-motion": "^1.10.3",
+    "framer-motion": "^5.6.0",
     "react-day-picker": "^7.4.10",
     "react-focus-lock": "^2.3.1",
     "react-hotkeys": "^2.0.0",

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -425,9 +425,10 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
                 d="M1,5.524A4.523,4.523,0,0,1,5.524,1h9.952A4.523,4.523,0,0,1,20,5.524v9.952A4.523,4.523,0,0,1,15.476,20H5.524A4.523,4.523,0,0,1,1,15.476Z"
                 fill="transparent"
                 stroke="var(--checkbox-secondary-emphasis)"
-                strokeOpacity="0"
+                strokeOpacity={0}
                 strokeMiterlimit="10"
-                strokeWidth="2"
+                strokeWidth={2}
+                initial={false}
                 variants={getBoxVariants({
                   disabled,
                   hasError,
@@ -438,12 +439,13 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
                 <motion.path
                   d="M6.5,10.458h8"
                   fill="transparent"
-                  strokeWidth="2.25"
+                  strokeWidth={2.25}
                   stroke="#FFFFFF"
                   strokeLinecap="round"
                   strokeLinejoin="round"
                   style={{ pathLength, opacity }}
                   custom={checked}
+                  initial={false}
                   variants={getTickVariants({
                     disabled,
                     indeterminate,
@@ -455,12 +457,13 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
                   <motion.path
                     d="M10.5,10.458h-4"
                     fill="transparent"
-                    strokeWidth="2.25"
+                    strokeWidth={2.25}
                     stroke="#FFFFFF"
                     strokeLinecap="round"
                     strokeLinejoin="round"
                     style={{ pathLength, opacity }}
                     custom={checked}
+                    initial={false}
                     variants={getTickVariants({
                       disabled,
                       indeterminate,
@@ -470,12 +473,13 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
                   <motion.path
                     d="M10.5,10.458h4"
                     fill="transparent"
-                    strokeWidth="2.25"
+                    strokeWidth={2.25}
                     stroke="#FFFFFF"
                     strokeLinecap="round"
                     strokeLinejoin="round"
                     style={{ pathLength, opacity }}
                     custom={checked}
+                    initial={false}
                     variants={getTickVariants({
                       disabled,
                       indeterminate,
@@ -487,13 +491,14 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
                 <motion.path
                   d="M5.761,11.962l2.187,2.187,7.291-7.3"
                   fill="transparent"
-                  strokeWidth="2.25"
+                  strokeWidth={2.25}
                   stroke="#FFFFFF"
-                  strokeOpacity="1"
+                  strokeOpacity={1}
                   strokeLinecap="round"
                   strokeLinejoin="round"
                   style={{ pathLength, opacity }}
                   custom={checked}
+                  initial={false}
                   variants={getTickVariants({ disabled, indeterminate, color })}
                 />
               )}

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -251,7 +251,6 @@ const ModalInner = React.forwardRef<HTMLDivElement, ModalProps>(
               },
             ])}
             ref={thisRef}
-            positionTransition
             initial={{ opacity: 0 }}
             animate={{
               opacity: 1,

--- a/src/components/Snackbar/Snackbar.tsx
+++ b/src/components/Snackbar/Snackbar.tsx
@@ -175,7 +175,6 @@ export const Snackbar: React.FC<SnackbarProps> = React.forwardRef<
             role={role}
             onMouseEnter={onMouseEnter}
             onMouseLeave={onMouseLeave}
-            positionTransition
             initial={
               shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: -40 }
             }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4098,22 +4098,6 @@
     schema-utils "^3.0.0"
     source-map "^0.7.3"
 
-"@popmotion/easing@^1.0.1", "@popmotion/easing@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@popmotion/easing/-/easing-1.0.2.tgz#17d925c45b4bf44189e5a38038d149df42d8c0b4"
-  integrity sha512-IkdW0TNmRnWTeWI7aGQIVDbKXPWHVEYdGgd5ZR4SH/Ty/61p63jCjrPxX1XrR7IGkl08bjhJROStD7j+RKgoIw==
-
-"@popmotion/popcorn@^0.4.2", "@popmotion/popcorn@^0.4.4":
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/@popmotion/popcorn/-/popcorn-0.4.4.tgz#a5f906fccdff84526e3fcb892712d7d8a98d6adc"
-  integrity sha512-jYO/8319fKoNLMlY4ZJPiPu8Ea8occYwRZhxpaNn/kZsK4QG2E7XFlXZMJBsTWDw7I1i0uaqyC4zn1nwEezLzg==
-  dependencies:
-    "@popmotion/easing" "^1.0.1"
-    framesync "^4.0.1"
-    hey-listen "^1.0.8"
-    style-value-types "^3.1.7"
-    tslib "^1.10.0"
-
 "@popperjs/core@^2.11.5":
   version "2.11.5"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.5.tgz#db5a11bf66bdab39569719555b0f76e138d7bd64"
@@ -9835,6 +9819,11 @@ dayjs@^1.10.7:
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.7.tgz#2cf5f91add28116748440866a0a1d26f3a6ce468"
   integrity sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig==
 
+debounce@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"
+  integrity sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==
+
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -11564,29 +11553,27 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-framer-motion@^1.10.3:
-  version "1.10.3"
-  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-1.10.3.tgz#d58a57ccb0ccc3317d0fc3abc4da2b3e4227bd43"
-  integrity sha512-VooCzGWg7brSO4Gc0YwpY5AadJe4OPS74ZyOlOHWll5rMXCoOc6Ia3uDQ6RfOJlwCP/D9TQuRGtboyJiVXjVcw==
+framer-motion@^5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-5.6.0.tgz#8203b5bc4e172265d43dfe67c3c41346c67a3940"
+  integrity sha512-Y4FtwUU+LUWLKSzoT6Sq538qluvhpe6izdQK8/xZeVjQZ/ORKGfZzyhzcUxNfscqnfEa3dUOA47s+dwrSipdGA==
   dependencies:
-    "@popmotion/easing" "^1.0.2"
-    "@popmotion/popcorn" "^0.4.2"
-    framesync "^4.0.4"
+    framesync "6.0.1"
     hey-listen "^1.0.8"
-    popmotion "9.0.0-beta-8"
-    style-value-types "^3.1.6"
-    stylefire "^7.0.2"
-    tslib "^1.10.0"
+    popmotion "11.0.3"
+    react-merge-refs "^1.1.0"
+    react-use-measure "^2.1.1"
+    style-value-types "5.0.0"
+    tslib "^2.1.0"
   optionalDependencies:
     "@emotion/is-prop-valid" "^0.8.2"
 
-framesync@^4.0.0, framesync@^4.0.1, framesync@^4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/framesync/-/framesync-4.0.4.tgz#79c42c0118f26821c078570db0ff81fb863516a2"
-  integrity sha512-mdP0WvVHe0/qA62KG2LFUAOiWLng5GLpscRlwzBxu2VXOp6B8hNs5C5XlFigsMgrfDrr2YbqTsgdWZTc4RXRMQ==
+framesync@6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/framesync/-/framesync-6.0.1.tgz#5e32fc01f1c42b39c654c35b16440e07a25d6f20"
+  integrity sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==
   dependencies:
-    hey-listen "^1.0.8"
-    tslib "^1.10.0"
+    tslib "^2.1.0"
 
 fresh@0.5.2:
   version "0.5.2"
@@ -16593,17 +16580,15 @@ polished@^4.2.2:
   dependencies:
     "@babel/runtime" "^7.17.8"
 
-popmotion@9.0.0-beta-8:
-  version "9.0.0-beta-8"
-  resolved "https://registry.yarnpkg.com/popmotion/-/popmotion-9.0.0-beta-8.tgz#f5a709f11737734e84f2a6b73f9bcf25ee30c388"
-  integrity sha512-6eQzqursPvnP7ePvdfPeY4wFHmS3OLzNP8rJRvmfFfEIfpFqrQgLsM50Gd9AOvGKJtYJOFknNG+dsnzCpgIdAA==
+popmotion@11.0.3:
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/popmotion/-/popmotion-11.0.3.tgz#565c5f6590bbcddab7a33a074bb2ba97e24b0cc9"
+  integrity sha512-Y55FLdj3UxkR7Vl3s7Qr4e9m0onSnP8W7d/xQLsoJM40vs6UKHFdygs6SWryasTZYqugMjm3BepCF4CWXDiHgA==
   dependencies:
-    "@popmotion/easing" "^1.0.1"
-    "@popmotion/popcorn" "^0.4.2"
-    framesync "^4.0.4"
+    framesync "6.0.1"
     hey-listen "^1.0.8"
-    style-value-types "^3.1.6"
-    tslib "^1.10.0"
+    style-value-types "5.0.0"
+    tslib "^2.1.0"
 
 popper.js@^1.14.4, popper.js@^1.14.7:
   version "1.15.0"
@@ -17590,6 +17575,13 @@ react-transition-group@^4.4.2:
     dom-helpers "^5.0.1"
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
+
+react-use-measure@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/react-use-measure/-/react-use-measure-2.1.1.tgz#5824537f4ee01c9469c45d5f7a8446177c6cc4ba"
+  integrity sha512-nocZhN26cproIiIduswYpV5y5lQpSQS1y/4KuvUCjSKmw7ZWIS/+g3aFnX3WdBkyuGUtTLif3UTqnLLhbDoQig==
+  dependencies:
+    debounce "^1.2.1"
 
 react@16.14.0:
   version "16.14.0"
@@ -19312,24 +19304,13 @@ style-loader@^3.3.1:
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-3.3.3.tgz#bba8daac19930169c0c9c96706749a597ae3acff"
   integrity sha512-53BiGLXAcll9maCYtZi2RCQZKa8NQQai5C4horqKyRmHj9H7QmcUyucrH+4KW/gBQbXM2AsB0axoEcFZPlfPcw==
 
-style-value-types@^3.1.6, style-value-types@^3.1.7:
-  version "3.1.7"
-  resolved "https://registry.yarnpkg.com/style-value-types/-/style-value-types-3.1.7.tgz#3d7d3cf9cb9f9ee86c00e19ba65d6a181a0db33a"
-  integrity sha512-jPaG5HcAPs3vetSwOJozrBXxuHo9tjZVnbRyBjxqb00c2saIoeuBJc1/2MtvB8eRZy41u/BBDH0CpfzWixftKg==
+style-value-types@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/style-value-types/-/style-value-types-5.0.0.tgz#76c35f0e579843d523187989da866729411fc8ad"
+  integrity sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==
   dependencies:
     hey-listen "^1.0.8"
-    tslib "^1.10.0"
-
-stylefire@^7.0.2:
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/stylefire/-/stylefire-7.0.2.tgz#874a82dd2bcada39c13e75e0c67b70009e06f556"
-  integrity sha512-LFIBP6fIA+EMqLSvM4V6zLa+O/iAcHoNJVuXkkZ5G8+T+Pd3KaQLqgxrpkeo1bwWQHqzgab8U3V3gudO231fZA==
-  dependencies:
-    "@popmotion/popcorn" "^0.4.4"
-    framesync "^4.0.0"
-    hey-listen "^1.0.8"
-    style-value-types "^3.1.7"
-    tslib "^1.10.0"
+    tslib "^2.1.0"
 
 stylis@4.0.13:
   version "4.0.13"
@@ -19887,11 +19868,6 @@ tslib@^1.0.0, tslib@^1.9.0, tslib@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
-
-tslib@^1.10.0:
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
-  integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
 
 tslib@^1.13.0:
   version "1.14.1"


### PR DESCRIPTION
## Changes

- Upgrade framer-motion from v1 to v5. 
- Remove deprecated `positionTransition` prop
- Update animated svg props from string values to number values to fix warning about animating unexpected values 

## Motivation

The reason for this change is because we've recently ran into an odd issue where using checkboxes in a mobile scroll view can cause some bad ux.

As a user scrolls + checks a checkbox the checkbox appears to animate to a checked or even partial checked state - but the value never actually was toggled. Then when a checkbox is actually toggled in the group, the "partial" checked revert

I believe it is an issue with starting but never ending the animation - this issue seems to addressed or handled better in later versions of framer-motion

See the before video for a better idea.

## Behavior

### Before


https://github.com/lifeomic/chroma-react/assets/19804196/0695e065-223e-48f7-b4b6-29426cd61a00



### After


https://github.com/lifeomic/chroma-react/assets/19804196/123a0b3e-5498-49a4-815c-ebb68b29fb77


