### PR TITLE
fix: remove table row action cell :after which causes artifacting

### DIFF
--- a/src/components/TableModule/TableModule.tsx
+++ b/src/components/TableModule/TableModule.tsx
@@ -143,18 +143,6 @@ export const useStyles = makeStyles(
       textAlign: 'right',
       width: theme.pxToRem(1),
       zIndex: theme.zIndex.byValueUpTo20[6],
-      // Add bottom border to table action row
-      // when actions are hidden
-      '&::after': {
-        background: theme.palette.divider,
-        content: `''`,
-        display: 'block',
-        height: theme.pxToRem(1),
-        left: 0,
-        position: 'absolute',
-        width: '100%',
-        bottom: theme.pxToRem(-1),
-      },
     },
     tableModuleActions: {
       background: `linear-gradient(135deg,


### PR DESCRIPTION
|Before|After|
|---|---|
<img width="183" height="154" alt="image" src="https://github.com/user-attachments/assets/986ec86e-2715-44a1-87a8-aaa916db89aa" />|<img width="202" height="159" alt="image" src="https://github.com/user-attachments/assets/d8993742-2ee9-44f8-a08f-6409862bf332" />|


This has bugged me for 4 years.