### PR TITLE
fix(PrimaryNavigation): replace scrollHeight dep with ResizeObserver to prevent infinite loop

### DIFF
--- a/src/components/PrimaryNavigation/PrimaryNavigationExpansionItem.tsx
+++ b/src/components/PrimaryNavigation/PrimaryNavigationExpansionItem.tsx
@@ -201,10 +201,18 @@ export const PrimaryNavigationExpansionItem = React.forwardRef<
     );
 
     React.useEffect(() => {
-      if (innerRef && innerRef.current && children) {
-        setContentHeight(innerRef.current.scrollHeight);
-      }
-    }, [children, innerRef?.current?.scrollHeight]);
+      const el = innerRef.current;
+      if (!el || !children) return;
+
+      setContentHeight(el.scrollHeight);
+
+      const observer = new ResizeObserver(() => {
+        setContentHeight(el.scrollHeight);
+      });
+      observer.observe(el);
+
+      return () => observer.disconnect();
+    }, [children]);
 
     return (
       <motion.li

--- a/src/jest.js
+++ b/src/jest.js
@@ -1,0 +1,5 @@
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};


### PR DESCRIPTION
The `useEffect` in `PrimaryNavigationExpansionItem` used `innerRef.current.scrollHeight` as a dependency. Since `scrollHeight` is a DOM measurement that can change after each `setState`-triggered re-render, this created a feedback loop that crashed with "Maximum update depth exceeded" in complex layouts (e.g. the Annual Report viewer in PHC).

**Fix:** Replace the problematic dependency with a `ResizeObserver` that only fires `setContentHeight` when the element actually resizes, breaking the render cycle.

Also adds a `ResizeObserver` mock to `src/jest.js` for the jsdom test environment.

Made with [Cursor](https://cursor.com)